### PR TITLE
chore: track fisherman dev (NBD + OCI fixes merged)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fisherman"]
 	path = fisherman
 	url = https://github.com/tuna-os/fisherman.git
-	branch = wootc/vhdx-fixes
+	branch = dev


### PR DESCRIPTION
Points the fisherman submodule at the fork's `dev` branch, which now carries both wootc fixes via fisherman PR #47. Single-commit follow-up to #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)