### PR TITLE
docs(phase3): correct stale nbd0 → loop device in blank-disk selection

### DIFF
--- a/tests/e2e/pick-blank-disk.sh
+++ b/tests/e2e/pick-blank-disk.sh
@@ -7,10 +7,12 @@
 # than buried as a shell string inside run-e2e.sh.
 #
 # THE RULE IS EMPTINESS, NOT "not root".
-# In Phase 2 the running root is /dev/nbd0 (the root.disk loopback on NTFS), so
-# "any disk that isn't root's" cheerfully selects /dev/sda — the Windows disk.
-# Emptiness is what actually identifies the spare drive: no partitions AND no
-# filesystem signature on the whole device.
+# In Phase 2 the running root is a partition on a LOOP device (/dev/loopNpM —
+# root.disk is a raw image attached with losetup since the VHDX→raw switch; it
+# was /dev/nbd0 under the old qemu-nbd path), so "any disk that isn't root's"
+# cheerfully selects /dev/sda — the Windows disk. Emptiness is what actually
+# identifies the spare drive: no partitions AND no filesystem signature on the
+# whole device.
 #
 # Prints the device path and exits 0 on success; prints nothing and exits 1 when
 # no blank disk exists. Failing closed is mandatory — the caller must abort

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1596,10 +1596,10 @@ if [ "${RUN_PHASE3:-false}" = true ]; then
 
     # Pick the graduate target: a BLANK whole disk (no partitions, no
     # filesystem). Do NOT use "any disk that isn't root's" — in Phase 2 root
-    # lives on /dev/nbd0 (the root.disk loopback), so that rule excludes nbd0
-    # and happily selects /dev/sda, i.e. the WINDOWS disk. `bootc install
-    # --wipe` on that destroys the user's Windows. Emptiness is what actually
-    # identifies the spare drive.
+    # lives on a /dev/loopNpM partition (root.disk attached via losetup since the
+    # raw switch), so that rule excludes the loop device and happily selects
+    # /dev/sda, i.e. the WINDOWS disk. `bootc install --wipe` on that destroys
+    # the user's Windows. Emptiness is what actually identifies the spare drive.
     # Selection logic lives in tests/e2e/pick-blank-disk.sh so it can be unit
     # tested — its output is handed to `bootc install --wipe`, so a wrong answer
     # destroys the user's Windows. Shipped as text over QGA and run in the guest.


### PR DESCRIPTION
Comment-only. Since the VHDX→raw switch, Phase-2 root is a loop device, not /dev/nbd0. The selection code already skips both; this just makes the safety-critical provenance accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)