### PR TITLE
fix(ci): sudo-create /mnt/wootc-snapshot (root-owned /mnt broke priming)

### DIFF
--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -69,7 +69,7 @@ jobs:
           TAG="${{ inputs.win_version }}-bl-${{ inputs.bitlocker }}"
           echo "${{ secrets.GITHUB_TOKEN }}" | \
             oras login ghcr.io -u "${{ github.actor }}" --password-stdin
-          mkdir -p /mnt/wootc-snapshot
+          sudo mkdir -p /mnt/wootc-snapshot && sudo chown "$USER" /mnt/wootc-snapshot
           if oras pull "${PKG}:${TAG}" -o /mnt/wootc-snapshot; then
             echo "WOOTC_E2E_SNAPSHOT_IN=/mnt/wootc-snapshot" >> "$GITHUB_ENV"
             echo "Restored base image ${PKG}:${TAG}"; ls -lh /mnt/wootc-snapshot

--- a/.github/workflows/e2e-snapshot.yml
+++ b/.github/workflows/e2e-snapshot.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Put VM storage on /mnt (the only volume with room)
         run: |
-          sudo mkdir -p /mnt/wootc-storage /mnt/wootc-iso
-          sudo chown -R "$USER" /mnt/wootc-storage /mnt/wootc-iso
+          sudo mkdir -p /mnt/wootc-storage /mnt/wootc-iso /mnt/wootc-snapshot
+          sudo chown -R "$USER" /mnt/wootc-storage /mnt/wootc-iso /mnt/wootc-snapshot
           rm -rf tests/e2e/storage tests/e2e/iso-cache
           ln -s /mnt/wootc-storage tests/e2e/storage
           ln -s /mnt/wootc-iso     tests/e2e/iso-cache
@@ -88,7 +88,6 @@ jobs:
           WOOTC_E2E_BITLOCKER:  ${{ env.BITLOCKER }}
           WOOTC_E2E_SNAPSHOT_OUT: /mnt/wootc-snapshot
         run: |
-          mkdir -p /mnt/wootc-snapshot
           cd tests/e2e
           # The image ref is irrelevant to priming (nothing is deployed), but
           # run-e2e.sh needs a positional; pass the default target.


### PR DESCRIPTION
The prime job failed instantly on `mkdir: cannot create directory '/mnt/wootc-snapshot': Permission denied` — /mnt is root-owned on hosted runners. Create+chown it with sudo in the snapshot job and the hosted pull step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)