### PR TITLE
fix(phase2): coherent early-cpio staging, verified initrds, btrfs readiness (#28, #35, #45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ package-lock.json
 app/wootc
 app/wootc.exe
 handoff.md
+__pycache__/

--- a/docs/finish-plan.md
+++ b/docs/finish-plan.md
@@ -1,0 +1,79 @@
+# Finishing plan — dakota (composefs), btrfs, and the rest of the matrix
+
+*Written 2026-08-01. Scope set by the maintainer: get `dakota`, composefs,
+and btrfs green. Windows 10 Home/Enterprise/LTSC (#58) is explicitly
+deprioritized ("pretty rare").*
+
+The project's green core is done: `bluefin:lts` (ostree/grub2/ext4-sealed)
+passes the full Phase 1 → 2 → 3 chain, GUI-driven, 29/29. What separates
+"working demo for one image family" from "finished installer" is the red
+half of the build/test matrix, and almost all of it funnels through two
+bugs: the composefs Phase-2 staging path (#28) and btrfs device readiness
+(#35).
+
+## Where each red cell actually is
+
+| Red cell | Funnel | Blocking defect |
+|---|---|---|
+| `dakota` deploy → Phase 2 | #28 | early-cpio staging: incoherent ntfs-3g sourcing, unverified initrd |
+| `marlin` / `flounder` deploy | #28 | same composefs-native path (backend detection fixed in 96d1f5b) |
+| btrfs sealed root | #35 | root device never becomes SYSTEMD_READY; sysroot.mount times out |
+| `tpm2-luks` | #33 | Phase-2 dracut regen fails on the LUKS root (independent track) |
+| Matrix ✅s predating 2026-07-27 | harness | being re-run under the failure-ledger harness (already fixed in 3d7f9e2) |
+
+## What this branch fixes (code-side, container-verifiable)
+
+1. **One early-cpio implementation** (`stage_wootc_overlay`,
+   `stage_ntfs3g_closure`, `build_phase2_initrd` in `deploy.sh`), used by
+   all three prepend-cpio branches. The `/mnt/sysroot` phantom paths are
+   gone. ntfs-3g is sourced coherently: the target deployment's own binary
+   + libraries first; otherwise the deployer's binary as a **complete
+   private closure** (every `NEEDED` lib + the loader under
+   `/usr/lib/wootc/ntfs3g/`, wrapper-invoked, exec-verified at stage time)
+   — agent-lessons §8, mechanically enforced.
+2. **The built Phase-2 initrd is verified by inspection**: overlay
+   completeness (unit, wants edge, executable hook) before packing; the
+   base initrd is listed and must ship the hook's interpreter and tools
+   (`bash losetup udevadm mount`) — fail closed on proof, warn on
+   unlistable. Mutation-tested in `tests/unit/phase2-early-cpio.bats`.
+3. **#45 fail-closed**: a deploy whose installed root cannot be mounted and
+   recognized exits 1 with the partition table, per-partition blkid, and
+   bounded mount errors — it no longer advertises deploy-ready and reboots.
+4. **#35 layered fix**: btrfs deploys bake a `modules-load.d` entry into
+   the regenerated Phase-2 initramfs (early, dependency-resolved btrfs.ko
+   load — no hook modprobe, honoring the Secure Boot lockdown lesson); the
+   attach hook registers the just-attached partitions (`btrfs device
+   scan`), re-triggers CHANGE events so udev's readiness import re-runs,
+   and logs `module loaded= SYSTEMD_READY=` per btrfs partition so a
+   persisting failure is diagnosable from one serial log.
+
+## What only the E2E rig can do (the actual finish line)
+
+Each rung is one KVM run; do them in this order, one change per run:
+
+1. **btrfs re-run** (`wootc.filesystem=btrfs`, bluefin:lts): expect green;
+   if not, the new `btrfs <part>: module loaded=… SYSTEMD_READY=…` serial
+   line says which layer failed. When green twice, consider flipping the
+   sealed default to btrfs (native fs-verity, reflinks) — a product call,
+   not a bug fix; ext4 stays default until then.
+2. **dakota full chain**: deploy now runs the hardened staging; the
+   composefs Phase-2 boot (deployer kernel + patched UKI initrd +
+   root=UUID/composefs= kargs) is the first thing that has never been
+   proven end-to-end. Expect the next failure — if any — *after* attach,
+   in `bootc-root-setup`/composefs pivot; the verify guards will name it.
+3. **marlin / flounder**: same path as dakota post-96d1f5b; run after
+   dakota is green so composefs failures aren't double-counted.
+4. **Matrix re-sweep** under the ledger harness to re-earn the pre-3d7f9e2
+   ✅s (already tracked in README).
+5. **#33 tpm2-luks**: independent; the regen now surfaces dracut's own
+   output, so the next failing run carries its cause.
+
+## Definition of done for "support for dakota, composefs, btrfs"
+
+- dakota: Arm → Deploy → Phase-2 boot → seeded-file assertion green under
+  the ledger harness (Phase-3 graduation is a follow-on rung).
+- One non-dakota composefs-native family (marlin or flounder) green
+  through Phase-2, proving the path is image-agnostic, not dakota-shaped.
+- btrfs: bluefin:lts sealed-btrfs green through Phase-2 twice; #35 closed.
+- All three keep their bats regression guards
+  (`phase2-early-cpio.bats`, `btrfs-phase2.bats`) green in CI.

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -1077,6 +1077,170 @@ vstage() {
     log "vstage: $*"
 }
 
+# ── [generic] Early-cpio overlay helpers ─────────────────────────────────────
+# Three Phase-2 staging branches (composefs+systemd-boot, generic
+# systemd-boot, ostree/grub2 with a target initramfs that cannot be
+# regenerated) prepend the same wootc-boot overlay onto the target's own
+# initrd. They used to carry three hand-copied variants of this code, and two
+# of them looked for ntfs-3g under a /mnt/sysroot that never exists in this
+# initramfs — silently falling through to a deployer binary shipped WITHOUT
+# its library closure (the exact cross-image soname failure documented in
+# docs/agent-lessons.md §8). One implementation, used by all branches.
+
+# stage_wootc_overlay <ovl-dir>
+# The attach unit, its wants edge, and the loop script — the minimum that
+# makes root.disk appear to the base initrd's ordinary sysroot.mount.
+stage_wootc_overlay() {
+    local ovl="$1"
+    # early_cpio marker: makes lsinitrd/skipcpio recognise this as a leading
+    # (early) cpio and skip past it to show the base initrd — honest
+    # introspection. Harmless to the kernel (same as microcode).
+    : > "$ovl/early_cpio"
+    install -D -m0644 /usr/lib/wootc/99wootc-boot/wootc-attach.service \
+        "$ovl/usr/lib/systemd/system/wootc-attach.service"
+    install -D -m0755 /usr/lib/wootc/99wootc-boot/wootc-attach-loop.sh \
+        "$ovl/usr/lib/wootc/wootc-attach-loop.sh"
+    mkdir -p "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants"
+    ln -sf ../wootc-attach.service \
+        "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
+}
+
+# stage_ntfs3g_closure <ovl-dir>
+# Stage a userspace NTFS driver into the overlay for kernels without ntfs3.
+# Source order matters (agent-lessons §8 — never mix libraries across images):
+#   1. the TARGET deployment's own ntfs-3g: the binary plus its
+#      libntfs-3g/libfuse from the SAME tree. The rest of its closure (libc,
+#      loader) is the base initrd's own — coherent, both come from the image.
+#   2. the DEPLOYER's ntfs-3g as a COMPLETE private closure: binary, every
+#      ldd-resolved library, and the dynamic loader under
+#      /usr/lib/wootc/ntfs3g/, invoked through a wrapper. The target's
+#      libraries are never mixed in (measured skew that motivated this:
+#      libfuse3.so.4 vs .so.3 — lands, then dies exactly like a missing one).
+# Returns 0 when a driver was staged, 1 when none was available (the caller
+# decides whether kernel ntfs3 makes that survivable).
+stage_ntfs3g_closure() {
+    local ovl="$1" d tsrc="" lib nbin ldso=""
+    for d in /usr/bin /usr/sbin /bin /sbin; do
+        [[ -x "$DEPLOY_ROOT$d/ntfs-3g" ]] && { tsrc="$DEPLOY_ROOT$d/ntfs-3g"; break; }
+    done
+    if [[ -n "$tsrc" ]]; then
+        install -D -m0755 "$tsrc" "$ovl/usr/bin/ntfs-3g"
+        # Its NTFS/FUSE libraries from the same tree, symlink chains intact
+        # (libntfs-3g.so.N is a link to .so.N.0.0 — both must land). $lib is
+        # the path with the deployment prefix stripped, so it doubles as the
+        # destination inside the overlay.
+        while IFS= read -r lib; do
+            mkdir -p "$ovl${lib%/*}" 2>/dev/null || true
+            cp -a "$DEPLOY_ROOT$lib" "$ovl${lib%/*}/" 2>/dev/null || true
+        done < <(find "$DEPLOY_ROOT/usr/lib64" "$DEPLOY_ROOT/lib64" \
+                      "$DEPLOY_ROOT/usr/lib" "$DEPLOY_ROOT/lib" \
+                      -maxdepth 1 \( -name 'libntfs-3g*' -o -name 'libfuse*' \) \
+                      2>/dev/null | sed "s|^$DEPLOY_ROOT||")
+        mkdir -p "$ovl/usr/sbin"
+        ln -sf /usr/bin/ntfs-3g "$ovl/usr/sbin/mount.ntfs"
+        ln -sf /usr/bin/ntfs-3g "$ovl/usr/sbin/mount.ntfs-3g"
+        log "  early-cpio: staged the TARGET's own ntfs-3g (+libs) from the deployment"
+        return 0
+    fi
+    nbin=$(command -v ntfs-3g 2>/dev/null || true)
+    if [[ -n "$nbin" ]]; then
+        local pdir="usr/lib/wootc/ntfs3g"
+        install -D -m0755 "$nbin" "$ovl/$pdir/ntfs-3g"
+        # Every ldd-resolved dependency AND the loader (the line without "=>").
+        while IFS= read -r lib; do
+            [[ -f "$lib" ]] || continue
+            install -D -m0755 "$lib" "$ovl/$pdir/${lib##*/}"
+            case "$lib" in
+                */ld-linux*|*/ld64.so*|*/ld.so*) ldso="${lib##*/}" ;;
+            esac
+        done < <(ldd "$nbin" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i ~ /^\//) print $i}')
+        if [[ -z "$ldso" ]]; then
+            err "  [FAIL] early-cpio: ldd on the deployer's ntfs-3g surfaced no dynamic loader — cannot build a self-contained closure"
+            rm -rf "${ovl:?}/$pdir"
+            return 1
+        fi
+        # PROVE the closure is complete by RUNNING it (ldd reports only the
+        # first missing library; execution reports the truth). This is the
+        # deployer's own binary on the deployer's own kernel, so it can run
+        # here — pinned to the staged loader + staged libs only.
+        if ! "$ovl/$pdir/$ldso" --library-path "$ovl/$pdir" "$ovl/$pdir/ntfs-3g" --version >/dev/null 2>&1; then
+            err "  [FAIL] early-cpio: staged ntfs-3g closure does not execute against its own libraries"
+            rm -rf "${ovl:?}/$pdir"
+            return 1
+        fi
+        # The wrapper the attach hook's mount_host() will find as `ntfs-3g`.
+        # Needs only a POSIX sh, which the hook (bash) already requires.
+        mkdir -p "$ovl/usr/bin" "$ovl/usr/sbin"
+        cat > "$ovl/usr/bin/ntfs-3g" <<NTFSWRAP
+#!/bin/sh
+exec /$pdir/$ldso --library-path /$pdir /$pdir/ntfs-3g "\$@"
+NTFSWRAP
+        chmod 0755 "$ovl/usr/bin/ntfs-3g"
+        ln -sf /usr/bin/ntfs-3g "$ovl/usr/sbin/mount.ntfs"
+        ln -sf /usr/bin/ntfs-3g "$ovl/usr/sbin/mount.ntfs-3g"
+        log "  early-cpio: staged the DEPLOYER's ntfs-3g as a private closure (loader=$ldso, exec-verified)"
+        return 0
+    fi
+    return 1
+}
+
+# build_phase2_initrd <ovl-dir> <base-initrd> <out-path>
+# Pack the overlay ahead of the base initrd and VERIFY the result by
+# inspection — "the concatenated file is non-empty" validated nothing (a
+# hookless or interpreter-less initramfs is non-empty too, and costs a full
+# VM run to diagnose). Fails closed on a defective overlay; base-initrd
+# introspection is best-effort (its compression varies by image) and only
+# fails when a successful listing PROVES a required piece missing.
+build_phase2_initrd() {
+    local ovl="$1" base="$2" out="$3"
+    # The overlay must be verifiably complete BEFORE packing: unit file,
+    # wants edge (a dangling wants is a proven silent no-op), executable hook.
+    if [[ ! -f "$ovl/usr/lib/systemd/system/wootc-attach.service" ]] || \
+       [[ ! -L "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service" ]] || \
+       [[ ! -x "$ovl/usr/lib/wootc/wootc-attach-loop.sh" ]]; then
+        err "  [FAIL] early-cpio overlay is incomplete (unit/wants/hook) — refusing to build a Phase-2 initrd that cannot attach root.disk"
+        return 1
+    fi
+    if ! ( cd "$ovl" && find . | cpio -o -H newc --quiet ) > "$ovl.cpio" || \
+       ! cat "$ovl.cpio" "$base" > "$out" || [[ ! -s "$out" ]]; then
+        rm -f "$ovl.cpio"
+        err "  [FAIL] early-cpio: cpio prepend failed — Phase-2 initrd would be hookless"
+        return 1
+    fi
+    rm -f "$ovl.cpio"
+    # The overlay supplies unit+hook (+ possibly ntfs-3g); everything else the
+    # hook needs at runtime must come from the BASE initrd: its interpreter
+    # (bash — the hook's shebang), losetup, udevadm, mount. List the base with
+    # whatever decompressor matches; each failed candidate is fine, an empty
+    # result overall just means "unverifiable here", which must WARN, not fail
+    # a deploy that may be good.
+    local listing="" dec
+    for dec in "cat" "zstd -qdc" "gzip -dc" "xz -dc" "lz4 -dc" "bzip2 -dc"; do
+        listing=$($dec < "$base" 2>/dev/null | cpio -it --quiet 2>/dev/null || true)
+        [[ -n "$listing" ]] && break
+    done
+    if [[ -z "$listing" ]]; then
+        log "  [WARN] early-cpio: could not list the base initrd (unknown compression) — interpreter/tool presence unverified"
+        return 0
+    fi
+    local missing=() tool found
+    for tool in bash losetup udevadm mount; do
+        found=0
+        grep -qE "(^|/)(usr/)?s?bin/$tool$" <<<"$listing" && found=1
+        # busybox-style initrds provide tools as applet symlinks with the
+        # same basename; the grep above already matches those. A systemd
+        # UKI initrd without a shell at all is the real failure mode here.
+        [[ "$found" == 1 ]] || missing+=("$tool")
+    done
+    if (( ${#missing[@]} > 0 )); then
+        err "  [FAIL] the target's base initrd lacks: ${missing[*]} — the wootc-attach hook cannot run in Phase 2"
+        err "         (listing succeeded, so this is proof, not a probe failure; the image's initrd must ship these or the hook must be rewritten against what it ships)"
+        return 1
+    fi
+    log "  early-cpio: base initrd verified (bash/losetup/udevadm/mount present)"
+    return 0
+}
+
 # Re-mount the installed disk while its NTFS backing mount is still live.
 # `losetup --find` picks a fresh loop device rather than reusing the previous
 # one, so verification is independent of any teardown race on the old nodes.
@@ -1487,6 +1651,24 @@ if [[ -n "$VERIFY_ROOT" ]]; then
         else
             log "  [WARN] no ntfs-3g in the deployment — Phase-2 relies on a kernel ntfs3"
         fi
+        # btrfs root (#35): udev's 64-btrfs.rules keeps every btrfs partition
+        # SYSTEMD_READY=0 until the btrfs module has it registered, so the
+        # root=UUID device unit never activates if btrfs.ko is not loaded when
+        # the attach's partition events land — sysroot.mount then times out
+        # with the UUID sitting right there in by-uuid. The attach hook may
+        # not modprobe (Secure Boot lockdown lesson), so load it the
+        # systemd-native way: a modules-load.d entry baked into the initramfs;
+        # systemd-modules-load runs at initrd sysinit, dependency-resolved,
+        # long before wootc-attach.service.
+        DRACUT_INCLUDE_ARGS=()
+        if [[ "$FILESYSTEM" == btrfs ]]; then
+            # Under $DEPLOY_ROOT/run (same trick as wootc-nofw): dracut runs
+            # chrooted, so the path handed to --include must exist inside it.
+            mkdir -p "$DEPLOY_ROOT/run/wootc-btrfs-inc/usr/lib/modules-load.d"
+            echo btrfs > "$DEPLOY_ROOT/run/wootc-btrfs-inc/usr/lib/modules-load.d/wootc-btrfs.conf"
+            DRACUT_INCLUDE_ARGS=(--include /run/wootc-btrfs-inc /)
+            log "  btrfs root: baking modules-load.d/wootc-btrfs.conf into the Phase-2 initramfs (#35)"
+        fi
         # BOUNDED. An unbounded chroot dracut is a prime suspect for the
         # 31-minute silent hang: it writes nothing to the journal, so a block
         # here looks exactly like a dead deployer. A regen legitimately takes a
@@ -1496,6 +1678,7 @@ if [[ -n "$VERIFY_ROOT" ]]; then
         timeout 900 chroot "$DEPLOY_ROOT" dracut --force --no-hostonly \
             --add "ostree wootc-boot" \
             "${DRACUT_INSTALL_ARGS[@]}" \
+            "${DRACUT_INCLUDE_ARGS[@]}" \
             --fwdir /run/wootc-nofw \
             --omit "$DRACUT_OMIT" \
             "$INITRD_CHROOT_PATH" "$KVER" > /tmp/dracut-regen.log 2>&1
@@ -1955,29 +2138,14 @@ QGAEOF
                 # is overwritten. The base already ships loop/ntfs3/losetup/udevadm
                 # (verified on bonito), so no modules or binaries need adding.
                 OVL=$(mktemp -d)
-                # early_cpio marker: makes lsinitrd/skipcpio recognise this as a
-                # leading (early) cpio and skip past it to show the base initrd —
-                # honest introspection. Harmless to the kernel (same as microcode).
-                : > "$OVL/early_cpio"
-                install -D -m0644 /usr/lib/wootc/99wootc-boot/wootc-attach.service \
-                    "$OVL/usr/lib/systemd/system/wootc-attach.service"
-                install -D -m0755 /usr/lib/wootc/99wootc-boot/wootc-attach-loop.sh \
-                    "$OVL/usr/lib/wootc/wootc-attach-loop.sh"
-                mkdir -p "$OVL/usr/lib/systemd/system/initrd-root-device.target.wants"
-                ln -sf ../wootc-attach.service \
-                    "$OVL/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
-
-                if [[ -x /mnt/sysroot/usr/bin/ntfs-3g || -x /usr/bin/ntfs-3g ]]; then
-                    nbin=""
-                    nbin=$(ls /mnt/sysroot/usr/bin/ntfs-3g /usr/bin/ntfs-3g 2>/dev/null | head -1)
-                    install -D -m0755 "$nbin" "$OVL/usr/bin/ntfs-3g"
-                    ln -sf /usr/bin/ntfs-3g "$OVL/usr/sbin/mount.ntfs" 2>/dev/null || true
-                    ln -sf /usr/bin/ntfs-3g "$OVL/usr/sbin/mount.ntfs-3g" 2>/dev/null || true
-                    # Copy libntfs-3g.so.89 and dependencies
-                    find /mnt/sysroot/lib64 /lib64 /mnt/sysroot/usr/lib64 /usr/lib64 -name "libntfs-3g*" 2>/dev/null | while read -r lib; do
-                        relpath="${lib#/mnt/sysroot}"
-                        install -D -m0755 "$lib" "$OVL/$relpath"
-                    done
+                stage_wootc_overlay "$OVL"
+                # EL-class kernels have no ntfs3, so Phase 2 needs a userspace
+                # driver. Sourced coherently (target first, then the deployer's
+                # complete private closure) — the old inline copy here looked
+                # under a /mnt/sysroot that never exists and shipped the
+                # deployer binary without its closure (agent-lessons §8).
+                if ! stage_ntfs3g_closure "$OVL"; then
+                    log "  [WARN] no ntfs-3g stageable for the composefs Phase-2 initrd — relying on kernel ntfs3"
                 fi
                 # Composefs images (dakota) lack qemu-guest-agent which the E2E
                 # harness needs.  Copy the deployer's own qemu-ga into the cpio
@@ -2047,16 +2215,12 @@ SMODSH
                     log "  Staged deployer kernel modules ($_dkver) for Phase 2"
                 fi
 
-                CPIO_OK=0
-                if ( cd "$OVL" && find . | cpio -o -H newc --quiet ) > "$OVL.cpio" && \
-                   cat "$OVL.cpio" "$ISRC" > /mnt/esp/EFI/wootc/phase2-initramfs.img; then
-                    CPIO_OK=1
-                fi
-                rm -f "$OVL.cpio"; rm -rf "$OVL"
-                if [[ "$CPIO_OK" == 1 && -s /mnt/esp/EFI/wootc/phase2-initramfs.img ]]; then
-                    log "  [PASS] composefs Phase-2 initrd patched with wootc-boot (prepend-cpio)"
+                if build_phase2_initrd "$OVL" "$ISRC" /mnt/esp/EFI/wootc/phase2-initramfs.img; then
+                    rm -rf "$OVL"
+                    log "  [PASS] composefs Phase-2 initrd patched with wootc-boot (prepend-cpio, contents verified)"
                 else
-                    err "  [FAIL] composefs: cpio prepend failed — Phase-2 initrd would be hookless"
+                    rm -rf "$OVL"
+                    err "  [FAIL] composefs: Phase-2 initrd build/verify failed — aborting before the ESP advertises an unbootable Phase 2"
                     exit 1
                 fi
                 # Keep root=UUID + composefs=<hash>; drop unresolved \$vars + quiet.
@@ -2115,41 +2279,20 @@ GRUBCFGEOF
                     cp "$KERNEL_SRC" /mnt/esp/EFI/wootc/phase2-vmlinuz
                     OVL="/tmp/wootc-ovl-$$"
                     rm -rf "$OVL"; mkdir -p "$OVL"
-                    : > "$OVL/early_cpio"
-                    install -D -m0644 /usr/lib/wootc/99wootc-boot/wootc-attach.service \
-                        "$OVL/usr/lib/systemd/system/wootc-attach.service"
-                    install -D -m0755 /usr/lib/wootc/99wootc-boot/wootc-attach-loop.sh \
-                        "$OVL/usr/lib/wootc/wootc-attach-loop.sh"
-                    mkdir -p "$OVL/usr/lib/systemd/system/initrd-root-device.target.wants"
-                    ln -sf ../wootc-attach.service \
-                        "$OVL/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
-
-                    if [[ -x /mnt/sysroot/usr/bin/ntfs-3g || -x /usr/bin/ntfs-3g ]]; then
-                        nbin=""
-                        nbin=$(ls /mnt/sysroot/usr/bin/ntfs-3g /usr/bin/ntfs-3g 2>/dev/null | head -1)
-                        install -D -m0755 "$nbin" "$OVL/usr/bin/ntfs-3g"
-                        ln -sf /usr/bin/ntfs-3g "$OVL/usr/sbin/mount.ntfs" 2>/dev/null || true
-                        ln -sf /usr/bin/ntfs-3g "$OVL/usr/sbin/mount.ntfs-3g" 2>/dev/null || true
-                        # Copy libntfs-3g.so.89 and dependencies
-                        find /mnt/sysroot/lib64 /lib64 /mnt/sysroot/usr/lib64 /usr/lib64 -name "libntfs-3g*" 2>/dev/null | while read -r lib; do
-                            relpath="${lib#/mnt/sysroot}"
-                            install -D -m0755 "$lib" "$OVL/$relpath"
-                        done
+                    stage_wootc_overlay "$OVL"
+                    if ! stage_ntfs3g_closure "$OVL"; then
+                        log "  [WARN] no ntfs-3g stageable for the systemd-boot Phase-2 initrd — relying on kernel ntfs3"
                     fi
 
                     # NOTE: Storage kernel modules are intentionally NOT staged here.
                     # See branch-1 comment above for rationale (Secure Boot lockdown rejection).
 
-                    CPIO_OK=0
-                    if ( cd "$OVL" && find . | cpio -o -H newc --quiet ) > "$OVL.cpio" && \
-                       cat "$OVL.cpio" "$INITRD_SRC" > /mnt/esp/EFI/wootc/phase2-initramfs.img; then
-                        CPIO_OK=1
-                    fi
-                    rm -f "$OVL.cpio"; rm -rf "$OVL"
-                    if [[ "$CPIO_OK" != 1 || ! -s /mnt/esp/EFI/wootc/phase2-initramfs.img ]]; then
-                        err "  [FAIL] systemd-boot: cpio prepend failed"
+                    if ! build_phase2_initrd "$OVL" "$INITRD_SRC" /mnt/esp/EFI/wootc/phase2-initramfs.img; then
+                        rm -rf "$OVL"
+                        err "  [FAIL] systemd-boot: Phase-2 initrd build/verify failed"
                         exit 1
                     fi
+                    rm -rf "$OVL"
 
                     ROOT_OPTIONS=$(grep '^options ' "${BLS_DIR:-$DEPLOY_ROOT/boot/loader/entries}"/*.conf 2>/dev/null | head -1 | sed 's/^options *//')
                     ROOT_OPTIONS=$(printf '%s' "$ROOT_OPTIONS" | tr ' ' '\n' | grep -v '\$' | grep -v -E '^(quiet|rhgb)$' | tr '\n' ' ' || true)
@@ -2222,47 +2365,27 @@ BLSEOF
                 log "  Staging Phase-2 kernel and initramfs to ESP:EFI/wootc/..."
                 cp "$KERNEL_SRC" /mnt/esp/EFI/wootc/phase2-vmlinuz
                 # Patch Phase-2 initrd with wootc-boot via prepend-cpio. The target image
-                # (e.g. yellowfin) lacks ntfs3/ntfs-3g, so we also copy the deployer's
-                # own ntfs-3g binary and fuse module/libraries into the early cpio.
+                # (e.g. yellowfin) may lack ntfs3/ntfs-3g, so a userspace driver is
+                # staged too — coherently sourced (the old inline copy staged the
+                # deployer's libraries at the TARGET's library paths, overriding the
+                # base initrd's own libc-adjacent files: cross-image soname roulette).
                 OVL="/tmp/wootc-ovl-$$"
                 rm -rf "$OVL"; mkdir -p "$OVL"
-                : > "$OVL/early_cpio"
-                install -D -m0644 /usr/lib/wootc/99wootc-boot/wootc-attach.service \
-                    "$OVL/usr/lib/systemd/system/wootc-attach.service"
-                install -D -m0755 /usr/lib/wootc/99wootc-boot/wootc-attach-loop.sh \
-                    "$OVL/usr/lib/wootc/wootc-attach-loop.sh"
-                mkdir -p "$OVL/usr/lib/systemd/system/initrd-root-device.target.wants"
-                ln -sf ../wootc-attach.service \
-                    "$OVL/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
-
-                # If deployer has ntfs-3g, stage it and ALL its ldd dependencies into early cpio overlay
-                if command -v ntfs-3g >/dev/null 2>&1; then
-                    nbin=""
-                    nbin=$(command -v ntfs-3g)
-                    install -D -m0755 "$nbin" "$OVL/usr/bin/ntfs-3g"
-                    # copy all dynamic dependencies found via ldd
-                    ldd "$nbin" 2>/dev/null | awk '/=>/ {print $3}' | while read -r lib; do
-                        if [[ -f "$lib" ]]; then
-                            install -D -m0755 "$lib" "$OVL/$lib"
-                        fi
-                    done
+                stage_wootc_overlay "$OVL"
+                if ! stage_ntfs3g_closure "$OVL"; then
+                    log "  [WARN] no ntfs-3g stageable for the Phase-2 initrd — relying on kernel ntfs3"
                 fi
 
                 # NOTE: Storage kernel modules are intentionally NOT staged here.
                 # See branch-1 comment above for rationale (Secure Boot lockdown rejection).
 
-                CPIO_OK=0
-                if ( cd "$OVL" && find . | cpio -o -H newc --quiet ) > "$OVL.cpio" && \
-                   cat "$OVL.cpio" "$INITRD_SRC" > /mnt/esp/EFI/wootc/phase2-initramfs.img; then
-                    CPIO_OK=1
-                fi
-                rm -f "$OVL.cpio"; rm -rf "$OVL"
-                if [[ "$CPIO_OK" == 1 && -s /mnt/esp/EFI/wootc/phase2-initramfs.img ]]; then
-                    log "  [PASS] Phase-2 initrd patched with wootc-boot & ntfs-3g (prepend-cpio)"
-                else
-                    err "  [FAIL] cpio prepend failed — Phase-2 initrd would be hookless"
+                if ! build_phase2_initrd "$OVL" "$INITRD_SRC" /mnt/esp/EFI/wootc/phase2-initramfs.img; then
+                    rm -rf "$OVL"
+                    err "  [FAIL] Phase-2 initrd build/verify failed"
                     exit 1
                 fi
+                rm -rf "$OVL"
+                log "  [PASS] Phase-2 initrd patched with wootc-boot & ntfs-3g (prepend-cpio, contents verified)"
 
                 # BCD loads \EFI\fedora\shimx64.efi; the target shim then loads
                 # grubx64.efi from that same dir. Overwrite both with the
@@ -2417,7 +2540,27 @@ GRUBEOF
     fi
     umount /mnt/verify 2>/dev/null || err "  [WARN] could not unmount /mnt/verify (busy?) — continuing"
 else
-    err "  [WARN] Could not mount installed root for verification (checking via loop file only)"
+    # FAIL CLOSED (#45). No mountable, recognized installed root means Phase 2
+    # cannot be verified OR staged — the ESP never gets a Phase-2 kernel, and
+    # the firmware would fall straight back to Windows (exactly the recorded
+    # composefs failure shape). "Checking via loop file only" verified nothing;
+    # advertising deploy-ready here misattributes the later boot failure and
+    # shows the user a success path for an unbootable system. Say precisely
+    # what was found instead, then refuse.
+    err "  [FAIL] no mountable, recognized installed root on ${VERIFY_LOOP} — cannot verify or stage Phase 2"
+    err "         partition table as the kernel sees it:"
+    sfdisk -l "$VERIFY_LOOP" 2>&1 | sed 's/^/    /' >&2 || true
+    for _p in "${VERIFY_LOOP}"p*; do
+        [[ -b "$_p" ]] || continue
+        err "         $_p: $(blkid "$_p" 2>/dev/null || echo 'blkid: no signature')"
+        _mnt_err=$(timeout 15 mount -o ro "$_p" /mnt/verify 2>&1) && {
+            err "           mounts, but no ostree/composefs deployment or /etc/os-release inside"
+            umount /mnt/verify 2>/dev/null || true
+        } || err "           mount: $(printf '%s' "$_mnt_err" | head -c 300)"
+    done
+    err "         The install is either unstaged or in a layout this deployer does not recognize."
+    err "         Refusing to advertise deploy-ready for a system that cannot boot."
+    exit 1
 fi
 
 if [[ -n "$VERIFY_CRYPT" ]]; then
@@ -2453,9 +2596,9 @@ umount /var/fisherman-tmp 2>/dev/null || true
 SCRATCH_LOOP=""
 rm -f "$SCRATCH_IMG"
 
-# Robustly unmount the host NTFS. The composefs verify path can fail to mount the
-# installed root ("checking via loop file only") and leave a loop device or
-# overlay pinning a file under /mnt/ntfs — then a plain `umount /mnt/ntfs` blocks
+# Robustly unmount the host NTFS. (The verify path that reached here having
+# failed to mount the installed root is now fatal — #45 — but a loop device or
+# overlay can still pin a file under /mnt/ntfs) — a plain `umount /mnt/ntfs` blocks
 # "target is busy" forever and the whole deploy times out without ever rebooting
 # into Phase 2. So: sync, detach any loop still backed by a /mnt/ntfs file,
 # unmount anything nested, then a BOUNDED umount with a lazy fallback. (The sync

--- a/platform/dracut/99wootc-boot/module-setup.sh
+++ b/platform/dracut/99wootc-boot/module-setup.sh
@@ -25,6 +25,11 @@ installkernel() {
     # virtio_scsi, virtio_pci, sd_mod, ahci — host disk controller drivers
     instmods loop fuse virtio_scsi virtio_pci sd_mod ahci nvme
     instmods ntfs3 2>/dev/null || :   # optional: not built on EL kernels
+    # btrfs (#35): a btrfs root=UUID device stays SYSTEMD_READY=0 until the
+    # btrfs module has it registered (udev 64-btrfs.rules), and dracut's own
+    # 90btrfs module is only auto-selected when the image ships btrfs-progs.
+    # The attach hook modprobes it for btrfs roots; make sure it is there.
+    instmods btrfs 2>/dev/null || :   # optional: not built on all kernels
 }
 
 install() {
@@ -102,6 +107,10 @@ install() {
     # udevadm: the attach script settles udev and waits for the Windows NTFS
     # by-uuid symlink (a oneshot service gets one shot, no initqueue retry).
     inst_multiple mount mountpoint mkdir modprobe blockdev sleep udevadm
+    # btrfs-progs, when the image has it: the attach hook registers btrfs
+    # loop partitions with `btrfs device scan` so the udev readiness gate
+    # (#35) clears. Optional — the udev builtin re-trigger is the fallback.
+    inst_multiple -o btrfs
     # The userspace NTFS driver (ntfs-3g) for kernels without ntfs3 is added by
     # the deployer's regen via `dracut --install` — module-level inst does not
     # reliably resolve it there, but a regen-level --install does.

--- a/platform/dracut/99wootc-boot/wootc-attach-loop.sh
+++ b/platform/dracut/99wootc-boot/wootc-attach-loop.sh
@@ -208,6 +208,42 @@ udevadm trigger --action=add --sysname-match="${loopname}" --sysname-match="${lo
     udevadm trigger --action=add 2>/dev/null || true
 udevadm settle --timeout=30 2>/dev/null || true
 
+# btrfs readiness (#35). A by-uuid symlink is NOT device readiness: udev's
+# 64-btrfs.rules gates every btrfs partition behind IMPORT{builtin}="btrfs
+# ready" and marks it SYSTEMD_READY=0 until the btrfs module has the device
+# registered. If btrfs.ko is not loaded when the loop partitions' add events
+# are processed, the builtin fails, the root=UUID device UNIT never
+# activates, and sysroot.mount times out into the emergency shell even though
+# the UUID sits right there in /dev/disk/by-uuid — the exact #35 shape (GUI
+# takes 9+10: attach clean at t=3s, UUID listed, timeout anyway).
+#
+# No modprobe here (see the storage-driver note above — same lockdown
+# constraint, asserted by tests/unit/raw-loopback.bats). btrfs.ko is loaded
+# EARLY and dependency-resolved by systemd-modules-load via the
+# modules-load.d entry the deployer bakes into this initramfs for btrfs
+# deploys. This block only REGISTERS the just-attached partitions and
+# re-runs the udev readiness import, then reports the result.
+if blkid "${LOOP_DEV}"p* 2>/dev/null | grep -q 'TYPE="btrfs"'; then
+    say "btrfs partitions present — registering devices so the udev readiness gate clears"
+    # Registration via btrfs-progs when available; the udev builtin re-run
+    # below covers the case where it is not.
+    if command -v btrfs >/dev/null 2>&1; then
+        for part in "${LOOP_DEV}"p*; do
+            blkid "$part" 2>/dev/null | grep -q 'TYPE="btrfs"' || continue
+            btrfs device scan "$part" >/dev/null 2>&1 || true
+        done
+    fi
+    udevadm trigger --action=change --sysname-match="${loopname}p*" 2>/dev/null || \
+        udevadm trigger --action=change 2>/dev/null || true
+    udevadm settle --timeout=15 2>/dev/null || true
+    # Report readiness per btrfs partition — if #35 persists, THIS line is the
+    # discriminator between "device never became ready" and a different bug.
+    for part in "${LOOP_DEV}"p*; do
+        blkid "$part" 2>/dev/null | grep -q 'TYPE="btrfs"' || continue
+        say "btrfs $part: module loaded=$(grep -cw btrfs /proc/modules 2>/dev/null) $(udevadm info --query=property "$part" 2>/dev/null | grep -E '^(SYSTEMD_READY|ID_BTRFS_READY)=' | tr '\n' ' ')"
+    done
+fi
+
 : > /run/wootc-loop-attached
 say "attached raw root.disk $FULL_LOOP_PATH as $LOOP_DEV"
 # The whole point of the attach: the root partition's UUID must now appear to

--- a/tests/unit/btrfs-phase2.bats
+++ b/tests/unit/btrfs-phase2.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# btrfs sealed root, Phase 2 (#35): the deploy formats and completes, the
+# attach is clean (loop partitions + by-uuid symlinks at t=3s), and
+# sysroot.mount STILL times out — because a by-uuid symlink is not device
+# readiness. udev's 64-btrfs.rules gates btrfs partitions behind
+# IMPORT{builtin}="btrfs ready" (SYSTEMD_READY=0 until the btrfs module has
+# the device registered), so the root=UUID device UNIT never activates if
+# btrfs.ko is not loaded when the attach's partition events land.
+#
+# The fix is layered, and constrained by the no-modprobe lesson
+# (tests/unit/raw-loopback.bats: a hook modprobe under Secure Boot lockdown
+# is rejected and blocks the correctly-signed module):
+#   1. deploy.sh bakes a modules-load.d entry into the regenerated Phase-2
+#      initramfs for btrfs deploys — systemd-modules-load loads btrfs.ko
+#      early, dependency-resolved, long before wootc-attach.service;
+#   2. the attach hook registers the just-attached partitions (btrfs device
+#      scan) and re-triggers CHANGE events so the readiness import re-runs;
+#   3. the hook reports module-loaded + SYSTEMD_READY per btrfs partition,
+#      so a persisting #35 is diagnosable from one serial log.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DEPLOY="${DEPLOY:-$REPO_ROOT/payload/deployer/deploy.sh}"
+    HOOK="${HOOK:-$REPO_ROOT/platform/dracut/99wootc-boot/wootc-attach-loop.sh}"
+    MODSETUP="${MODSETUP:-$REPO_ROOT/platform/dracut/99wootc-boot/module-setup.sh}"
+}
+
+@test "btrfs deploys bake an early modules-load.d entry into the Phase-2 initramfs" {
+    grep -q 'FILESYSTEM" == btrfs' "$DEPLOY"
+    grep -q 'modules-load.d/wootc-btrfs.conf' "$DEPLOY"
+    # The include dir must be created under $DEPLOY_ROOT — dracut runs
+    # chrooted, so a path on the deployer's own / is invisible to it.
+    grep -q '"\$DEPLOY_ROOT/run/wootc-btrfs-inc' "$DEPLOY"
+    grep -q -- '--include /run/wootc-btrfs-inc /' "$DEPLOY"
+    # And the args must actually reach the regen invocation.
+    grep -q '"\${DRACUT_INCLUDE_ARGS\[@\]}"' "$DEPLOY"
+}
+
+@test "the attach hook clears the btrfs udev readiness gate without modprobe" {
+    grep -q 'TYPE="btrfs"' "$HOOK"
+    grep -q 'btrfs device scan' "$HOOK"
+    grep -q -- '--action=change' "$HOOK"
+    # Diagnosability: one serial line must discriminate "module never loaded"
+    # from "device never became ready" from "different bug entirely".
+    grep -q 'SYSTEMD_READY' "$HOOK"
+    grep -q '/proc/modules' "$HOOK"
+    # The no-modprobe constraint stays intact (also asserted by
+    # raw-loopback.bats; repeated here so THIS file fails too if the btrfs
+    # block regresses into a modprobe).
+    run grep -nE '^[^#]*modprobe ' "$HOOK"
+    [ "$status" -ne 0 ]
+}
+
+@test "the dracut module carries btrfs.ko and (optionally) btrfs-progs" {
+    # dracut's own 90btrfs is only auto-selected when the image ships
+    # btrfs-progs; wootc must not depend on that.
+    grep -q 'instmods btrfs' "$MODSETUP"
+    grep -q 'inst_multiple -o btrfs' "$MODSETUP"
+}
+
+@test "ext4 stays the sealed default until #35 is proven green" {
+    # btrfs remains reachable via wootc.filesystem=btrfs; flipping the sealed
+    # default is an E2E decision (a green btrfs matrix run), not a code one.
+    grep -q 'FILESYSTEM=ext4' "$DEPLOY"
+    grep -q 'btrfs blocked on #35\|btrfs stays reachable' "$DEPLOY"
+}

--- a/tests/unit/phase2-early-cpio.bats
+++ b/tests/unit/phase2-early-cpio.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# Phase-2 early-cpio staging: one overlay implementation for every branch,
+# coherent ntfs-3g sourcing, and verification of the built initrd by
+# INSPECTION rather than by "the concatenated file is non-empty".
+#
+# Context (#28): two branches looked for ntfs-3g under a /mnt/sysroot that
+# never exists in the deployer initramfs, then fell through to the deployer's
+# own binary WITHOUT its library closure — the cross-image soname failure of
+# docs/agent-lessons.md §8 (libfuse3.so.4 vs .so.3: lands, then dies exactly
+# like a missing binary). And (#45): a deploy whose installed root could not
+# be mounted still advertised deploy-ready and rebooted.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DEPLOY="${DEPLOY:-$REPO_ROOT/payload/deployer/deploy.sh}"
+}
+
+# Extract a top-level function from deploy.sh so it can be exercised for real.
+# Returns the function text; empty output fails the caller loudly.
+extract_fn() {
+    awk "/^$1\(\) \{/,/^\}/" "$DEPLOY"
+}
+
+@test "no early-cpio branch references the phantom /mnt/sysroot" {
+    # Comments may tell the story; code may not resurrect the path.
+    run grep -nE '^[^#]*/mnt/sysroot' "$DEPLOY"
+    [ "$status" -ne 0 ]
+}
+
+@test "all three prepend-cpio branches share one overlay implementation" {
+    # Hand-copied variants drifted (one staged libs, one did not, one staged
+    # the deployer's libs at the TARGET's library paths). The helpers must be
+    # defined once and called from every branch.
+    [ "$(grep -c '^stage_wootc_overlay() {' "$DEPLOY")" -eq 1 ]
+    [ "$(grep -c '^stage_ntfs3g_closure() {' "$DEPLOY")" -eq 1 ]
+    [ "$(grep -c '^build_phase2_initrd() {' "$DEPLOY")" -eq 1 ]
+    [ "$(grep -c '^[^#]*stage_wootc_overlay "\$OVL"' "$DEPLOY")" -ge 3 ]
+    [ "$(grep -c '^[^#]*stage_ntfs3g_closure "\$OVL"' "$DEPLOY")" -ge 3 ]
+    [ "$(grep -c 'build_phase2_initrd "\$OVL"' "$DEPLOY")" -ge 3 ]
+    # No branch may keep a private copy of the packing pipeline.
+    [ "$(grep -c 'cpio -o -H newc' "$DEPLOY")" -eq 1 ]
+}
+
+@test "the deployer-sourced fallback ships the loader and is exec-verified" {
+    # agent-lessons §8: full closure = binary + every NEEDED lib + the
+    # loader, invoked via the staged loader — and proven by RUNNING it (ldd
+    # reports only the first missing library).
+    grep -q -- '--library-path' "$DEPLOY"
+    grep -q 'usr/lib/wootc/ntfs3g' "$DEPLOY"
+    grep -q 'staged ntfs-3g closure does not execute' "$DEPLOY"
+    # The wrapper pins the private closure; the target's libraries are never
+    # mixed in — so nothing may install deployer libs at target lib paths.
+    run grep -nE 'install -D [^ ]+ "\$OVL/\$lib"' "$DEPLOY"
+    [ "$status" -ne 0 ]
+}
+
+@test "the built Phase-2 initrd is verified by listing, not by size" {
+    grep -q 'cpio -it' "$DEPLOY"
+    grep -q 'the target.s base initrd lacks' "$DEPLOY"
+    # Overlay completeness is asserted BEFORE packing (dangling wants was a
+    # proven silent no-op).
+    grep -q 'early-cpio overlay is incomplete' "$DEPLOY"
+    # An unlistable base initrd WARNs (unknown compression is not proof of a
+    # defect), it does not kill a possibly-good deploy.
+    grep -q 'could not list the base initrd' "$DEPLOY"
+}
+
+@test "a missing mountable installed root is fatal, with evidence (#45)" {
+    # The old branch logged '[WARN] Could not mount installed root
+    # (checking via loop file only)' and then set DEPLOY_OK=1 — advertising
+    # deploy-ready for a system with no verified (or even findable) root.
+    run grep -nE '^[^#]*checking via loop file only' "$DEPLOY"
+    [ "$status" -ne 0 ]
+    grep -q 'no mountable, recognized installed root' "$DEPLOY"
+    # Evidence: partition table, per-partition blkid, bounded mount errors.
+    fail_line=$(grep -n 'no mountable, recognized installed root' "$DEPLOY" | head -1 | cut -d: -f1)
+    exit_line=$(awk -v start="$fail_line" 'NR > start && /^[[:space:]]*exit 1/ { print NR; exit }' "$DEPLOY")
+    [ -n "$fail_line" ] && [ -n "$exit_line" ]
+    [ "$exit_line" -le $((fail_line + 25)) ]
+    sed -n "${fail_line},${exit_line}p" "$DEPLOY" | grep -q 'sfdisk -l'
+    sed -n "${fail_line},${exit_line}p" "$DEPLOY" | grep -q 'blkid'
+    # And the success reboot must come AFTER this gate in program order.
+    ok_line=$(grep -n '^DEPLOY_OK=1' "$DEPLOY" | head -1 | cut -d: -f1)
+    [ "$exit_line" -lt "$ok_line" ]
+}
+
+# ── Behavioral: the helpers, run for real ───────────────────────────────────
+
+run_helpers() { # <bash-snippet> — with the extracted helpers + stubs loaded
+    bash -c "
+        set -e
+        log() { echo \"LOG: \$*\"; }
+        err() { echo \"ERR: \$*\" >&2; }
+        $(extract_fn stage_ntfs3g_closure)
+        $(extract_fn build_phase2_initrd)
+        $1
+    "
+}
+
+@test "behavioral: target ntfs-3g is staged with its libraries, symlinks intact" {
+    tmp="$BATS_TEST_TMPDIR/target"
+    mkdir -p "$tmp/root/usr/bin" "$tmp/root/usr/lib64" "$tmp/ovl"
+    printf '#!/bin/sh\necho fake\n' > "$tmp/root/usr/bin/ntfs-3g"
+    chmod +x "$tmp/root/usr/bin/ntfs-3g"
+    # Symlink chain: .so.89 -> .so.89.0.0 — both must land in the overlay.
+    echo lib > "$tmp/root/usr/lib64/libntfs-3g.so.89.0.0"
+    ln -s libntfs-3g.so.89.0.0 "$tmp/root/usr/lib64/libntfs-3g.so.89"
+    run run_helpers "DEPLOY_ROOT='$tmp/root'; stage_ntfs3g_closure '$tmp/ovl'"
+    [ "$status" -eq 0 ]
+    [ -x "$tmp/ovl/usr/bin/ntfs-3g" ]
+    [ -f "$tmp/ovl/usr/lib64/libntfs-3g.so.89.0.0" ]
+    [ -L "$tmp/ovl/usr/lib64/libntfs-3g.so.89" ]
+    [ -L "$tmp/ovl/usr/sbin/mount.ntfs" ]
+}
+
+make_overlay() { # <dir> — a complete wootc overlay tree
+    mkdir -p "$1/usr/lib/systemd/system/initrd-root-device.target.wants" \
+             "$1/usr/lib/wootc"
+    echo unit > "$1/usr/lib/systemd/system/wootc-attach.service"
+    ln -sf ../wootc-attach.service \
+        "$1/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
+    printf '#!/bin/bash\n' > "$1/usr/lib/wootc/wootc-attach-loop.sh"
+    chmod +x "$1/usr/lib/wootc/wootc-attach-loop.sh"
+}
+
+make_base_initrd() { # <out> [tools...] — a gzip cpio shipping the named tools
+    local out="$1"; shift
+    local tree="$BATS_TEST_TMPDIR/base-tree"
+    rm -rf "$tree"; mkdir -p "$tree/usr/bin" "$tree/usr/sbin"
+    local t
+    for t in "$@"; do echo x > "$tree/usr/bin/$t"; done
+    ( cd "$tree" && find . | cpio -o -H newc --quiet ) | gzip > "$out"
+}
+
+@test "behavioral: a complete overlay + complete base initrd builds and verifies" {
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    ovl="$BATS_TEST_TMPDIR/ovl-ok"; make_overlay "$ovl"
+    make_base_initrd "$BATS_TEST_TMPDIR/base.img" bash losetup udevadm mount
+    run run_helpers "build_phase2_initrd '$ovl' '$BATS_TEST_TMPDIR/base.img' '$BATS_TEST_TMPDIR/out.img'"
+    [ "$status" -eq 0 ]
+    # Output must start with the overlay's uncompressed newc cpio magic.
+    head -c 6 "$BATS_TEST_TMPDIR/out.img" | grep -q 070701
+}
+
+@test "behavioral: a base initrd without bash is REFUSED (mutation test)" {
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    ovl="$BATS_TEST_TMPDIR/ovl-nobash"; make_overlay "$ovl"
+    make_base_initrd "$BATS_TEST_TMPDIR/base-nobash.img" losetup udevadm mount
+    run run_helpers "build_phase2_initrd '$ovl' '$BATS_TEST_TMPDIR/base-nobash.img' '$BATS_TEST_TMPDIR/out2.img'"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q 'lacks: bash'
+}
+
+@test "behavioral: an overlay with a missing wants edge is refused before packing" {
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    ovl="$BATS_TEST_TMPDIR/ovl-dangling"; make_overlay "$ovl"
+    rm "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
+    make_base_initrd "$BATS_TEST_TMPDIR/base3.img" bash losetup udevadm mount
+    run run_helpers "build_phase2_initrd '$ovl' '$BATS_TEST_TMPDIR/base3.img' '$BATS_TEST_TMPDIR/out3.img'"
+    [ "$status" -ne 0 ]
+    [ ! -e "$BATS_TEST_TMPDIR/out3.img" ]
+}
+
+@test "behavioral: an unlistable base initrd warns but does not fail the deploy" {
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    ovl="$BATS_TEST_TMPDIR/ovl-unk"; make_overlay "$ovl"
+    head -c 4096 /dev/urandom > "$BATS_TEST_TMPDIR/base-unknown.img"
+    run run_helpers "build_phase2_initrd '$ovl' '$BATS_TEST_TMPDIR/base-unknown.img' '$BATS_TEST_TMPDIR/out4.img'"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'could not list the base initrd'
+}


### PR DESCRIPTION
Code-side fixes for the three defects gating the dakota / composefs / btrfs matrix cells, plus `docs/finish-plan.md` laying out the E2E rungs that remain. Windows 10 Home/Enterprise/LTSC (#58) is explicitly out of scope per the maintainer.

## Early-cpio staging (#28, remaining defect from the 2026-07-25 review)

The three prepend-cpio branches carried hand-copied variants that looked for ntfs-3g under a `/mnt/sysroot` that never exists in the deployer initramfs, then fell through to the deployer's binary **without its library closure** — the cross-image soname failure documented in `docs/agent-lessons.md` §8 (`libfuse3.so.4` vs `.so.3`: lands, then dies exactly like a missing binary). One implementation now serves all branches:

- `stage_wootc_overlay` — unit + wants edge + hook, once.
- `stage_ntfs3g_closure` — the **target deployment's own** ntfs-3g (+its libs from the same tree) first; else the **deployer's** binary as a complete private closure: every `NEEDED` lib + the dynamic loader under `/usr/lib/wootc/ntfs3g/`, wrapper-invoked, and **exec-verified at stage time** (`ld.so --library-path … ntfs-3g --version`), so an incomplete closure fails the deploy instead of Phase 2. Deployer libs are never installed at target library paths.
- `build_phase2_initrd` — packs and **verifies by inspection**: overlay completeness (unit, wants, executable hook) before packing; the base initrd is listed and must ship the hook's interpreter and tools (`bash losetup udevadm mount`). Fail closed on proof; warn (don't kill a possibly-good deploy) when the base is unlistable.

## Fail-closed verification (#45)

A deploy whose installed root cannot be mounted and recognized no longer logs `[WARN] … (checking via loop file only)`, sets `DEPLOY_OK=1`, and reboots into a system with no Phase-2 kernel on the ESP. It now exits 1 **before any success marker**, printing the partition table, per-partition `blkid`, and bounded per-partition mount errors.

## btrfs Phase-2 readiness (#35)

A by-uuid symlink is not device readiness: udev's `64-btrfs.rules` keeps btrfs partitions `SYSTEMD_READY=0` until btrfs.ko has them registered, so the `root=UUID` device unit never activates and `sysroot.mount` times out with the UUID sitting right there in by-uuid — the exact GUI-takes-9/10 shape. Layered fix, honoring the no-modprobe-in-the-hook lockdown lesson (`raw-loopback.bats`):

1. btrfs deploys bake a `modules-load.d/wootc-btrfs.conf` into the regenerated Phase-2 initramfs (`dracut --include`, dir under `$DEPLOY_ROOT/run` so the chrooted dracut can see it) — `systemd-modules-load` loads btrfs.ko early and dependency-resolved.
2. The attach hook registers the just-attached partitions (`btrfs device scan` when present), re-triggers CHANGE events so the readiness import re-runs, and settles.
3. The hook logs `module loaded= SYSTEMD_READY=` per btrfs partition — if #35 persists, one serial line discriminates the failing layer.
4. `module-setup.sh` carries `btrfs.ko` + optional btrfs-progs regardless of whether dracut auto-selects its 90btrfs module. ext4 stays the sealed default until a green btrfs E2E run says otherwise.

## Tests

- `tests/unit/phase2-early-cpio.bats` — structural guards plus **behavioral mutation tests** of the extracted helpers: target ntfs-3g staged with symlink chains intact; complete overlay + complete base builds; base-without-bash **refused**; dangling wants refused before packing; unlistable base warns but passes.
- `tests/unit/btrfs-phase2.bats` — modules-load baking reaches the regen invocation; hook clears the readiness gate without modprobe; ext4 stays the sealed default.
- Full suite: 355/357 pass; the 2 failures (`apply-look` once-only marker, fisherman stateroot-var pin) pre-exist on `main` unchanged.

## What only the KVM rig can verify (see docs/finish-plan.md)

1. btrfs re-run (`wootc.filesystem=btrfs`, bluefin:lts) — the new serial diagnostics pin the layer if it still fails.
2. dakota full chain — deploy now runs the hardened staging; the composefs Phase-2 boot is the first unproven step after it.
3. marlin/flounder after dakota, then the post-ledger matrix re-sweep, then #33 (tpm2-luks) as an independent track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->