### PR TITLE
ci: cancel superseded validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number || github.ref
+    }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add workflow/ref concurrency to ordinary CI so a newer push or PR update cancels obsolete validation runs. Stateful E2E, snapshot, release, and Pages workflows are unchanged.

Validated with actionlint and git diff checks. SOFA integration was unavailable in this session; local repository guidance was reviewed.