### PR TITLE
test(e2e): filesystem axis + btrfs matrix cell (#35)

### DIFF
--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -34,6 +34,10 @@ on:
       # per-image heuristic (EL→grub2, else→systemd). Ostree images (e.g.
       # bluefin) want grub2 (the proven attach path); composefs wants systemd.
       bootloader: { type: string, default: '' }
+      # Force the root filesystem (xfs|ext4|btrfs) via wootc.filesystem=.
+      # Empty/auto = the deployer's own default (xfs unsealed, ext4 sealed).
+      # The btrfs matrix cell uses this to prove #35.
+      filesystem: { type: string, default: '' }
       # Arm Phase 1 through the REAL wootc.exe GUI (drive mode) instead of the
       # OEM setup-wootc.ps1 script. Needs no host GUI — the app is staged +
       # driven over QGA via a directive file (CDP is impossible in stock
@@ -183,6 +187,8 @@ jobs:
           WOOTC_E2E_DISK2_SIZE: ${{ inputs.phase3 && '40G' || '' }}
           # Empty string → run-e2e.sh's per-image heuristic picks the bootloader.
           WOOTC_E2E_BOOTLOADER: ${{ inputs.bootloader }}
+          # Empty string → the deployer's own filesystem default.
+          WOOTC_E2E_FILESYSTEM: ${{ inputs.filesystem }}
           # WOOTC_E2E_SNAPSHOT_IN is set by the pull step above on a cache hit.
           # Drive mode gate for the app's E2E bindings (inert otherwise).
           WOOTC_E2E_DRIVE: ${{ inputs.gui_install && '1' || '' }}

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -62,11 +62,17 @@ jobs:
               # force it back on for a big-disk self-hosted runner pool.
               if 'phase3=on' in opts and os.environ.get('INCLUDE_PHASE3') != '1':
                   continue
+              # filesystem=<fs> opt (#35): forces wootc.filesystem= for the cell.
+              fs = ''
+              for o in opts.split(','):
+                  if o.startswith('filesystem='):
+                      fs = o.split('=', 1)[1]
               cases.append({
                   'name': name, 'image': image, 'win_version': ver,
                   'win_edition': ed, 'win_key': key,
                   'bitlocker': 'on' if 'bitlocker=on' in opts else 'off',
                   'phase3': 'phase3=on' in opts,
+                  'filesystem': fs,
               })
           assert cases, 'no cases matched'
           print('matrix=' + json.dumps({'include': cases}))
@@ -94,6 +100,7 @@ jobs:
       bitlocker: ${{ matrix.bitlocker }}
       case_name: ${{ matrix.name }}
       phase3: ${{ matrix.phase3 }}
+      filesystem: ${{ matrix.filesystem }}
       # GUI mode has only ever been exercised on one cell (bluefin:lts via
       # e2e-gui.yml). Driving Phase 1 through the real wootc.exe across the whole
       # matrix is what proves the INSTALLER — not just the harness — works on

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -512,3 +512,51 @@ Three habits:
   5.8.4, so an environment repair must be unconditional and then *verified by a
   real `podman run`*, not gated on a version comparison. Version strings are a
   proxy; a container that starts is the fact.
+
+## 27. Rebooting is not releasing. Phase 2 owed Windows a clean unmount.
+
+Both `fedora-gnome` cells of run 30704513401 failed identically — so, not a
+flake — with `[FAIL] QGA did not become available for Windows return after
+Phase 2 Linux within 10 minutes`. Phase 2 itself was flawless: it booted,
+passed every passthrough and user-data check, and rebooted on cue. The damage
+was done on the way out, and it was visible in five lines of serial nobody had
+been reading:
+
+```
+(sd-remount)[...]: Failed to remount '/run/initramfs/wootc-host' read-only: Device or resource busy
+systemd-shutdown[1]: Not all file systems unmounted, 1 left.
+systemd-shutdown[1]: Not all loop devices detached, 1 left.
+systemd-shutdown[1]: Cannot finalize remaining file systems, loop devices, continuing.
+reboot: machine restart
+```
+
+Windows then showed a desktop for ~26 s, rebooted itself, looped the boot
+manager three or four times and died in Startup Repair. The QGA timeout was a
+*symptom four reboots downstream* of the actual bug.
+
+- **A boot stack that lives on the thing it must release cannot release it.**
+  Phase-2 `/` is a loop device backed by `root.disk`, a file on the rw NTFS
+  mount. Nothing running inside that stack can unmount the volume. The
+  deployer already knew this — `deploy.sh` has a whole block ending "a
+  still-mounted rw NTFS would be flagged dirty" — and Phase 2 simply never got
+  the same treatment. **When one side of a symmetric operation has a hard-won
+  teardown, go look for the other side.**
+- **A missing file can disable an entire subsystem in total silence.**
+  `dracut-shutdown.service` populates `/run/initramfs` from
+  `/boot/initramfs-$(uname -r).img`. On ostree/composefs that path does not
+  exist, `dracut-initramfs-restore` no-ops, and systemd — which only pivots
+  when `/run/initramfs/shutdown` is executable — quietly skips the whole
+  shutdown-initramfs mechanism. No error, no warning, and the *absence* of
+  "Returning to initrd..." in the log is the only tell.
+- **Corruption sorts by driver, and the passing cells were the clue.** Every
+  cell mounting the host volume with kernel `ntfs3` failed; every cell that
+  fell back to the `ntfs-3g` FUSE driver passed. That correlation is what
+  turned "flaky Fedora cell" into "structural teardown bug" — a green cell is
+  evidence too, and diffing it against the red one costs minutes.
+- **Make the dangerous new path revert to the old one.** The fix arms a
+  shutdown pivot that did not previously happen, on every cell's boot path,
+  and cannot be tested outside a 60–90 minute VM run. So every failure path in
+  the staging hook ends by deleting `/run/initramfs/shutdown` — without it
+  systemd does not pivot, which is *exactly* today's behaviour. A partial or
+  broken staging can only reproduce the bug it is fixing; it cannot invent a
+  new one.

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -560,3 +560,38 @@ manager three or four times and died in Startup Repair. The QGA timeout was a
   systemd does not pivot, which is *exactly* today's behaviour. A partial or
   broken staging can only reproduce the bug it is fixing; it cannot invent a
   new one.
+
+## 28. The initramfs is not your laptop, and `[FAIL]` is not a log level
+
+`bluefin-dakota-win11pro` (run 30707067821) died 11 minutes into the deploy on
+two lines:
+
+```
+[wootc] ABORT: line 1281: awk '{for(i=1;i<=NF;i++) if ($i ~ /^\//) print $i}' (exit 127)
+[FAIL] qga: ldd on the deployer's qemu-ga surfaced no dynamic loader
+```
+
+- **A dracut initramfs contains exactly what `module-setup.sh` names.** Every
+  closure builder in `deploy.sh` resolved libraries with `ldd "$bin" | awk …`.
+  `ldd` is a glibc-common *shell script*; no library dependency drags it in,
+  nothing listed it, so it was never in the image. Reach for the thing whose
+  presence is structurally guaranteed instead: the dynamic loader has to be
+  there or the deployer itself could not run, and `$ldso --list` is what `ldd`
+  execs anyway. `dso_closure()` now does that in pure bash, so no missing text
+  tool can break a closure either.
+- **Exit 127 names the wrong command.** Under `set -o pipefail` the ERR trap
+  reported the `awk` stage of a pipeline whose *first* stage was the missing
+  one. When a trap blames a command that obviously exists, suspect the rest of
+  the pipeline before you suspect the trap.
+- **`[FAIL]` on the deployer serial is an API, not a severity.** `run-e2e.sh`
+  greps the serial for `fatal|panic|[FAIL]` and ends the deploy on the first
+  hit. The qga stager printed `[FAIL]` for a condition its own caller absorbs
+  with `[WARN] no fallback qemu-ga staged` — so a survivable best-effort miss
+  killed a cell that was otherwise fine. A function may only shout `[FAIL]` if
+  every one of its callers treats the failure as fatal.
+- **The same rule bites the harness.** `run-e2e.sh` also printed
+  `[FAIL] run-e2e.sh aborted: awk …` on every hosted cell, because `-E`
+  propagates the ERR trap into the command substitution probing for a
+  `tailscale0` that hosted runners do not have. Nothing aborted. The matrix
+  takes the *last* `[FAIL]` as the verdict, so an optional probe was one silent
+  timeout away from becoming a run's official cause of death.

--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -595,3 +595,54 @@ two lines:
   `tailscale0` that hosted runners do not have. Nothing aborted. The matrix
   takes the *last* `[FAIL]` as the verdict, so an optional probe was one silent
   timeout away from becoming a run's official cause of death.
+
+## 29. The harness destroyed the run it had already passed
+
+`fedora-gnome-win11pro-btrfs` (run 30710282779) failed on:
+
+```
+[FAIL] Windows QGA did not become available within 10 minutes
+```
+
+It had already succeeded. Every Linux assertion passed, §27's shutdown pivot
+worked (`wootc: shutdown: unmounted the Windows host NTFS at
+/oldsys/run/initramfs/wootc-host`), and the serial shows the return happening
+two seconds after the reboot request:
+
+```
+[   75.9] reboot: machine restart
+BdsDxe: starting Boot0003 "Windows Boot Manager" ...
+```
+
+Then the harness power-cut it. The two boot-manager loads after that one are
+its own `system_reset` and the loop that followed; the final screenshot is a
+recovery screen.
+
+- **A ping is not an identity.** The reboot step watched for `qga_probe` to
+  *fail* and reset the VM if it never did. `qga_probe` is `guest-ping`, which
+  answers for whichever agent is up — so "Phase 2 has not rebooted" and
+  "Windows is already back" produced the identical reading, and the fallback
+  for the first is a hard power cut to the second. §1 again, in its purest
+  form: the observable is *which* OS answers, and the code only ever sampled
+  *whether* one did. `qga_windows_probe` had existed for months, six lines
+  above; `qga_wait_down` already used it. This loop just didn't.
+- **A destructive fallback needs positive evidence, not the absence of
+  evidence.** `p2_reboot_observe()` now returns one of `down` / `windows` /
+  `linux` / `unknown`, and only `linux` — a guest that answered `uname -s` —
+  may be reset. `unknown` (a Windows agent pinging before PowerShell is up)
+  deliberately does nothing: the cost of waiting is one honest timeout, the
+  cost of guessing wrong is the whole run.
+- **Blind time is where the state changes underneath you.** The request went
+  out through an unbounded `qga_call exec`, which polls `guest-exec-status`
+  until exit and then retries three times at 60s. Against a guest that is busy
+  dying that is ~110 seconds of not looking — long enough for Phase 2 to leave
+  *and* Windows to come back, so the observation opened its eyes on the wrong
+  OS. §4 says bound the blocking call; the corollary is that anything you do
+  not watch is free to become its own opposite while you wait.
+- **This is why §27 read as a partial fix.** That session saw Windows "show a
+  desktop for ~26 s, reboot, and die in Startup Repair" and attributed the
+  reboot to the dirty volume. The unclean unmount was real and worth fixing,
+  but the reboot at ~26 s was this bug: the harness resetting a Windows that
+  had come back fine. When a fix lands and the symptom shifts but survives,
+  check whether you are now looking at a *second* cause rather than a
+  an incomplete first one.

--- a/docs/finish-plan.md
+++ b/docs/finish-plan.md
@@ -51,11 +51,17 @@ bugs: the composefs Phase-2 staging path (#28) and btrfs device readiness
 
 Each rung is one KVM run; do them in this order, one change per run:
 
-1. **btrfs re-run** (`wootc.filesystem=btrfs`, bluefin:lts): expect green;
+1. **btrfs re-run** (`wootc.filesystem=btrfs`, bonito:gnome): expect green;
    if not, the new `btrfs <part>: module loaded=… SYSTEMD_READY=…` serial
    line says which layer failed. When green twice, consider flipping the
    sealed default to btrfs (native fs-verity, reflinks) — a product call,
    not a bug fix; ext4 stays default until then.
+   *Not bluefin:lts*: matrix run 30700616717 proved CentOS Stream 10 cannot
+   load btrfs at all here — the module is out-of-tree, signed with a key the
+   locked-down (Secure Boot) kernel rejects (`Loading of module with
+   unavailable key is rejected`, `module loaded=0`), so that cell dies a
+   layer before the #35 mount. The deployer now refuses such a deploy up
+   front instead of proving it again over 25 minutes.
 2. **dakota full chain**: deploy now runs the hardened staging; the
    composefs Phase-2 boot (deployer kernel + patched UKI initrd +
    root=UUID/composefs= kargs) is the first thing that has never been
@@ -74,6 +80,8 @@ Each rung is one KVM run; do them in this order, one change per run:
   the ledger harness (Phase-3 graduation is a follow-on rung).
 - One non-dakota composefs-native family (marlin or flounder) green
   through Phase-2, proving the path is image-agnostic, not dakota-shaped.
-- btrfs: bluefin:lts sealed-btrfs green through Phase-2 twice; #35 closed.
+- btrfs: bonito:gnome sealed-btrfs green through Phase-2 twice; #35 closed
+  (bluefin:lts is not a candidate — its btrfs kmod is rejected under Secure
+  Boot, and the deployer's btrfs preflight now says so at deploy time).
 - All three keep their bats regression guards
   (`phase2-early-cpio.bats`, `btrfs-phase2.bats`) green in CI.

--- a/payload/deployer/Containerfile
+++ b/payload/deployer/Containerfile
@@ -83,6 +83,10 @@ RUN for bin in conmon crun podman skopeo fisherman ostree cpio sfdisk mkfs.ext4 
         { echo "FATAL: CA bundle missing from initramfs"; exit 1; } && \
     lsinitrd /out/deployer-initramfs.img | grep -q "usr/lib/wootc/99wootc-boot/wootc-attach-loop.sh" || \
         { echo "FATAL: 99wootc-boot payload missing from initramfs"; exit 1; } && \
+    lsinitrd /out/deployer-initramfs.img | grep -q "usr/lib/wootc/99wootc-boot/wootc-stage-shutdown.sh" || \
+        { echo "FATAL: Phase-2 shutdown staging hook missing from initramfs (Windows would get a dirty NTFS back)"; exit 1; } && \
+    lsinitrd /out/deployer-initramfs.img | grep -q "usr/lib/wootc/99wootc-boot/wootc-umount-host.sh" || \
+        { echo "FATAL: Phase-2 NTFS umount hook missing from initramfs (Windows would get a dirty NTFS back)"; exit 1; } && \
     lsinitrd /out/deployer-initramfs.img | grep -q "usr/lib/wootc/migration/wootc-passthrough.service" || \
         { echo "FATAL: User Data Bridge migration payload missing from initramfs"; exit 1; } && \
     lsinitrd /out/deployer-initramfs.img | grep -q "usr/lib/wootc/migration/org.tunaos.wootc.policy" || \

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -1244,6 +1244,116 @@ NTFSWRAP
     return 1
 }
 
+# stage_qemu_ga_into_target
+# Give the deployed system a guest agent the E2E control plane can reach, on
+# images that ship none.
+#
+# The previous implementation wrote the binary to $DEPLOY_ROOT/usr/bin/qemu-ga
+# and the unit to $DEPLOY_ROOT/usr/lib/systemd/system/. On a composefs
+# deployment both writes SUCCEED and both are INVISIBLE at runtime: the sealed
+# .cfs image is mounted over /usr, so the deployment directory's own /usr is
+# shadowed. dakota booted Phase 2 all the way to a login prompt carrying
+# `systemd.wants=qemu-guest-agent.service`, with no such unit anywhere in the
+# booted system, while the deployer logged "[PASS] qemu-guest-agent installed
+# from deployer into target" (run 30703716667). The harness then reported
+# "the Phase-2 guest agent never answered". A PASS derived from a write
+# landing rather than from the runtime seeing it.
+#
+# /etc and /var ARE the runtime ones under composefs. Ground truth from that
+# same boot: wootc-passthrough.service (installed into $DEPLOY_ROOT/etc with
+# ExecStart=/var/usrlocal/bin/wootc-mount-user-dirs) started and finished.
+# So stage into those, never into /usr:
+#   binary + full ldd closure  → /var/usrlocal/lib/wootc-qga/
+#   wrapper                    → /var/usrlocal/bin/qemu-ga
+#   unit + wants symlink       → /etc/systemd/system/
+#
+# The closure is the agent-lessons §8 rule that stage_ntfs3g_closure follows:
+# never mix the deployer's binary with the target's libraries: ship every
+# ldd-resolved library plus the loader, invoke through the staged loader, and
+# PROVE it by running it (ldd reports only the first missing library).
+#
+# The unit is named wootc-qemu-ga.service and gated on
+# ConditionPathExists=!/usr/bin/qemu-ga so it can never displace an agent the
+# image ships itself. That condition is evaluated in the booted real root,
+# the only place where "does this image have qemu-ga" is observable. A chroot
+# probe here cannot answer it: under composefs $DEPLOY_ROOT/usr is empty, so
+# the probe reports "absent" for every image, including ones that have it.
+stage_qemu_ga_into_target() {
+    local src pdir="var/usrlocal/lib/wootc-qga" lib ldso=""
+    src=$(command -v qemu-ga 2>/dev/null || true)
+    if [[ -z "$src" ]]; then
+        err "  [WARN] qga: the deployer initramfs carries no qemu-ga to stage"
+        return 1
+    fi
+    rm -rf "${DEPLOY_ROOT:?}/$pdir"
+    install -D -m0755 "$src" "$DEPLOY_ROOT/$pdir/qemu-ga"
+    while IFS= read -r lib; do
+        [[ -f "$lib" ]] || continue
+        install -D -m0755 "$lib" "$DEPLOY_ROOT/$pdir/${lib##*/}"
+        case "$lib" in
+            */ld-linux*|*/ld64.so*|*/ld.so*) ldso="${lib##*/}" ;;
+        esac
+    done < <(ldd "$src" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i ~ /^\//) print $i}')
+    if [[ -z "$ldso" ]]; then
+        err "  [FAIL] qga: ldd on the deployer's qemu-ga surfaced no dynamic loader; cannot build a self-contained closure"
+        rm -rf "${DEPLOY_ROOT:?}/$pdir"
+        return 1
+    fi
+    if ! "$DEPLOY_ROOT/$pdir/$ldso" --library-path "$DEPLOY_ROOT/$pdir" \
+            "$DEPLOY_ROOT/$pdir/qemu-ga" --version >/dev/null 2>&1; then
+        err "  [FAIL] qga: staged qemu-ga closure does not execute against its own libraries"
+        rm -rf "${DEPLOY_ROOT:?}/$pdir"
+        return 1
+    fi
+    install -d -m0755 "$DEPLOY_ROOT/var/usrlocal/bin"
+    cat > "$DEPLOY_ROOT/var/usrlocal/bin/qemu-ga" <<QGAWRAP
+#!/bin/sh
+exec /$pdir/$ldso --library-path /$pdir /$pdir/qemu-ga "\$@"
+QGAWRAP
+    chmod 0755 "$DEPLOY_ROOT/var/usrlocal/bin/qemu-ga"
+    install -d -m0755 "$DEPLOY_ROOT/etc/systemd/system" \
+                      "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants"
+    cat > "$DEPLOY_ROOT/etc/systemd/system/wootc-qemu-ga.service" <<'QGAUNIT'
+[Unit]
+Description=QEMU Guest Agent (staged by the wootc deployer)
+Documentation=https://github.com/tuna-os/wootc
+# Never displace an agent the image ships itself.
+ConditionPathExists=!/usr/bin/qemu-ga
+ConditionPathExists=!/usr/sbin/qemu-ga
+ConditionPathExists=/var/usrlocal/bin/qemu-ga
+After=local-fs.target
+# The virtio-serial port can appear after this unit is first tried; Restart
+# handles that, so the default 5-starts-in-10s limit must not give up on it.
+StartLimitIntervalSec=0
+
+[Service]
+# A breadcrumb on the console: the serial log is the only Phase-2 evidence the
+# harness can read when the agent is the thing that is broken, so "the unit was
+# tried" must be distinguishable from "the unit does not exist".
+ExecStartPre=/bin/sh -c 'echo "wootc: starting staged qemu-ga" > /dev/kmsg'
+ExecStart=/var/usrlocal/bin/qemu-ga --method=virtio-serial --path=/dev/virtio-ports/org.qemu.guest_agent.0
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+QGAUNIT
+    ln -sf ../wootc-qemu-ga.service \
+        "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-qemu-ga.service"
+    # Assert the runtime view, not the writes: the wants symlink must resolve
+    # to the unit, and the unit's ExecStart must exist under the deployment.
+    if [[ ! -e "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-qemu-ga.service" ]]; then
+        err "  [FAIL] qga: multi-user.target.wants/wootc-qemu-ga.service dangles; the agent would never start"
+        return 1
+    fi
+    if [[ ! -x "$DEPLOY_ROOT/var/usrlocal/bin/qemu-ga" ]]; then
+        err "  [FAIL] qga: /var/usrlocal/bin/qemu-ga is not executable in the deployment"
+        return 1
+    fi
+    log "  [PASS] fallback qemu-ga staged (loader=$ldso, exec-verified) at /var/usrlocal/bin/qemu-ga, enabled as wootc-qemu-ga.service"
+    return 0
+}
+
 # ── initramfs introspection ────────────────────────────────────────────────
 # An initramfs image is a CONCATENATION, not one archive: zero or more
 # UNCOMPRESSED early-cpio segments (CPU microcode, ACPI overrides) followed by
@@ -2030,20 +2140,10 @@ block-rpcs=
 QGAEOF
     cp "$DEPLOY_ROOT/etc/qemu/qemu-ga.conf" "$DEPLOY_ROOT/etc/qemu-ga.conf" 2>/dev/null || true
 
-    # If the target image lacks qemu-guest-agent (common in composefs images),
-    # install the deployer's own binary + service so the E2E harness can reach
-    # Phase 2.  The dnf-based injection path fails on non-RPM images.
-    if ! chroot "$DEPLOY_ROOT" command -v qemu-ga >/dev/null 2>&1 && command -v qemu-ga >/dev/null 2>&1; then
-        install -D -m0755 "$(command -v qemu-ga)" "$DEPLOY_ROOT/usr/bin/qemu-ga"
-        for _svc in qemu-guest-agent.service qemu-ga@.service; do
-            for _d in /usr/lib/systemd/system /lib/systemd/system; do
-                [[ -f "$_d/$_svc" ]] && { install -D -m0644 "$_d/$_svc" "$DEPLOY_ROOT/usr/lib/systemd/system/$_svc"; break; }
-            done
-        done
-        mkdir -p "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants"
-        ln -sf /usr/lib/systemd/system/qemu-guest-agent.service \
-            "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/qemu-guest-agent.service"
-        log "  [PASS] qemu-guest-agent installed from deployer into target"
+    # A fallback guest agent for images that ship none, staged where the
+    # runtime can actually see it. See stage_qemu_ga_into_target.
+    if ! stage_qemu_ga_into_target; then
+        err "  [WARN] no fallback qemu-ga staged; Phase 2 is reachable only if the image ships its own agent"
     fi
 
     # Set SELinux to permissive mode so Phase 3 QGA & User Data Bridge are not blocked by virt_qemu_ga_t
@@ -2289,21 +2389,13 @@ QGAEOF
                 if ! stage_ntfs3g_closure "$OVL"; then
                     log "  [WARN] no ntfs-3g stageable for the composefs Phase-2 initrd — relying on kernel ntfs3"
                 fi
-                # Composefs images (dakota) lack qemu-guest-agent which the E2E
-                # harness needs.  Copy the deployer's own qemu-ga into the cpio
-                # overlay (the deployed chroot won't have a package manager).
-                if command -v qemu-ga >/dev/null 2>&1; then
-                    install -D -m0755 "$(command -v qemu-ga)" "$OVL/usr/bin/qemu-ga"
-                    for _svc in qemu-guest-agent.service qemu-ga@.service; do
-                        for _d in /usr/lib/systemd/system /lib/systemd/system; do
-                            [[ -f "$_d/$_svc" ]] && { install -D -m0644 "$_d/$_svc" "$OVL/usr/lib/systemd/system/$_svc"; break; }
-                        done
-                    done
-                    # Enable it
-                    mkdir -p "$OVL/usr/lib/systemd/system/multi-user.target.wants"
-                    ln -sf ../qemu-guest-agent.service \
-                        "$OVL/usr/lib/systemd/system/multi-user.target.wants/qemu-guest-agent.service"
-                fi
+                # NOTHING guest-agent-related belongs in this overlay. It is a
+                # cpio unpacked into the INITRAMFS: at switch-root the whole
+                # tree is discarded, so a qemu-ga binary at $OVL/usr/bin and a
+                # multi-user.target.wants symlink (a target the initrd never
+                # reaches) cannot put an agent in the booted system: they only
+                # made the initrd bigger and the intent look satisfied. The
+                # real-root staging is stage_qemu_ga_into_target, above.
 
                 # The deployer kernel needs its OWN kernel modules — the UKI
                 # initrd has modules for the composefs kernel (vermagic

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -1182,6 +1182,75 @@ stage_wootc_overlay() {
         "$ovl/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
 }
 
+# find_ldso
+# Print the path of the dynamic loader this initramfs runs on.
+#
+# Unlike ldd, the loader is NOT optional here: every dynamically linked binary
+# in the initramfs — bash, podman, qemu-ga — is unrunnable without it, so if
+# this returns nothing the deployer is not executing at all.
+find_ldso() {
+    local c
+    for c in /usr/lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 \
+             /usr/lib64/ld-linux-aarch64.so.1 /lib64/ld-linux-aarch64.so.1 \
+             /usr/lib64/ld-linux-*.so.* /lib64/ld-linux-*.so.* \
+             /usr/lib/ld-linux*.so.* /lib/ld-linux*.so.*; do
+        if [[ -x "$c" ]]; then printf '%s\n' "$c"; return 0; fi
+    done
+    return 1
+}
+
+# dso_closure <binary>
+# Print, one absolute path per line, every shared object <binary> needs plus
+# the dynamic loader itself.
+#
+# This replaces `ldd "$bin" | awk '…print $i'`, which every closure builder
+# here used to call and which is unrunnable in the deployer initramfs: `ldd`
+# is a glibc-common SHELL SCRIPT and dracut installs only what
+# module-setup.sh names, so it was never there. Under `set -o pipefail` the
+# missing script failed the pipeline with 127 while the ERR trap named the
+# *awk* stage, and the closure came back empty — the deployer then printed
+#   [FAIL] qga: ldd on the deployer's qemu-ga surfaced no dynamic loader
+# which run-e2e.sh reads as a fatal deployer error and kills the run
+# (bluefin-dakota-win11pro, run 30707067821, 11 minutes in).
+#
+# `$ldso --list` is what ldd ultimately execs, so it yields identical output
+# without the script. Parsing is pure bash for the same reason: a closure
+# resolver must not be breakable by a missing text tool.
+#
+# Returns 1 and prints nothing when <binary> is not a dynamic executable (a
+# shell script, a static binary): the callers read "no loader in the output"
+# as "no self-contained closure is possible", and that verdict has to stay
+# true, so the loader is never emitted for a binary that does not use it.
+dso_closure() {
+    local bin="$1" ldso="" raw="" line word saw_ldso=0 found=0
+    ldso="$(find_ldso 2>/dev/null || true)"
+    if [[ -n "$ldso" ]]; then
+        raw="$("$ldso" --list "$bin" 2>/dev/null || true)"
+    fi
+    if [[ -z "$raw" ]] && command -v ldd >/dev/null 2>&1; then
+        raw="$(ldd "$bin" 2>/dev/null || true)"
+    fi
+    [[ -n "$raw" ]] || return 1
+    while IFS=$' \t' read -r -a line; do
+        (( ${#line[@]} )) || continue
+        for word in "${line[@]}"; do
+            case "$word" in
+                /*) [[ -f "$word" ]] || continue
+                    printf '%s\n' "$word"
+                    found=1
+                    case "$word" in
+                        */ld-linux*|*/ld64.so*|*/ld.so*) saw_ldso=1 ;;
+                    esac ;;
+            esac
+        done
+    done <<< "$raw"
+    (( found )) || return 1
+    # glibc's --list names the loader itself; some libcs do not. Emit it only
+    # when the binary really did resolve against one.
+    if (( ! saw_ldso )) && [[ -n "$ldso" ]]; then printf '%s\n' "$ldso"; fi
+    return 0
+}
+
 # stage_ntfs3g_closure <ovl-dir>
 # Stage a userspace NTFS driver into the overlay for kernels without ntfs3.
 # Source order matters (agent-lessons §8 — never mix libraries across images):
@@ -1230,9 +1299,12 @@ stage_ntfs3g_closure() {
             case "$lib" in
                 */ld-linux*|*/ld64.so*|*/ld.so*) ldso="${lib##*/}" ;;
             esac
-        done < <(ldd "$nbin" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i ~ /^\//) print $i}')
+        done < <(dso_closure "$nbin")
         if [[ -z "$ldso" ]]; then
-            err "  [FAIL] early-cpio: ldd on the deployer's ntfs-3g surfaced no dynamic loader — cannot build a self-contained closure"
+            # Best-effort: all three callers fall back to kernel ntfs3 with a
+            # [WARN]. Never say [FAIL] for something the deployer survives —
+            # run-e2e.sh kills the run on the first [FAIL] on the serial.
+            err "  [WARN] early-cpio: no dynamic loader resolved for the deployer's ntfs-3g — cannot build a self-contained closure"
             rm -rf "${ovl:?}/$pdir"
             return 1
         fi
@@ -1241,7 +1313,7 @@ stage_ntfs3g_closure() {
         # deployer's own binary on the deployer's own kernel, so it can run
         # here — pinned to the staged loader + staged libs only.
         if ! "$ovl/$pdir/$ldso" --library-path "$ovl/$pdir" "$ovl/$pdir/ntfs-3g" --version >/dev/null 2>&1; then
-            err "  [FAIL] early-cpio: staged ntfs-3g closure does not execute against its own libraries"
+            err "  [WARN] early-cpio: staged ntfs-3g closure does not execute against its own libraries"
             rm -rf "${ovl:?}/$pdir"
             return 1
         fi
@@ -1310,15 +1382,19 @@ stage_qemu_ga_into_target() {
         case "$lib" in
             */ld-linux*|*/ld64.so*|*/ld.so*) ldso="${lib##*/}" ;;
         esac
-    done < <(ldd "$src" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i ~ /^\//) print $i}')
+    done < <(dso_closure "$src")
     if [[ -z "$ldso" ]]; then
-        err "  [FAIL] qga: ldd on the deployer's qemu-ga surfaced no dynamic loader; cannot build a self-contained closure"
+        # [WARN], not [FAIL]: the caller continues with "no fallback qemu-ga
+        # staged", and run-e2e.sh aborts the deploy on the first [FAIL] it
+        # sees on the serial — which is how this line, on its own, ended
+        # bluefin-dakota-win11pro in run 30707067821.
+        err "  [WARN] qga: no dynamic loader resolved for the deployer's qemu-ga; cannot build a self-contained closure"
         rm -rf "${DEPLOY_ROOT:?}/$pdir"
         return 1
     fi
     if ! "$DEPLOY_ROOT/$pdir/$ldso" --library-path "$DEPLOY_ROOT/$pdir" \
             "$DEPLOY_ROOT/$pdir/qemu-ga" --version >/dev/null 2>&1; then
-        err "  [FAIL] qga: staged qemu-ga closure does not execute against its own libraries"
+        err "  [WARN] qga: staged qemu-ga closure does not execute against its own libraries"
         rm -rf "${DEPLOY_ROOT:?}/$pdir"
         return 1
     fi
@@ -1360,11 +1436,11 @@ QGAUNIT
     # Assert the runtime view, not the writes: the wants symlink must resolve
     # to the unit, and the unit's ExecStart must exist under the deployment.
     if [[ ! -e "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-qemu-ga.service" ]]; then
-        err "  [FAIL] qga: multi-user.target.wants/wootc-qemu-ga.service dangles; the agent would never start"
+        err "  [WARN] qga: multi-user.target.wants/wootc-qemu-ga.service dangles; the agent would never start"
         return 1
     fi
     if [[ ! -x "$DEPLOY_ROOT/var/usrlocal/bin/qemu-ga" ]]; then
-        err "  [FAIL] qga: /var/usrlocal/bin/qemu-ga is not executable in the deployment"
+        err "  [WARN] qga: /var/usrlocal/bin/qemu-ga is not executable in the deployment"
         return 1
     fi
     log "  [PASS] fallback qemu-ga staged (loader=$ldso, exec-verified) at /var/usrlocal/bin/qemu-ga, enabled as wootc-qemu-ga.service"
@@ -1900,7 +1976,10 @@ if [[ -n "$VERIFY_ROOT" ]]; then
                     # installed binary's deps INSIDE the chroot, so a bare copy
                     # would be installed and then fail to run for want of
                     # libntfs-3g.
-                    ldd "$_ntfs_src" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i ~ /^\//) print $i}' | \
+                    # `|| true` is load-bearing under `set -o pipefail`:
+                    # dso_closure returns 1 for a binary with no closure, and
+                    # a missing ntfs-3g closure must not abort the deploy.
+                    { dso_closure "$_ntfs_src" || true; } | \
                     while read -r _lib; do
                         [[ -e "$DEPLOY_ROOT$_lib" ]] && continue
                         mkdir -p "$DEPLOY_ROOT${_lib%/*}" 2>/dev/null || continue

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -994,24 +994,63 @@ if [[ "${ROOTFS_SEALED:-0}" == 1 || "$COMPOSEFS" == 1 ]] && \
     log "  composefs-sealed rootfs → ext4 (fs-verity, proven); btrfs blocked on #35"
 fi
 
-# A btrfs root requires the TARGET kernel to ship btrfs.ko — and EL-family
-# kernels (bluefin:lts, yellowfin) ship none at all. The deployer's Fedora
-# kernel formats btrfs happily, the deploy completes, and Phase 2 then sits at
-# SYSTEMD_READY=0 until sysroot.mount's dependency fails into an emergency
-# shell (bluefin-lts-btrfs cell, run 30700616717: systemd-modules-load FAILED
-# at t=2.9s, hook reported "module loaded=0"). That is knowable HERE, in
-# seconds, from the image the backend probe already pulled — refuse now
-# instead of shipping a deployment that provably cannot boot. #35's btrfs axis
-# is only meaningful on Fedora-kernel images.
+# ── btrfs preflight: can the TARGET kernel actually LOAD btrfs? ─────────────
+# Knowable here in seconds, otherwise it costs a full deploy plus a Phase-2
+# emergency shell to discover. bluefin-lts-win11pro-btrfs (hosted matrix run
+# 30700616717) formatted btrfs happily, deployed green, and then Phase 2 said:
+#   Loading of module with unavailable key is rejected
+#   [FAILED] Failed to start systemd-modules-load.service
+#   wootc: btrfs /dev/loop0p3: module loaded=0 ID_BTRFS_READY=0 SYSTEMD_READY=0
+# and sat in emergency until the harness gave up 25 minutes later. CentOS
+# Stream 10 has no in-tree btrfs, so bluefin:lts carries an out-of-tree kmod
+# signed with a key that kernel does not trust; under Secure Boot the kernel
+# is locked down and rejects it, the udev readiness gate never clears, and the
+# root=UUID device unit never activates (#35's shape, different cause).
+#
+# The SIGNER is the observable, not the module's presence: a kmod signed by
+# the kernel's own key loads fine, and an unsigned-module kernel has no
+# signature to reject. Compare btrfs's signer against the signer of a module
+# that ships WITH the kernel, and only refuse on a positive mismatch.
 if [[ "$FILESYSTEM" == btrfs ]]; then
-    if timeout 120 podman run --rm "$IMAGE" \
-        sh -c 'find /usr/lib/modules -name "btrfs.ko*" 2>/dev/null | grep -q .' 2>/dev/null; then
-        log "  btrfs root requested and the target kernel ships btrfs.ko — proceeding"
-    else
-        err "  [FAIL] wootc.filesystem=btrfs, but ${IMAGE}'s kernel ships NO btrfs module"
-        err "         (EL-family kernels do not build btrfs). Phase 2 could never mount this root."
-        err "         Choose ext4 (sealed-capable) or xfs, or a Fedora-kernel image for btrfs."
+    if ! timeout 120 podman image exists "$IMAGE" 2>/dev/null; then
+        log "  btrfs preflight: pulling $IMAGE (not local yet)"
+        timeout "${WOOTC_PROBE_PULL_TIMEOUT:-1800}" podman pull "$IMAGE" >/dev/null 2>&1 || true
+    fi
+    BTRFS_PROBE="$(timeout 120 podman run --rm --network=host "$IMAGE" sh -c '
+        KV=$(ls /usr/lib/modules 2>/dev/null | head -1)
+        [ -n "$KV" ] || exit 0
+        echo "KVER=$KV"
+        KO=$(modinfo -k "$KV" -n btrfs 2>/dev/null || true)
+        echo "BTRFS_KO=$KO"
+        [ -n "$KO" ] || exit 0
+        echo "BTRFS_SIGNER=$(modinfo -k "$KV" -F signer btrfs 2>/dev/null | head -1)"
+        # Any module under the kernel package'"'"'s own tree carries the key the
+        # locked-down kernel trusts; out-of-tree kmods land in extra/ or
+        # weak-updates/ and are exactly what this compares against.
+        REF=$(find "/usr/lib/modules/$KV/kernel" -name "*.ko*" -print 2>/dev/null | head -1)
+        [ -n "$REF" ] || exit 0
+        echo "REF_KO=$REF"
+        echo "REF_SIGNER=$(modinfo -F signer "$REF" 2>/dev/null | head -1)"
+    ' 2>/dev/null || true)"
+    BTRFS_KO="$(sed -n 's/^BTRFS_KO=//p' <<<"$BTRFS_PROBE")"
+    BTRFS_SIGNER="$(sed -n 's/^BTRFS_SIGNER=//p' <<<"$BTRFS_PROBE")"
+    REF_SIGNER="$(sed -n 's/^REF_SIGNER=//p' <<<"$BTRFS_PROBE")"
+    if [[ -z "$BTRFS_PROBE" ]]; then
+        err "  [WARN] btrfs preflight could not inspect $IMAGE — proceeding blind"
+    elif [[ -z "$BTRFS_KO" ]]; then
+        err "  [FAIL] wootc.filesystem=btrfs but $IMAGE ships no btrfs module for its kernel"
+        err "         Phase 2 could not mount a btrfs root; refusing to deploy one."
         exit 1
+    elif [[ -n "$BTRFS_SIGNER" && -n "$REF_SIGNER" && "$BTRFS_SIGNER" != "$REF_SIGNER" ]]; then
+        err "  [FAIL] wootc.filesystem=btrfs but $BTRFS_KO is an out-of-tree module"
+        err "         signed by '$BTRFS_SIGNER', while the kernel's own modules are"
+        err "         signed by '$REF_SIGNER'. Under Secure Boot the target kernel"
+        err "         rejects it, the btrfs udev readiness gate never clears, and"
+        err "         Phase 2 lands in an emergency shell. Refusing to deploy."
+        err "         Use an image whose kernel has btrfs in-tree, or enrol the key."
+        exit 1
+    else
+        log "  btrfs preflight: $BTRFS_KO loads under the kernel's own signing key"
     fi
 fi
 

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -1163,6 +1163,23 @@ stage_wootc_overlay() {
     mkdir -p "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants"
     ln -sf ../wootc-attach.service \
         "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
+
+    # The Phase-2 shutdown pair — the counterpart to this deployer's own
+    # "leave the NTFS volume clean before the forced reboot" teardown, which
+    # Phase 2 had no equivalent of. Without them Phase 2 reboots with the rw
+    # NTFS still mounted and the loop device still attached (systemd: "Not all
+    # file systems unmounted, 1 left"), and Windows comes back to a volume it
+    # boot-loops on and cannot repair.
+    #
+    # These are dracut HOOKS, not units, so they go under the hook dirs rather
+    # than being wired through systemd. /usr/lib, never /lib: dracut's
+    # $hookdir is /lib/dracut/hooks, which is the same path on the usr-merged
+    # images this overlay targets, and creating a real /lib directory in an
+    # early cpio would collide with the base initrd's /lib -> usr/lib symlink.
+    install -D -m0755 /usr/lib/wootc/99wootc-boot/wootc-stage-shutdown.sh \
+        "$ovl/usr/lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh"
+    install -D -m0755 /usr/lib/wootc/99wootc-boot/wootc-umount-host.sh \
+        "$ovl/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
 }
 
 # stage_ntfs3g_closure <ovl-dir>
@@ -1448,6 +1465,15 @@ build_phase2_initrd() {
        [[ ! -L "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service" ]] || \
        [[ ! -x "$ovl/usr/lib/wootc/wootc-attach-loop.sh" ]]; then
         err "  [FAIL] early-cpio overlay is incomplete (unit/wants/hook) — refusing to build a Phase-2 initrd that cannot attach root.disk"
+        return 1
+    fi
+    # The shutdown pair is checked separately, and separately fatal: an
+    # overlay missing it produces a Phase 2 that BOOTS PERFECTLY and then
+    # hands Windows back a volume it cannot repair — a failure that costs a
+    # full 60-90 minute VM run to see, and looks nothing like its cause.
+    if [[ ! -x "$ovl/usr/lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh" ]] || \
+       [[ ! -x "$ovl/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh" ]]; then
+        err "  [FAIL] early-cpio overlay carries no Phase-2 shutdown hooks — refusing to build a Phase-2 initrd that would reboot with the Windows NTFS still mounted rw"
         return 1
     fi
     if ! ( cd "$ovl" && find . | cpio -o -H newc --quiet ) > "$ovl.cpio" || \

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -994,6 +994,27 @@ if [[ "${ROOTFS_SEALED:-0}" == 1 || "$COMPOSEFS" == 1 ]] && \
     log "  composefs-sealed rootfs → ext4 (fs-verity, proven); btrfs blocked on #35"
 fi
 
+# A btrfs root requires the TARGET kernel to ship btrfs.ko — and EL-family
+# kernels (bluefin:lts, yellowfin) ship none at all. The deployer's Fedora
+# kernel formats btrfs happily, the deploy completes, and Phase 2 then sits at
+# SYSTEMD_READY=0 until sysroot.mount's dependency fails into an emergency
+# shell (bluefin-lts-btrfs cell, run 30700616717: systemd-modules-load FAILED
+# at t=2.9s, hook reported "module loaded=0"). That is knowable HERE, in
+# seconds, from the image the backend probe already pulled — refuse now
+# instead of shipping a deployment that provably cannot boot. #35's btrfs axis
+# is only meaningful on Fedora-kernel images.
+if [[ "$FILESYSTEM" == btrfs ]]; then
+    if timeout 120 podman run --rm "$IMAGE" \
+        sh -c 'find /usr/lib/modules -name "btrfs.ko*" 2>/dev/null | grep -q .' 2>/dev/null; then
+        log "  btrfs root requested and the target kernel ships btrfs.ko — proceeding"
+    else
+        err "  [FAIL] wootc.filesystem=btrfs, but ${IMAGE}'s kernel ships NO btrfs module"
+        err "         (EL-family kernels do not build btrfs). Phase 2 could never mount this root."
+        err "         Choose ext4 (sealed-capable) or xfs, or a Fedora-kernel image for btrfs."
+        exit 1
+    fi
+fi
+
 # ── Write fisherman recipe ──────────────────────────────────────────────────
 # Fisherman handles partitioning, formatting, bootc install to-filesystem,
 # Flatpaks, and kernel cmdline injection. We just point it at the loop device.

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -2162,7 +2162,11 @@ if [[ -n "$VERIFY_ROOT" ]]; then
         GUARD_LOSETUP=$(chroot "$DEPLOY_ROOT" lsinitrd "$INITRD_CHROOT_PATH" 2>/dev/null | grep -c 'losetup' || true)
         log "  guard: losetup present in initramfs=$GUARD_LOSETUP"
         if [[ "${GUARD_LOSETUP:-0}" -lt 1 ]]; then
-            err "  [FAIL] Phase-2 initramfs has no losetup — root.disk cannot be attached"
+            # [WARN] here, [FAIL] in the summary below: this is a *detail* of a
+            # verdict that is rendered once, and every [FAIL] on the serial ends
+            # the run the instant run-e2e.sh reads it — which would truncate the
+            # very list this collector exists to print in full.
+            err "  [WARN] Phase-2 initramfs has no losetup — root.disk cannot be attached"
             PHASE2_PROBLEMS+=("initramfs missing losetup")
         fi
         if [[ "${GUARD_HITS:-0}" -ge 1 ]]; then
@@ -2177,9 +2181,18 @@ if [[ -n "$VERIFY_ROOT" ]]; then
     # One summary of everything that went wrong in this stretch, so a single run
     # yields the full picture instead of only its first fault.
     if (( ${#PHASE2_PROBLEMS[@]} > 0 )); then
+        # This is the summary's OWN verdict, so it aborts here. It used to only
+        # print — "PHASE2_PROBLEMS is only summarised, never fatal" (see the
+        # dracut-regen comment above) — but printing [FAIL] already ended the
+        # run: run-e2e.sh kills the deploy on the first [FAIL] it sees on the
+        # serial. So the run died either way; the difference was that the
+        # deployer never said why, and the harness recorded a generic
+        # "Deployer error" mid-deploy instead of a named cause. Exit on our own
+        # terms, after the full list has been printed.
         err "  [FAIL] Phase-2 setup completed with ${#PHASE2_PROBLEMS[@]} problem(s):"
         for p in "${PHASE2_PROBLEMS[@]}"; do err "         - $p"; done
         err "         Phase 2 will NOT boot correctly. Fix all of the above."
+        exit 1
     else
         log "  [PASS] Phase-2 setup completed with no problems"
     fi
@@ -2195,11 +2208,16 @@ if [[ -n "$VERIFY_ROOT" ]]; then
         mountpoint -q "$DEPLOY_ROOT/$fs" 2>/dev/null && umount "$DEPLOY_ROOT/$fs" 2>/dev/null || true
     done
 
-    # Check dracut module
+    # Check dracut module. [WARN], not [FAIL]: this inspects the module SOURCE
+    # tree, an input to the regen that already ran — and the guards above
+    # assert the thing that actually matters, the wootc-attach unit being
+    # present AND wired in the built initramfs, aborting when it is not. A
+    # [FAIL] here would let a stale source tree kill a deploy whose Phase-2
+    # initramfs had already been proven correct.
     if [[ -d "$DEPLOY_ROOT/usr/lib/dracut/modules.d/99wootc-boot" ]]; then
         log "  [PASS] dracut 99wootc-boot module installed"
     else
-        err "  [FAIL] dracut 99wootc-boot module NOT found"
+        err "  [WARN] dracut 99wootc-boot module source tree not found under \$DEPLOY_ROOT (the built initramfs was verified above)"
     fi
 
     vstage "before-userbridge (writes \$DEPLOY_ROOT/usr/local + /usr/share — read-only under composefs)"
@@ -2327,7 +2345,10 @@ QGAEOF
             "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-e2e-phase3.path"
         log "  [PASS] Phase-3 systemd request bridge enabled (units + wants link in target /etc)"
     else
-        log "  [FAIL] Phase-3 request bridge units missing from initramfs — dispatch will never trigger"
+        # [WARN]: Phase 3 is opt-in (rung 3) and a Phase-1/2 deploy is fully
+        # valid without it, so this must not end a run that never asked for it.
+        # Phase 3 has its own observable — the dispatch that never fires.
+        log "  [WARN] Phase-3 request bridge units missing from initramfs — a Phase-3 run would never dispatch"
     fi
     # WSL migration (§4.6): dotfiles + Brewfile from a WSL install.
     mig_opt 755 wootc-wsl-bridge "$DEPLOY_ROOT/var/usrlocal/bin/wootc-wsl-bridge"
@@ -2385,16 +2406,22 @@ QGAEOF
     ln -sf ../wootc-passthrough.service \
         "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-passthrough.service"
 
+    # [WARN] on both: the User Data Bridge is not what makes Phase 2 boot, and
+    # its absence has a real observable one reboot later — run-e2e.sh asserts
+    # "[FAIL] User data NOT visible in Phase 2 $HOME (expected RUN_ID …)". A
+    # [FAIL] here instead kills the deploy at the point of staging, so that
+    # assertion never gets to run and the recorded cause is a generic
+    # "Deployer error".
     if [[ -f "$DEPLOY_ROOT/etc/systemd/system/wootc-host-bind.service" ]]; then
         log "  [PASS] wootc-host-bind.service installed"
     else
-        err "  [FAIL] wootc-host-bind.service install failed"
+        err "  [WARN] wootc-host-bind.service install failed — user data will not be visible in Phase 2"
     fi
 
     if [[ -f "$DEPLOY_ROOT/etc/systemd/system/wootc-passthrough.service" ]]; then
         log "  [PASS] wootc-passthrough.service installed"
     else
-        err "  [FAIL] wootc-passthrough.service install failed"
+        err "  [WARN] wootc-passthrough.service install failed — user data will not be visible in Phase 2"
     fi
 
     if grep -q 'wootc.host_uuid=.*loop=/wootc/disks/root.disk' "${BLS_DIR:-$DEPLOY_ROOT/boot/loader/entries}"/*.conf; then

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -1184,6 +1184,85 @@ NTFSWRAP
     return 1
 }
 
+# ── initramfs introspection ────────────────────────────────────────────────
+# An initramfs image is a CONCATENATION, not one archive: zero or more
+# UNCOMPRESSED early-cpio segments (CPU microcode, ACPI overrides) followed by
+# the compressed main archive. `cpio -it` stops at the first TRAILER!!!, so on
+# a Fedora/bootc image it lists the microcode segment — a handful of paths
+# under kernel/x86/microcode — and exits 0. That non-empty listing was then
+# read as proof that the initrd shipped no bash/losetup/udevadm/mount, and it
+# killed every dakota run at the Phase-2 gate (run 30700616717) on an initrd
+# that ships all four. Missing ALL FOUR is not a thing a bootable initrd does;
+# the listing was of the wrong segment. Walk the chain instead.
+
+# _initrd_segment_end <image> <offset>
+# Echo the offset just past the newc cpio archive that starts at <offset>
+# (i.e. past its TRAILER!!! member). Fails if no archive starts there.
+_initrd_segment_end() {
+    local img="$1" off="$2" hdr namesize filesize name
+    while :; do
+        hdr=$(dd if="$img" bs=1 skip="$off" count=110 status=none 2>/dev/null || true)
+        # 6-byte magic + 13 eight-digit hex fields = 110 ASCII bytes.
+        [[ "$hdr" =~ ^070701[0-9a-fA-F]{104}$ ]] || return 1
+        filesize=$((16#${hdr:54:8}))
+        namesize=$((16#${hdr:94:8}))
+        name=$(dd if="$img" bs=1 skip=$((off + 110)) count="$namesize" status=none 2>/dev/null | tr -d '\0')
+        # Header+name and then the file data are each padded to 4 bytes.
+        off=$(( (off + 110 + namesize + 3) / 4 * 4 ))
+        off=$(( (off + filesize + 3) / 4 * 4 ))
+        if [[ "$name" == "TRAILER!!!" ]]; then
+            printf '%s' "$off"
+            return 0
+        fi
+    done
+}
+
+# _initrd_skip_padding <image> <offset> <size>
+# Early-cpio segments are zero-padded (to 4 or to 512 bytes) before the next
+# segment begins. Echo the first non-padding offset, bounded so a corrupt
+# image cannot spin here.
+_initrd_skip_padding() {
+    local img="$1" off="$2" size="$3" limit nonzero
+    limit=$(( off + 4096 ))
+    (( limit > size )) && limit=$size
+    while (( off < limit )); do
+        nonzero=$(dd if="$img" bs=1 skip="$off" count=4 status=none 2>/dev/null | tr -d '\0' | wc -c)
+        if (( nonzero > 0 )); then
+            break
+        fi
+        off=$(( off + 4 ))
+    done
+    printf '%s' "$off"
+}
+
+# list_initrd_members <image>
+# Echo the member names of EVERY segment of an initramfs image. Empty output
+# means "unlistable here" (unknown compression), never "the initrd is empty".
+list_initrd_members() {
+    local img="$1" size off=0 seg dec end
+    size=$(wc -c < "$img" 2>/dev/null || echo 0)
+    while (( off < size )); do
+        if [[ $(dd if="$img" bs=1 skip="$off" count=6 status=none 2>/dev/null || true) == 070701 ]]; then
+            # An uncompressed segment: list it, then step over it.
+            seg=$(tail -c +$((off + 1)) "$img" 2>/dev/null | cpio -it --quiet 2>/dev/null || true)
+            [[ -n "$seg" ]] && printf '%s\n' "$seg"
+            end=$(_initrd_segment_end "$img" "$off") || break
+            off=$(_initrd_skip_padding "$img" "$end" "$size")
+            continue
+        fi
+        # Anything else is the compressed main archive, and it is last.
+        for dec in "zstd -qdc" "gzip -dc" "xz -dc" "lz4 -dc" "bzip2 -dc" "lzop -dc"; do
+            seg=$(tail -c +$((off + 1)) "$img" 2>/dev/null | $dec 2>/dev/null | cpio -it --quiet 2>/dev/null || true)
+            if [[ -n "$seg" ]]; then
+                printf '%s\n' "$seg"
+                break
+            fi
+        done
+        break
+    done
+    return 0
+}
+
 # build_phase2_initrd <ovl-dir> <base-initrd> <out-path>
 # Pack the overlay ahead of the base initrd and VERIFY the result by
 # inspection — "the concatenated file is non-empty" validated nothing (a
@@ -1210,17 +1289,20 @@ build_phase2_initrd() {
     rm -f "$ovl.cpio"
     # The overlay supplies unit+hook (+ possibly ntfs-3g); everything else the
     # hook needs at runtime must come from the BASE initrd: its interpreter
-    # (bash — the hook's shebang), losetup, udevadm, mount. List the base with
-    # whatever decompressor matches; each failed candidate is fine, an empty
-    # result overall just means "unverifiable here", which must WARN, not fail
-    # a deploy that may be good.
-    local listing="" dec
-    for dec in "cat" "zstd -qdc" "gzip -dc" "xz -dc" "lz4 -dc" "bzip2 -dc"; do
-        listing=$($dec < "$base" 2>/dev/null | cpio -it --quiet 2>/dev/null || true)
-        [[ -n "$listing" ]] && break
-    done
+    # (bash — the hook's shebang), losetup, udevadm, mount. Listing walks every
+    # segment of the image; an empty result just means "unverifiable here",
+    # which must WARN, not fail a deploy that may be good.
+    local listing=""
+    listing=$(list_initrd_members "$base")
     if [[ -z "$listing" ]]; then
         log "  [WARN] early-cpio: could not list the base initrd (unknown compression) — interpreter/tool presence unverified"
+        return 0
+    fi
+    # Only a listing that actually holds a root filesystem can prove a tool
+    # absent. A microcode-only early-cpio listing has no bin/ tree at all, and
+    # calling that proof is how a good initrd got declared unbootable.
+    if ! grep -qE '(^|/)(usr/)?s?bin/' <<<"$listing"; then
+        log "  [WARN] early-cpio: the base initrd listing holds no bin/ tree (early-cpio segment only?) — tool presence unverified"
         return 0
     fi
     local missing=() tool found
@@ -1234,7 +1316,7 @@ build_phase2_initrd() {
     done
     if (( ${#missing[@]} > 0 )); then
         err "  [FAIL] the target's base initrd lacks: ${missing[*]} — the wootc-attach hook cannot run in Phase 2"
-        err "         (listing succeeded, so this is proof, not a probe failure; the image's initrd must ship these or the hook must be rewritten against what it ships)"
+        err "         (every segment listed and a bin/ tree was found, so this is proof, not a probe failure; the image's initrd must ship these or the hook must be rewritten against what it ships)"
         return 1
     fi
     log "  early-cpio: base initrd verified (bash/losetup/udevadm/mount present)"

--- a/payload/deployer/module-setup.sh
+++ b/payload/deployer/module-setup.sh
@@ -38,7 +38,13 @@ install() {
         tee which basename date chown cp ln ls mkdir head wc tail
 
     # restorecon (policycoreutils) may not be installed in the build container.
-    inst_multiple -o restorecon
+    # ldd is a glibc-common shell script, not a binary pulled in by any
+    # library dependency — without naming it here the initramfs has no ldd at
+    # all, which is how the qemu-ga closure builder aborted with exit 127
+    # (bluefin-dakota-win11pro, run 30707067821). deploy.sh's dso_closure()
+    # no longer needs it (it drives the loader directly), so this is the
+    # belt-and-braces second path, hence -o.
+    inst_multiple -o restorecon ldd
     inst /usr/lib/systemd/systemd-cryptsetup
 
     # The 99wootc-boot dracut module payload, injected into the installed

--- a/payload/deployer/module-setup.sh
+++ b/payload/deployer/module-setup.sh
@@ -55,6 +55,15 @@ install() {
     # the booted ESP initramfs out of data.qcow2: the .wants symlink was present
     # but usr/lib/systemd/system/wootc-attach.service was absent.
     inst /usr/lib/wootc/99wootc-boot/wootc-attach.service
+    # The Phase-2 shutdown pair. deploy.sh stages these BY HAND into the
+    # early-cpio overlay on the branches that cannot regenerate the target's
+    # initramfs, so they have to survive into the deployer initramfs as files,
+    # exactly like wootc-attach-loop.sh and the unit above. Omitting them here
+    # is the same class of bug as the dangling-wants one described above: the
+    # overlay builder would find nothing to copy, Phase 2 would boot fine, and
+    # the breakage would only show up as a corrupt Windows on the way back.
+    inst /usr/lib/wootc/99wootc-boot/wootc-stage-shutdown.sh
+    inst /usr/lib/wootc/99wootc-boot/wootc-umount-host.sh
 
     # User Data Bridge (native passthrough) unit files, injected into the
     # installed system during verification the same way as 99wootc-boot.

--- a/platform/dracut/99wootc-boot/module-setup.sh
+++ b/platform/dracut/99wootc-boot/module-setup.sh
@@ -99,6 +99,43 @@ install() {
     # /run/wootc-loop-attached guard so the correctly-ordered service then no-op'd.
     # Attach ONCE, from wootc-attach.service, at the right ordering point.
 
+    # ── Clean hand-back of the Windows volume at Phase-2 shutdown ───────────
+    # Phase 2 runs its root off a loop device backed by a file on the rw NTFS
+    # mount, so nothing in the running system can release that volume: systemd
+    # gives up with "Not all file systems unmounted, 1 left" / "Not all loop
+    # devices detached, 1 left" and reboots into a Windows that then boot-loops
+    # into Startup Repair (run 30704513401, both fedora-gnome cells).
+    #
+    # The fix is two hooks. The pre-pivot one stages /run/initramfs so
+    # systemd-shutdown pivots back into an initramfs — which ostree/composefs
+    # otherwise never gets, because dracut-initramfs-restore needs a
+    # /boot/initramfs-$(uname -r).img that does not exist there. The shutdown
+    # one then unmounts the volume once dracut's shutdown.sh has torn down
+    # /oldroot and detached the loop. Both files carry the full rationale.
+    #
+    # Ordering: 99 in pre-pivot so the copy happens after every other hook has
+    # finished writing into the initramfs; 50 in shutdown, which is after
+    # dracut's own umount/losetup sweep either way (shutdown.sh runs the umount
+    # loop to completion before it ever sources a shutdown hook).
+    inst_hook pre-pivot 99 "$moddir/wootc-stage-shutdown.sh"
+    inst_hook shutdown 50 "$moddir/wootc-umount-host.sh"
+    # inst_hook dfatals on a missing source, but not on a hook that failed to
+    # land — and a shutdown hook that is absent from the staged tree is the
+    # difference between a clean hand-back and the corruption above, silently.
+    local h
+    for h in "/lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh" \
+             "/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"; do
+        if [[ ! -f "$initdir$h" ]]; then
+            dfatal "wootc-boot: $h did not install into the initramfs — Phase 2 could not hand a clean NTFS volume back to Windows"
+            return 1
+        fi
+    done
+    # `reboot -f -d -n` does not sync, and the staging hook copies a tree; both
+    # hooks call sync explicitly, so the binary has to be there. mknod builds
+    # the staged /dev, cp/rm/mkdir do the staging itself (all from 99base, but
+    # named here so a base change cannot quietly remove them).
+    inst_multiple sync mknod cp rm mkdir umount
+
     # losetup is all the hook needs — no staged binary, no closure. Target bootc
     # images already ship it (verified: yellowfin has /usr/sbin/losetup and no
     # qemu-nbd), which is exactly why root.disk is a raw image rather than VHDX.

--- a/platform/dracut/99wootc-boot/wootc-stage-shutdown.sh
+++ b/platform/dracut/99wootc-boot/wootc-stage-shutdown.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+# shellcheck disable=SC1091,SC2317  # dracut-lib.sh comes from the initramfs
+# /usr/lib/dracut/modules.d/99wootc-boot/wootc-stage-shutdown.sh
+#
+# dracut PRE-PIVOT hook: stage a usable initramfs into /run/initramfs so that
+# systemd-shutdown pivots back into it at reboot, which is the only place the
+# Windows host NTFS can be unmounted cleanly.
+#
+# WHY THIS EXISTS
+# ---------------
+# Phase 2 runs its root filesystem out of a loop device backed by root.disk,
+# which is a FILE ON THE WINDOWS NTFS VOLUME mounted rw at
+# /run/initramfs/wootc-host. At shutdown that stack is self-pinning:
+#
+#     /            -> /dev/loop0p3   (XFS/ext4/btrfs, cannot unmount itself)
+#     /dev/loop0   -> wootc-host/wootc/disks/root.disk
+#     wootc-host   -> /dev/sdXn      (rw ntfs3)
+#
+# systemd's own last-ditch pass therefore reports, verbatim (fedora-gnome
+# cells, run 30704513401):
+#
+#     (sd-remount)[...]: Failed to remount '/run/initramfs/wootc-host'
+#                        read-only: Device or resource busy
+#     systemd-shutdown[1]: Not all file systems unmounted, 1 left.
+#     systemd-shutdown[1]: Not all loop devices detached, 1 left.
+#     systemd-shutdown[1]: Cannot finalize remaining file systems, loop
+#                          devices, continuing.
+#     reboot: machine restart
+#
+# Windows then gets C: back with the volume never closed out. Observed
+# consequence: the desktop appears for ~26s, the box reboots itself, loops
+# through "Windows Boot Manager" three or four times, and lands in Startup
+# Repair with "your device ran into a problem and couldn't be repaired" — so
+# the harness's QGA wait for the Windows return times out after 10 minutes.
+# The deployer already enforces exactly this invariant for its own teardown
+# (deploy.sh, "a still-mounted rw NTFS would be flagged dirty"); Phase 2 had
+# no equivalent, and this hook plus wootc-umount-host.sh is that equivalent.
+#
+# The escape hatch systemd offers is switch_root_initramfs(): if
+# /run/initramfs/shutdown is executable, PID 1 pivots into /run/initramfs and
+# hands off to it, at which point / and /usr are no longer the loop device and
+# the whole stack can be torn down in order. dracut normally populates
+# /run/initramfs from /boot/initramfs-$(uname -r).img via
+# dracut-shutdown.service -> dracut-initramfs-restore. ON AN OSTREE/COMPOSEFS
+# DEPLOYMENT THAT FILE DOES NOT EXIST, dracut-initramfs-restore silently
+# no-ops, /run/initramfs/shutdown is never created, and no pivot happens —
+# which is why the trace above shows systemd giving up rather than "Returning
+# to initrd..." So we stage /run/initramfs ourselves, from the initramfs we
+# are *currently running in*, while it is still there to copy.
+#
+# FAIL-SAFE BY CONSTRUCTION
+# -------------------------
+# Every failure path ends by deleting /run/initramfs/shutdown and dropping the
+# staged tree. Without an executable /run/initramfs/shutdown systemd does not
+# pivot, which is precisely today's behaviour — so a broken or partial staging
+# can only reproduce the current bug, never invent a new failure mode.
+#
+# THIS FILE IS SOURCED, NOT EXECUTED (dracut's source_hook uses `.`), so it
+# must never call `exit` — that would take dracut-pre-pivot down with it.
+# Everything lives in a function and every exit path is a `return`.
+
+_wootc_stage_shutdown() {
+    # The four paths this hook touches, as variables with their real defaults.
+    # Nothing in the initramfs ever sets the overrides — they exist so
+    # tests/unit/phase2-clean-ntfs-umount.bats can run this function for real
+    # against a sandbox tree instead of asserting on its source text. A hook
+    # that only ever gets grepped is a hook nobody has proven works, and this
+    # one runs exactly once per Phase-2 boot with no second chance.
+    local root="${WOOTC_STAGE_ROOT:-}"
+    local dst="${WOOTC_STAGE_DST:-/run/initramfs}"
+    local procmounts="${WOOTC_STAGE_MOUNTS:-/proc/mounts}"
+    local meminfo="${WOOTC_STAGE_MEMINFO:-/proc/meminfo}"
+    local host_mnt="$dst/wootc-host"
+    local e name
+
+    _wootc_say() {
+        echo "wootc: $*" > /dev/console 2>/dev/null || true
+        echo "<27>wootc: $*" > /dev/kmsg 2>/dev/null || true
+        [ -n "$WOOTC_STAGE_DST" ] && echo "wootc: $*"
+        return 0
+    }
+
+    # Undo a partial staging. NEVER touches wootc-host: that is the live rw
+    # NTFS mount this whole exercise exists to protect, and it lives inside
+    # the directory we are cleaning. A blanket `rm -rf $dst` here would delete
+    # into the Windows volume.
+    _wootc_unstage() {
+        local victim
+        for victim in "$dst"/*; do
+            [ -e "$victim" ] || continue
+            case "${victim##*/}" in
+                wootc-host) continue ;;
+            esac
+            rm -rf "$victim" 2>/dev/null || true
+        done
+        rm -f "$dst/shutdown" 2>/dev/null || true
+    }
+
+    # Copy the children of $1 into $2, skipping the names listed in $3. Used
+    # to descend past /usr/lib/{modules,firmware} without ever copying them:
+    # a copy-then-delete would transiently double the largest thing in the
+    # initramfs in RAM, on a box that is already mid-shutdown.
+    _wootc_copy_children() {
+        local src="$1" out="$2" skip=" $3 " child base
+        mkdir -p "$out" || return 1
+        for child in "$src"/*; do
+            [ -e "$child" ] || [ -L "$child" ] || continue
+            base="${child##*/}"
+            case "$skip" in
+                *" $base "*) continue ;;
+            esac
+            cp -a "$child" "$out/" || return 1
+        done
+        return 0
+    }
+
+    # 1. Only ever act on a Phase-2 wootc boot. If the host NTFS is not
+    #    mounted there is nothing that needs a pivot, and staging one would be
+    #    pure added risk on every other boot of this image.
+    local _dev _mp _rest mounted=0
+    while read -r _dev _mp _rest; do
+        [ "$_mp" = "$host_mnt" ] && { mounted=1; break; }
+    done < "$procmounts"
+    if [ "$mounted" != 1 ]; then
+        return 0
+    fi
+
+    # 2. If dracut-shutdown.service already restored a real initramfs — a
+    #    non-ostree layout where /boot/initramfs-$(uname -r).img does exist —
+    #    leave it alone. That image was built from this same dracut module, so
+    #    it already carries the shutdown hook, and overwriting a tree systemd
+    #    is about to pivot into would be gratuitous risk.
+    if [ -x "$dst/shutdown" ]; then
+        _wootc_say "shutdown-stage: /run/initramfs already populated by dracut; leaving it"
+        return 0
+    fi
+
+    # 3. Do not push a shutting-down box into OOM. The staged tree is a tmpfs
+    #    copy of the initramfs minus modules and firmware — tens of MB — so
+    #    half a gig of headroom is a generous floor, and falling under it just
+    #    means we behave exactly as we do today.
+    local memavail="" _k _v
+    while read -r _k _v _rest; do
+        [ "$_k" = "MemAvailable:" ] && { memavail="$_v"; break; }
+    done < "$meminfo"
+    if [ -n "$memavail" ] && [ "$memavail" -lt 524288 ]; then
+        _wootc_say "shutdown-stage: only ${memavail}kB available; skipping the initramfs staging (host NTFS will not be unmounted cleanly)"
+        return 0
+    fi
+
+    # 4. Copy the live initramfs into /run/initramfs. /run is a tmpfs that
+    #    systemd carries across the pivot, so this survives; the initramfs
+    #    root itself does not (switch-root frees it).
+    #
+    #    Skips: the kernel/api filesystems, the real root, and /run itself —
+    #    copying /run would recurse into the destination and into the mounted
+    #    Windows volume.
+    local skip_top="proc sys dev run tmp mnt sysroot oldroot oldsys usr lib lib64"
+    mkdir -p "$dst" || { _wootc_say "shutdown-stage: cannot create $dst"; return 0; }
+
+    for e in "$root"/*; do
+        [ -e "$e" ] || [ -L "$e" ] || continue
+        name="${e##*/}"
+        case " $skip_top " in
+            *" $name "*) continue ;;
+        esac
+        if ! cp -a "$e" "$dst/"; then
+            _wootc_say "shutdown-stage: failed copying /$name into $dst — abandoning the staging"
+            _wootc_unstage
+            return 0
+        fi
+    done
+
+    # /usr, /lib and /lib64 are handled by descent so the module and firmware
+    # trees are never copied at all. When they are symlinks (usr-merge) cp -a
+    # reproduces the link and the descent is skipped.
+    for name in usr lib lib64; do
+        e="$root/$name"
+        [ -e "$e" ] || continue
+        if [ -L "$e" ]; then
+            cp -a "$e" "$dst/" || { _wootc_unstage; return 0; }
+            continue
+        fi
+        [ -d "$e" ] || continue
+        # "lib" is held back so /usr/lib is descended into rather than copied
+        # wholesale — that is where the module tree lives.
+        if ! _wootc_copy_children "$e" "$dst/$name" "modules firmware lib"; then
+            _wootc_say "shutdown-stage: failed copying $e into $dst — abandoning the staging"
+            _wootc_unstage
+            return 0
+        fi
+        [ -e "$e/lib" ] || continue
+        if [ -L "$e/lib" ]; then
+            cp -a "$e/lib" "$dst/$name/" || { _wootc_unstage; return 0; }
+        elif ! _wootc_copy_children "$e/lib" "$dst/$name/lib" "modules firmware"; then
+            _wootc_say "shutdown-stage: failed copying $e/lib into $dst — abandoning the staging"
+            _wootc_unstage
+            return 0
+        fi
+    done
+
+    # 4b. Mount points and a minimal /dev, because we deliberately did not copy
+    #     either. systemd's switch_root() moves /sys, /dev, /run and /proc into
+    #     the new root before pivoting and needs the directories to exist to do
+    #     it; /oldroot and /oldsys are where the old tree and dracut's
+    #     shutdown.sh put things afterwards. The static device nodes are the
+    #     same handful dracut bakes into a real initramfs image — insurance for
+    #     the log channel, since a missing /dev/console would silently turn
+    #     every diagnostic below into a regular file nobody ever reads.
+    mkdir -p "$dst/proc" "$dst/sys" "$dst/dev" "$dst/run" \
+             "$dst/oldroot" "$dst/oldsys" 2>/dev/null || true
+    [ -e "$dst/dev/console" ] || mknod -m 0600 "$dst/dev/console" c 5 1 2>/dev/null || true
+    [ -e "$dst/dev/kmsg" ]    || mknod -m 0600 "$dst/dev/kmsg"    c 1 11 2>/dev/null || true
+    [ -e "$dst/dev/null" ]    || mknod -m 0666 "$dst/dev/null"    c 1 3 2>/dev/null || true
+
+    # 5. VERIFY the staged tree can actually do the job, and unstage it if it
+    #    cannot. `-x $dst/shutdown` is the exact predicate systemd tests, so
+    #    checking anything weaker would let a useless tree take over shutdown.
+    if [ ! -x "$dst/shutdown" ]; then
+        _wootc_say "shutdown-stage: no executable $dst/shutdown after staging — reverting"
+        _wootc_unstage
+        return 0
+    fi
+    local hookdst="" cand
+    for e in "$dst/lib/dracut/hooks/shutdown" "$dst/usr/lib/dracut/hooks/shutdown"; do
+        [ -d "$e" ] || continue
+        # A hook directory with no wootc hook in it means the pivot would
+        # happen and STILL leave the NTFS mounted — worse than not pivoting.
+        for cand in "$e"/*wootc-umount-host.sh; do
+            [ -f "$cand" ] || continue
+            hookdst="$e"
+            break
+        done
+        [ -n "$hookdst" ] && break
+    done
+    if [ -z "$hookdst" ]; then
+        _wootc_say "shutdown-stage: staged initramfs carries no wootc-umount-host shutdown hook — reverting"
+        _wootc_unstage
+        return 0
+    fi
+
+    _wootc_say "shutdown-stage: staged $dst for the shutdown pivot (hook: ${hookdst#"$dst"}/*wootc-umount-host.sh)"
+    return 0
+}
+
+_wootc_stage_shutdown

--- a/platform/dracut/99wootc-boot/wootc-umount-host.sh
+++ b/platform/dracut/99wootc-boot/wootc-umount-host.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# shellcheck disable=SC2154  # $final is exported into us by dracut's shutdown.sh
+# shellcheck disable=SC3043  # `local` in #!/bin/sh: dracut's own shutdown.sh,
+#                              which sources this hook, is #!/bin/sh and uses
+#                              `local` throughout — every shell that runs it
+#                              (bash, dash, busybox ash) supports it.
+# /usr/lib/dracut/modules.d/99wootc-boot/wootc-umount-host.sh
+#
+# dracut SHUTDOWN hook: unmount the Windows host NTFS cleanly, after the
+# Phase-2 root and its loop device are gone.
+#
+# Runs inside /run/initramfs after systemd-shutdown has pivoted out of the
+# Phase-2 root (see wootc-stage-shutdown.sh, which makes that pivot possible
+# in the first place). By this point dracut's shutdown.sh has already killed
+# everything under /oldroot, unmounted it, and run `losetup -D` — so the loop
+# device backed by root.disk is detached and the NTFS volume is finally
+# unpinned. This is the last moment before `reboot -f -d -n`, and that `-n`
+# means nothing else will sync for us.
+#
+# WHERE THE MOUNT IS BY NOW
+# -------------------------
+# The volume was mounted at /run/initramfs/wootc-host. Two path rewrites
+# happen before this hook runs and neither leaves it under that name:
+#   * systemd pivots into /run/initramfs, so the mount's path is rewritten
+#     relative to the new root;
+#   * shutdown.sh then does `mount --move /oldroot/run /oldsys/run`, landing
+#     it at /oldsys/run/initramfs/wootc-host.
+# dracut's own umount_a() only considers mount points whose path contains
+# "oldroot", so /oldsys/... is invisible to it — this hook is the only thing
+# that will unmount it. Rather than hard-code one of the possible spellings,
+# match on the leaf name, which is stable under every rewrite.
+#
+# CONTRACT WITH shutdown.sh
+# -------------------------
+# The hook is sourced in a subshell and retried up to 40 times while it
+# returns non-zero, then invoked once more with final="final". Returning 1 is
+# how we wait for a still-busy volume; the retry budget is bounded by
+# shutdown.sh, so we can never hang the reboot.
+#
+# Pure shell plus umount/losetup/sync only: at this point we are running out
+# of a hand-staged tmpfs copy of the initramfs, and the initramfs a dracut
+# base module guarantees has no grep, awk, sort or cut in it.
+
+_wootc_umount_host() {
+    # Defaults to the real thing; overridden only by
+    # tests/unit/phase2-clean-ntfs-umount.bats, which runs this hook for real
+    # against a fixture mount table. Nothing in the initramfs sets it.
+    local procmounts="${WOOTC_SHUTDOWN_MOUNTS:-/proc/mounts}"
+
+    _wootc_say() {
+        echo "wootc: $*" > /dev/console 2> /dev/null || true
+        echo "<27>wootc: $*" > /dev/kmsg 2> /dev/null || true
+        [ -n "$WOOTC_SHUTDOWN_MOUNTS" ] && echo "wootc: $*"
+        return 0
+    }
+
+    # Every mount point whose leaf name is wootc-host.
+    _wootc_host_mounts() {
+        local _dev _mp _rest
+        while read -r _dev _mp _rest; do
+            case "$_mp" in
+                */wootc-host | wootc-host) printf '%s\n' "$_mp" ;;
+            esac
+        done < "$procmounts"
+    }
+
+    local mp left=0
+
+    if [ -z "$(_wootc_host_mounts)" ]; then
+        # Already gone: either a previous pass of this hook did it, or the
+        # volume was never mounted on this boot. Either way we are done, and
+        # returning 0 tells shutdown.sh to stop calling us.
+        return 0
+    fi
+
+    # Detach anything still holding a file on the volume. shutdown.sh calls
+    # this too, but only from umount_a(), which stops being called once it has
+    # nothing left to unmount under /oldroot — and that can happen before the
+    # last close on root.disk has landed.
+    losetup -D 2> /dev/null || true
+    sync 2> /dev/null || true
+
+    for mp in $(_wootc_host_mounts); do
+        if umount "$mp" 2> /dev/null; then
+            _wootc_say "shutdown: unmounted the Windows host NTFS at $mp"
+            continue
+        fi
+        if [ "$final" = "final" ]; then
+            # Out of retries. A lazy unmount after an explicit sync at least
+            # detaches the volume and flushes what we have, which is strictly
+            # better for Windows than being left mounted rw, but it is NOT a
+            # clean close — say so, because this line is the difference
+            # between "Phase 2 handed C: back properly" and "chkdsk / Startup
+            # Repair on the next Windows boot".
+            sync 2> /dev/null || true
+            umount -l "$mp" 2> /dev/null || true
+            _wootc_say "shutdown: [WARN] host NTFS at $mp was still busy after every retry; lazy-detached — Windows may see a dirty volume"
+            continue
+        fi
+        left=1
+    done
+
+    if [ "$left" = 1 ]; then
+        # Busy. Return non-zero so shutdown.sh keeps us in the rotation and
+        # calls us again after another umount/losetup sweep.
+        return 1
+    fi
+
+    sync 2> /dev/null || true
+    return 0
+}
+
+_wootc_umount_host

--- a/tests/e2e/matrix.tsv
+++ b/tests/e2e/matrix.tsv
@@ -27,11 +27,16 @@ smoke	el10-gnome-win11pro	ghcr.io/tuna-os/yellowfin:gnome	11	pro	W269N-WFGWX-YVC
 smoke	fedora-gnome-win11pro	ghcr.io/tuna-os/bonito:gnome	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 smoke	bluefin-dakota-win11pro	ghcr.io/projectbluefin/dakota:latest	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 smoke	bluefin-lts-win11pro	ghcr.io/projectbluefin/bluefin:lts	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
-# btrfs root axis (#35): MUST run on a Fedora-kernel image — EL kernels
-# (bluefin:lts, yellowfin) ship no btrfs.ko, so a btrfs root can never boot
-# there (proven: run 30700616717, systemd-modules-load FAILED, module
-# loaded=0, sysroot dependency failure). The deployer now refuses that combo
-# at deploy time; bonito (Fedora) is the image where btrfs is real.
+# btrfs sealed-root axis (#35): a composefs-sealed image forced onto btrfs.
+# NOT bluefin:lts, despite it being the proven baseline — CentOS Stream 10
+# has no in-tree btrfs, so its btrfs comes from an out-of-tree kmod signed
+# with a key the locked-down (Secure Boot) kernel does not trust. Phase 2
+# printed "Loading of module with unavailable key is rejected",
+# systemd-modules-load failed, the attach logged module loaded=0, and the
+# root device unit never became ready (matrix run 30700616717). bonito's
+# Fedora kernel loaded btrfs in that same run ("Btrfs loaded, zoned=yes,
+# fsverity=yes") and is composefs-sealed, so it is the cell that actually
+# reaches the #35 mount, rather than dying one layer earlier on a signature.
 smoke	fedora-gnome-win11pro-btrfs	ghcr.io/tuna-os/bonito:gnome	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX	filesystem=btrfs
 smoke	el10-gnome-win10pro	ghcr.io/tuna-os/yellowfin:gnome	10	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 # ── backend axis — the three deployment flavors × Windows versions ──

--- a/tests/e2e/matrix.tsv
+++ b/tests/e2e/matrix.tsv
@@ -27,6 +27,8 @@ smoke	el10-gnome-win11pro	ghcr.io/tuna-os/yellowfin:gnome	11	pro	W269N-WFGWX-YVC
 smoke	fedora-gnome-win11pro	ghcr.io/tuna-os/bonito:gnome	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 smoke	bluefin-dakota-win11pro	ghcr.io/projectbluefin/dakota:latest	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 smoke	bluefin-lts-win11pro	ghcr.io/projectbluefin/bluefin:lts	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
+# btrfs sealed-root axis (#35): the proven baseline image, forced onto btrfs.
+smoke	bluefin-lts-win11pro-btrfs	ghcr.io/projectbluefin/bluefin:lts	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX	filesystem=btrfs
 smoke	el10-gnome-win10pro	ghcr.io/tuna-os/yellowfin:gnome	10	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 # ── backend axis — the three deployment flavors × Windows versions ──
 # ostree backend (yellowfin/bonito/bluefin — bluefin has a sealed rootfs,

--- a/tests/e2e/matrix.tsv
+++ b/tests/e2e/matrix.tsv
@@ -27,8 +27,12 @@ smoke	el10-gnome-win11pro	ghcr.io/tuna-os/yellowfin:gnome	11	pro	W269N-WFGWX-YVC
 smoke	fedora-gnome-win11pro	ghcr.io/tuna-os/bonito:gnome	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 smoke	bluefin-dakota-win11pro	ghcr.io/projectbluefin/dakota:latest	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 smoke	bluefin-lts-win11pro	ghcr.io/projectbluefin/bluefin:lts	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
-# btrfs sealed-root axis (#35): the proven baseline image, forced onto btrfs.
-smoke	bluefin-lts-win11pro-btrfs	ghcr.io/projectbluefin/bluefin:lts	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX	filesystem=btrfs
+# btrfs root axis (#35): MUST run on a Fedora-kernel image — EL kernels
+# (bluefin:lts, yellowfin) ship no btrfs.ko, so a btrfs root can never boot
+# there (proven: run 30700616717, systemd-modules-load FAILED, module
+# loaded=0, sysroot dependency failure). The deployer now refuses that combo
+# at deploy time; bonito (Fedora) is the image where btrfs is real.
+smoke	fedora-gnome-win11pro-btrfs	ghcr.io/tuna-os/bonito:gnome	11	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX	filesystem=btrfs
 smoke	el10-gnome-win10pro	ghcr.io/tuna-os/yellowfin:gnome	10	pro	W269N-WFGWX-YVC9B-4J6C9-T83GX
 # ── backend axis — the three deployment flavors × Windows versions ──
 # ostree backend (yellowfin/bonito/bluefin — bluefin has a sealed rootfs,

--- a/tests/e2e/oem/run-wootc-e2e.ps1
+++ b/tests/e2e/oem/run-wootc-e2e.ps1
@@ -60,6 +60,9 @@ try {
         PayloadDir = "$oemDir\payload"
     }
     if ($cfg.ComposeFs -eq "1") { $setupArgs.ComposeFs = $true }
+    # Filesystem axis (#35): only pass an explicit value through; "auto"/absent
+    # keeps setup-wootc.ps1's default (the deployer decides).
+    if ($cfg.ContainsKey("Filesystem") -and $cfg.Filesystem -and $cfg.Filesystem -ne "auto") { $setupArgs.Filesystem = $cfg.Filesystem }
     if ($cfg.ContainsKey("RootDiskGiB") -and $cfg.RootDiskGiB) { $setupArgs.DiskSizeGB = [int]$cfg.RootDiskGiB }
     # Run setup once, teeing every stream to the log. A terminating error in
     # setup-wootc.ps1 propagates through the pipeline to the outer catch, which

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -2779,6 +2779,14 @@ BOOT_STARTED=$(date +%s)
 BOOT_DEADLINE=$(deadline_in "$TIMEOUT")
 BOOT_SUCCESS=false
 PHASE2_DIAGNOSED=false
+# Byte offset where THIS Phase-2 boot starts in the serial. The diagnosis below
+# must read the whole boot, not the 5-second delta the poll loop happens to be
+# holding: the attach line lands at t≈5s and the emergency at t≈130s, so
+# grepping NEW_OUTPUT for it reported "root.disk never attached" against a
+# serial that says "attached raw root.disk … as /dev/loop0" two minutes
+# earlier (bluefin-lts-win11pro-btrfs, hosted matrix run 30700616717) — status
+# derived from a window instead of from the boot.
+PHASE2_BYTE0=$LAST_BYTE
 
 while ! past_deadline "$BOOT_DEADLINE"; do
     snapshot_serial || true
@@ -2809,15 +2817,30 @@ while ! past_deadline "$BOOT_DEADLINE"; do
             # dropped to an emergency shell. The diagnostic killed the run
             # before it could report (el10-gnome-win11pro-phase3, 2026-07-27).
             # Absence of the attach line is the very thing being tested for.
-            ATTACHED=$(printf '%s\n' "$NEW_OUTPUT" | grep -aiE "attached raw root.disk .* as /dev/loop" | tail -1 || true)
-            if [ -n "$ATTACHED" ]; then
+            PHASE2_OUTPUT=$(tail -c "+$((PHASE2_BYTE0 + 1))" "$PTY")
+            ATTACHED=$(printf '%s\n' "$PHASE2_OUTPUT" | grep -aiE "attached raw root.disk .* as /dev/loop" | tail -1 || true)
+            # A btrfs root the kernel cannot LOAD is its own verdict. The hook
+            # prints "module loaded=0" per btrfs partition and the kernel says
+            # "Loading of module with unavailable key is rejected" when the
+            # image's btrfs is an out-of-tree kmod signed with a key Secure
+            # Boot does not trust — blaming sysroot.mount there sends the next
+            # reader after the mount step instead of after the image.
+            BTRFS_UNLOADED=$(printf '%s\n' "$PHASE2_OUTPUT" \
+                | grep -aiE "btrfs .*module loaded=0|Loading of module with unavailable key is rejected" | tail -1 || true)
+            if [ -n "$BTRFS_UNLOADED" ]; then
+                PHASE2_DIAGNOSED=true; fail "Phase 2 dropped to an emergency shell — the target kernel never loaded btrfs"
+                info "  $(printf '%s' "$BTRFS_UNLOADED" | sed 's/.*wootc:/wootc:/')"
+                info "  → btrfs.ko is absent or its signature is untrusted under Secure Boot, so the"
+                info "    udev readiness gate never clears and the root=UUID device unit never activates."
+                info "    The image cannot host a btrfs root here; the attach and the mount are not the fault."
+            elif [ -n "$ATTACHED" ]; then
                 PHASE2_DIAGNOSED=true; fail "Phase 2 dropped to an emergency shell — root.disk ATTACHED but sysroot.mount failed"
                 info "  attach succeeded: $(printf '%s' "$ATTACHED" | sed 's/.*wootc:/wootc:/')"
                 info "  → the loop-attach worked; the mount/root-UUID step is the fault (see #35 for the btrfs case)"
             else
                 PHASE2_DIAGNOSED=true; fail "Phase 2 dropped to an emergency shell — root.disk never attached"
             fi
-            echo "$NEW_OUTPUT" | grep -aiE "wootc|sysroot|does not exist|mount|root=UUID" | tail -12
+            echo "$PHASE2_OUTPUT" | grep -aiE "wootc|sysroot|does not exist|mount|root=UUID" | tail -12
             break
         fi
         if printf '%s\n' "$NEW_OUTPUT" | grep -E "No bootable device|BOOTMGR is missing|kernel panic" >/dev/null 2>&1; then

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -607,6 +607,40 @@ qga_windows_probe() {
     [[ "$os" =~ Windows_NT ]]
 }
 
+# The mirror of qga_windows_probe, and the missing half of the pair. Every
+# transition in this script is "one OS leaves, another arrives", and guest-ping
+# cannot tell those two apart: it answers for whichever agent is up. So the
+# only way to say "the guest is STILL the one I was talking to" is to ask the
+# guest what it is, positively. Run 30710282779 is what the negative form
+# costs — see p2_reboot_observe().
+qga_linux_probe() {
+    local os
+    os=$(WOOTC_QGA_CALL_TIMEOUT=5 qga_call exec /bin/sh -c 'uname -s' 2>/dev/null | tr -d '\r\n' || true)
+    [[ "$os" == *Linux* ]]
+}
+
+# Classify what the guest is doing after a Phase-2 reboot request, from
+# observables only. Echoes exactly one of:
+#
+#   down     no agent answers — Phase 2 has left and the return is underway
+#   windows  the answering agent IS Windows — the return already completed
+#   linux    a LINUX agent still answers — the reboot request did nothing
+#   unknown  an agent answers but has not identified itself as either yet
+#
+# This function never resets anything. `linux` is the ONLY one of the four that
+# a QEMU system_reset is a correct answer to; every other value means the reset
+# would land on a Windows that is booting or already back, i.e. a hard power
+# cut to the exact thing this step exists to verify.
+p2_reboot_observe() {
+    local budget="${1:-9}" poll="${WOOTC_E2E_P2_REBOOT_POLL_S:-5}" i
+    for i in $(seq 1 "$budget"); do
+        if [ "$poll" -gt 0 ]; then sleep "$poll"; fi
+        qga_probe || { echo down; return 0; }
+        if qga_windows_probe; then echo windows; return 0; fi
+    done
+    if qga_linux_probe; then echo linux; else echo unknown; fi
+}
+
 qga_wait_windows() {
     local timeout="$1" elapsed=0 idle_hits=0 cpu
     step "Waiting for QGA: Windows guest..."
@@ -3188,16 +3222,42 @@ else
     # back to a QEMU-level reset while the guest is still answering. The
     # monitor write drains the HMP banner first (record-video.sh's proven
     # pattern) rather than a blind sendall.
-    qga_call exec /bin/sh -c 'systemctl reboot || systemctl reboot -ff' 2>/dev/null || true
-    P2_REBOOT_SEEN=false
-    for _ in $(seq 1 9); do
-        sleep 5
-        if ! qga_probe; then P2_REBOOT_SEEN=true; break; fi
-    done
-    if [ "$P2_REBOOT_SEEN" != true ]; then
-        info "Phase 2 Linux still answering QGA 45s after the reboot request — forcing a QEMU system_reset"
-        $DOCKER exec "$CONTAINER_NAME" python3 -c 'import socket,time; s=socket.socket(socket.AF_UNIX); s.connect("/run/shm/monitor.sock"); time.sleep(.2); s.recv(4096); s.sendall(b"system_reset\n"); time.sleep(.4); s.recv(4096); s.close()' || true
-    fi
+    #
+    # BOUND THE REQUEST. qga_call polls guest-exec-status until the process
+    # exits, then retries the whole call three times on timeout — up to ~3
+    # minutes against a guest that is busy dying. Run 30710282779 spent 110
+    # blind seconds right here: Phase 2 took the request and was through
+    # "reboot: machine restart" two seconds later (serial, t=75.97), Windows
+    # came back, and the observation below opened its eyes on the WINDOWS
+    # agent. A timeout of 5s or less collapses qga_call's retry budget to a
+    # single try, and guest-exec spawns asynchronously, so the request lands
+    # whether or not we linger for an exit status we never read.
+    WOOTC_QGA_CALL_TIMEOUT=5 qga_call exec /bin/sh -c 'systemctl reboot || systemctl reboot -ff' 2>/dev/null || true
+    # "An agent answers" is NOT "Phase 2 is still up" — guest-ping answers for
+    # whoever is home, and after this reboot that is increasingly Windows. The
+    # old loop only looked for the ping to FAIL, so a Windows that returned
+    # promptly read as a Phase 2 that had not rebooted at all, and the fallback
+    # then fired system_reset into it. That is run 30710282779's actual
+    # failure: every Linux assertion passed, the exitrd handed C: back cleanly
+    # ("wootc: shutdown: unmounted the Windows host NTFS"), Windows booted, and
+    # the harness power-cut it mid-boot — after which the firmware looped
+    # Boot0003 and the guest sat in recovery until the 10-minute budget ran
+    # out. Reset ONLY on a positively identified Linux agent.
+    case "$(p2_reboot_observe)" in
+        down)
+            info "Phase 2 Linux stopped answering QGA — the return to Windows is underway"
+            ;;
+        windows)
+            info "Windows QGA is already answering — Phase 2 rebooted and Windows returned inside the observation window"
+            ;;
+        linux)
+            info "Phase 2 Linux is STILL answering QGA after the reboot request — forcing a QEMU system_reset"
+            $DOCKER exec "$CONTAINER_NAME" python3 -c 'import socket,time; s=socket.socket(socket.AF_UNIX); s.connect("/run/shm/monitor.sock"); time.sleep(.2); s.recv(4096); s.sendall(b"system_reset\n"); time.sleep(.4); s.recv(4096); s.close()' || true
+            ;;
+        *)
+            info "An agent answers but has identified itself as neither Linux nor Windows — NOT resetting; a reset here would power-cut a booting Windows"
+            ;;
+    esac
     # Assert WINDOWS answered, not merely "some agent": a Phase 2 that never
     # went down would satisfy a bare QGA wait instantly and fake the return.
     qga_wait_windows 600

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1156,8 +1156,18 @@ cp "$SCRIPT_DIR/wootc-files/grub/"*.cfg "$OEM_PAYLOAD/grub/"
 # the deployer about it via mirror.txt beside vault.json; the deployer probes
 # before trusting, so a dead cache degrades to normal direct pulls.
 MIRROR_ADDR=""
-for ip in $(ip -4 addr show tailscale0 2>/dev/null | awk '/inet /{sub(/\/.*/,"",$2); print $2}') \
-          $(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<NF;i++) if($i=="src") print $(i+1); exit}'); do
+# `|| true` inside each group is load-bearing under `set -Eeuo pipefail`. A
+# hosted runner has no tailscale0, so `ip -4 addr show tailscale0` exits 1, the
+# pipeline inherits it, and the ERR trap — which -E propagates into command
+# substitutions — printed
+#     [FAIL] run-e2e.sh aborted: awk '/inet /{...}' (exit 1)
+# into the console log of a run that had aborted nothing (run 30707067821).
+# The matrix reads the LAST [FAIL] as the verdict, so on any run whose real
+# failure is silent (a timeout) this line becomes the recorded reason.
+for ip in $({ ip -4 addr show tailscale0 2>/dev/null || true; } \
+                | awk '/inet /{sub(/\/.*/,"",$2); print $2}') \
+          $({ ip -4 route get 1.1.1.1 2>/dev/null || true; } \
+                | awk '{for(i=1;i<NF;i++) if($i=="src") print $(i+1); exit}'); do
     if curl -fsS -m 2 "http://${ip}:5000/v2/" >/dev/null 2>&1; then
         MIRROR_ADDR="${ip}:5000"
         break

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1186,10 +1186,15 @@ fi
 # axis with WOOTC_E2E_BOOTLOADER=grub2|systemd / WOOTC_E2E_COMPOSEFS=0|1.
 E2E_BOOTLOADER="${WOOTC_E2E_BOOTLOADER:-auto}"
 E2E_COMPOSEFS="${WOOTC_E2E_COMPOSEFS:-auto}"
+# Root filesystem axis (#35): auto = the deployer's own default (xfs unsealed /
+# ext4 sealed); WOOTC_E2E_FILESYSTEM=btrfs forces wootc.filesystem=btrfs so the
+# matrix can prove the btrfs Phase-2 path.
+E2E_FILESYSTEM="${WOOTC_E2E_FILESYSTEM:-auto}"
 {
     printf 'ImageRef=%s\n'   "$IMAGE_REF"
     printf 'Bootloader=%s\n' "$E2E_BOOTLOADER"
     printf 'ComposeFs=%s\n'  "$E2E_COMPOSEFS"
+    printf 'Filesystem=%s\n' "$E2E_FILESYSTEM"
     # RunId lets the OEM barrier prove the completion marker came from THIS run.
     # Without it the barrier passes on a stale marker left by a previous run —
     # see the comment on the barrier loop below.
@@ -1209,8 +1214,8 @@ E2E_COMPOSEFS="${WOOTC_E2E_COMPOSEFS:-auto}"
         printf 'RootDiskGiB=%s\n' "${WOOTC_E2E_ROOT_DISK_GIB:-35}"
     fi
 } > "$OEM_DIR/wootc-config.txt"
-printf '[INFO] Deployer config: image=%s bootloader=%s composefs=%s\n' \
-    "$IMAGE_REF" "$E2E_BOOTLOADER" "$E2E_COMPOSEFS" >&2
+printf '[INFO] Deployer config: image=%s bootloader=%s composefs=%s filesystem=%s\n' \
+    "$IMAGE_REF" "$E2E_BOOTLOADER" "$E2E_COMPOSEFS" "$E2E_FILESYSTEM" >&2
 
 # ── Step 1: Check prerequisites ──────────────────────────────────────────────
 step "Checking prerequisites..."

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -3167,9 +3167,30 @@ if [ "${RUN_PHASE3:-false}" = true ]; then
     fi
 else
     step "Rebooting Phase 2 Linux and verifying return to Windows..."
-    qga_call exec /bin/sh -c 'systemctl reboot' 2>/dev/null \
-        || $DOCKER exec "$CONTAINER_NAME" python3 -c 'import socket; s=socket.socket(socket.AF_UNIX); s.connect("/run/shm/monitor.sock"); s.sendall(b"system_reset\n"); s.close()'
-    qga_wait "Windows return after Phase 2 Linux" 600
+    # A guest-exec RPC accepting the request only proves a process SPAWNED —
+    # not that the guest rebooted. On bonito the request was accepted and
+    # nothing happened: Phase 2 sat at its login prompt while this step
+    # waited 10 minutes for a Windows that was never coming (runs
+    # 30700616717 / 30704513401 — the serial's last line is
+    # "wootc-test login:"). `systemctl reboot -ff` is the in-guest fallback
+    # (direct syscall, no init round-trip for a confined agent context);
+    # then REQUIRE the observable — the Linux agent going silent — and fall
+    # back to a QEMU-level reset while the guest is still answering. The
+    # monitor write drains the HMP banner first (record-video.sh's proven
+    # pattern) rather than a blind sendall.
+    qga_call exec /bin/sh -c 'systemctl reboot || systemctl reboot -ff' 2>/dev/null || true
+    P2_REBOOT_SEEN=false
+    for _ in $(seq 1 9); do
+        sleep 5
+        if ! qga_probe; then P2_REBOOT_SEEN=true; break; fi
+    done
+    if [ "$P2_REBOOT_SEEN" != true ]; then
+        info "Phase 2 Linux still answering QGA 45s after the reboot request — forcing a QEMU system_reset"
+        $DOCKER exec "$CONTAINER_NAME" python3 -c 'import socket,time; s=socket.socket(socket.AF_UNIX); s.connect("/run/shm/monitor.sock"); time.sleep(.2); s.recv(4096); s.sendall(b"system_reset\n"); time.sleep(.4); s.recv(4096); s.close()' || true
+    fi
+    # Assert WINDOWS answered, not merely "some agent": a Phase 2 that never
+    # went down would satisfy a bare QGA wait instantly and fake the return.
+    qga_wait_windows 600
     pass "One-shot Phase 2 boot consumed; Windows returned successfully"
 fi
 

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -631,8 +631,13 @@ qga_linux_probe() {
 # a QEMU system_reset is a correct answer to; every other value means the reset
 # would land on a Windows that is booting or already back, i.e. a hard power
 # cut to the exact thing this step exists to verify.
+#
+# Both knobs are env overrides rather than arguments so the only call site stays
+# argument-free: a budget passed positionally by tests but never by the script
+# is indistinguishable from a bug (SC2120), and the tests are the one caller
+# that needs to shrink it.
 p2_reboot_observe() {
-    local budget="${1:-9}" poll="${WOOTC_E2E_P2_REBOOT_POLL_S:-5}" i
+    local budget="${WOOTC_E2E_P2_REBOOT_TRIES:-9}" poll="${WOOTC_E2E_P2_REBOOT_POLL_S:-5}" i
     for i in $(seq 1 "$budget"); do
         if [ "$poll" -gt 0 ]; then sleep "$poll"; fi
         qga_probe || { echo down; return 0; }

--- a/tests/e2e/setup-wootc.ps1
+++ b/tests/e2e/setup-wootc.ps1
@@ -27,6 +27,11 @@ param(
     [string]$Bootloader = "auto",
     # composefs-backed images require systemd-boot; adds wootc.composefs=1.
     [switch]$ComposeFs,
+    # Root filesystem axis (#35): "auto" (default) lets the deployer pick
+    # (xfs unsealed / ext4 sealed); an explicit value is passed through as
+    # wootc.filesystem= so the matrix can exercise btrfs.
+    [ValidateSet("xfs", "ext4", "btrfs", "auto")]
+    [string]$Filesystem = "auto",
     # In the E2E image, Dockur copies /oem to C:\OEM. Supplying this path
     # makes setup self-contained and avoids requiring SMB/WinRM to be ready.
     [string]$PayloadDir = ""
@@ -53,6 +58,7 @@ if (-not $gotMutex) {
 # grub2 + no composefs reproduces the historical default exactly.
 $WootcKargs = "wootc.bootloader=$Bootloader"
 if ($ComposeFs) { $WootcKargs += " wootc.composefs=1" }
+if ($Filesystem -ne "auto") { $WootcKargs += " wootc.filesystem=$Filesystem" }
 # ── BitLocker / FDE (SPEC §3.5) ─────────────────────────────────────────────
 # The deployer mounts the host NTFS from Linux; on a BitLocker-protected C: it
 # would see FVE ciphertext, so root.disk cannot live there. We never force a

--- a/tests/unit/backend-detection.bats
+++ b/tests/unit/backend-detection.bats
@@ -184,7 +184,10 @@ setup() {
     grep -q "Injected the deployer's own ntfs-3g" "$DEPLOY"
     grep -q 'command -v ntfs-3g' "$DEPLOY"
     # Its shared libraries must come too, or the installed binary cannot run.
-    grep -q 'ldd "\$_ntfs_src"' "$DEPLOY"
+    # Resolved through dso_closure, never `ldd` directly: ldd is a
+    # glibc-common shell script that the deployer initramfs does not carry
+    # (run 30707067821). See tests/unit/deployer-dso-closure.bats.
+    grep -q 'dso_closure "\$_ntfs_src"' "$DEPLOY"
     # And with no driver available at all, refuse rather than ship it.
     grep -q 'no NTFS driver for Phase 2' "$DEPLOY"
     grep -q 'Refusing to finish a deployment that cannot boot' "$DEPLOY"

--- a/tests/unit/btrfs-phase2.bats
+++ b/tests/unit/btrfs-phase2.bats
@@ -70,8 +70,31 @@ setup() {
     # Workflow plumbing: the reusable job takes it, the matrix passes it.
     grep -q 'WOOTC_E2E_FILESYSTEM: \${{ inputs.filesystem }}' "$REPO_ROOT/.github/workflows/e2e-hosted.yml"
     grep -q 'filesystem: \${{ matrix.filesystem }}' "$REPO_ROOT/.github/workflows/e2e-matrix.yml"
-    # And the matrix actually exercises btrfs on the proven baseline.
-    grep -Pq 'smoke\tbluefin-lts-win11pro-btrfs\t.*filesystem=btrfs' "$REPO_ROOT/tests/e2e/matrix.tsv"
+    # And the matrix exercises btrfs on a FEDORA-kernel image. EL kernels
+    # ship no btrfs.ko, so a bluefin:lts/yellowfin btrfs cell can only ever
+    # fail (run 30700616717) — the cell must stay on bonito or another
+    # Fedora-kernel image.
+    grep -Pq 'smoke\tfedora-gnome-win11pro-btrfs\tghcr.io/tuna-os/bonito:gnome\t.*filesystem=btrfs' "$REPO_ROOT/tests/e2e/matrix.tsv"
+    run grep -P '^\S+\t\S*btrfs\S*\t\S*(bluefin:lts|yellowfin)' "$REPO_ROOT/tests/e2e/matrix.tsv"
+    [ "$status" -ne 0 ]
+}
+
+@test "a btrfs request against a kernel without btrfs.ko is refused at deploy time" {
+    # The deployer's Fedora kernel formats btrfs happily and the deploy
+    # "succeeds" — then Phase 2 emergency-shells 25 VM-minutes later because
+    # the TARGET's EL kernel has no btrfs module to mount the root with
+    # (systemd-modules-load FAILED, hook: "module loaded=0"). The capability
+    # is knowable at deploy time from the already-pulled image; the deployer
+    # must probe it and fail closed with a message naming the alternatives.
+    grep -q 'find /usr/lib/modules -name "btrfs.ko\*"' "$DEPLOY"
+    grep -q "kernel ships NO btrfs module" "$DEPLOY"
+    # Bounded probe (no unbounded podman in the deployer — house rule).
+    grep -B2 'find /usr/lib/modules -name "btrfs.ko\*"' "$DEPLOY" | grep -q 'timeout'
+    # Fail-closed: the refusal must exit, not warn-and-continue.
+    fail_line=$(grep -n 'kernel ships NO btrfs module' "$DEPLOY" | head -1 | cut -d: -f1)
+    exit_line=$(awk -v start="$fail_line" 'NR > start && /^[[:space:]]*exit 1/ { print NR; exit }' "$DEPLOY")
+    [ -n "$fail_line" ] && [ -n "$exit_line" ]
+    [ "$exit_line" -le $((fail_line + 5)) ]
 }
 
 @test "ext4 stays the sealed default until #35 is proven green" {

--- a/tests/unit/btrfs-phase2.bats
+++ b/tests/unit/btrfs-phase2.bats
@@ -23,6 +23,7 @@ setup() {
     DEPLOY="${DEPLOY:-$REPO_ROOT/payload/deployer/deploy.sh}"
     HOOK="${HOOK:-$REPO_ROOT/platform/dracut/99wootc-boot/wootc-attach-loop.sh}"
     MODSETUP="${MODSETUP:-$REPO_ROOT/platform/dracut/99wootc-boot/module-setup.sh}"
+    RUNNER="${RUNNER:-$REPO_ROOT/tests/e2e/run-e2e.sh}"
 }
 
 @test "btrfs deploys bake an early modules-load.d entry into the Phase-2 initramfs" {
@@ -70,31 +71,51 @@ setup() {
     # Workflow plumbing: the reusable job takes it, the matrix passes it.
     grep -q 'WOOTC_E2E_FILESYSTEM: \${{ inputs.filesystem }}' "$REPO_ROOT/.github/workflows/e2e-hosted.yml"
     grep -q 'filesystem: \${{ matrix.filesystem }}' "$REPO_ROOT/.github/workflows/e2e-matrix.yml"
-    # And the matrix exercises btrfs on a FEDORA-kernel image. EL kernels
-    # ship no btrfs.ko, so a bluefin:lts/yellowfin btrfs cell can only ever
-    # fail (run 30700616717) — the cell must stay on bonito or another
-    # Fedora-kernel image.
+    # And the matrix exercises btrfs on an image whose kernel can LOAD it.
+    # An EL-family cell (bluefin:lts, yellowfin) can only ever fail here —
+    # see the preflight test below and run 30700616717.
     grep -Pq 'smoke\tfedora-gnome-win11pro-btrfs\tghcr.io/tuna-os/bonito:gnome\t.*filesystem=btrfs' "$REPO_ROOT/tests/e2e/matrix.tsv"
     run grep -P '^\S+\t\S*btrfs\S*\t\S*(bluefin:lts|yellowfin)' "$REPO_ROOT/tests/e2e/matrix.tsv"
     [ "$status" -ne 0 ]
 }
 
-@test "a btrfs request against a kernel without btrfs.ko is refused at deploy time" {
-    # The deployer's Fedora kernel formats btrfs happily and the deploy
-    # "succeeds" — then Phase 2 emergency-shells 25 VM-minutes later because
-    # the TARGET's EL kernel has no btrfs module to mount the root with
-    # (systemd-modules-load FAILED, hook: "module loaded=0"). The capability
-    # is knowable at deploy time from the already-pulled image; the deployer
-    # must probe it and fail closed with a message naming the alternatives.
-    grep -q 'find /usr/lib/modules -name "btrfs.ko\*"' "$DEPLOY"
-    grep -q "kernel ships NO btrfs module" "$DEPLOY"
-    # Bounded probe (no unbounded podman in the deployer — house rule).
-    grep -B2 'find /usr/lib/modules -name "btrfs.ko\*"' "$DEPLOY" | grep -q 'timeout'
-    # Fail-closed: the refusal must exit, not warn-and-continue.
-    fail_line=$(grep -n 'kernel ships NO btrfs module' "$DEPLOY" | head -1 | cut -d: -f1)
-    exit_line=$(awk -v start="$fail_line" 'NR > start && /^[[:space:]]*exit 1/ { print NR; exit }' "$DEPLOY")
-    [ -n "$fail_line" ] && [ -n "$exit_line" ]
-    [ "$exit_line" -le $((fail_line + 5)) ]
+@test "a btrfs deploy is refused when the target kernel cannot load btrfs" {
+    # Knowable at deploy time in seconds; the alternative is a green deploy
+    # followed by a Phase-2 emergency shell 25 minutes later
+    # (bluefin-lts-win11pro-btrfs, hosted matrix run 30700616717).
+    grep -q 'btrfs preflight' "$DEPLOY"
+    # The SIGNER is the observable — presence alone says nothing about whether
+    # a locked-down kernel will accept the module.
+    grep -q 'modinfo -k "\$KV" -F signer btrfs' "$DEPLOY"
+    grep -q 'REF_SIGNER' "$DEPLOY"
+    # Fail CLOSED on a positive mismatch and on a missing module...
+    grep -q 'ships no btrfs module for its kernel' "$DEPLOY"
+    grep -q 'out-of-tree module' "$DEPLOY"
+    # ...and the refusal must exit, not warn and carry on.
+    for msg in 'ships no btrfs module for its kernel' 'out-of-tree module'; do
+        fail_line=$(grep -n "$msg" "$DEPLOY" | head -1 | cut -d: -f1)
+        exit_line=$(awk -v start="$fail_line" 'NR > start && /^[[:space:]]*exit 1/ { print NR; exit }' "$DEPLOY")
+        [ -n "$fail_line" ] && [ -n "$exit_line" ]
+        [ "$exit_line" -le $((fail_line + 8)) ]
+    done
+    # Bounded probe — no unbounded podman in the deployer (house rule).
+    grep -q 'BTRFS_PROBE="$(timeout 120 podman run' "$DEPLOY"
+    # ...but never fail on an inconclusive probe: an unsigned-module kernel
+    # reports an empty signer for both, and refusing there breaks working images.
+    grep -q 'btrfs preflight could not inspect' "$DEPLOY"
+    grep -q -- '-n "\$BTRFS_SIGNER" && -n "\$REF_SIGNER"' "$DEPLOY"
+}
+
+@test "the Phase-2 emergency verdict reads the whole boot, and names the btrfs case" {
+    # The attach line lands ~2 minutes before the emergency, so diagnosing
+    # from the poll loop's 5-second delta reported "root.disk never attached"
+    # against a serial that says it attached cleanly (run 30700616717).
+    grep -q 'PHASE2_BYTE0=\$LAST_BYTE' "$RUNNER"
+    grep -q 'PHASE2_OUTPUT=\$(tail -c "+\$((PHASE2_BYTE0 + 1))" "\$PTY")' "$RUNNER"
+    grep -q 'ATTACHED=\$(printf .\%s\\n. "\$PHASE2_OUTPUT"' "$RUNNER"
+    # An unloadable btrfs is its own verdict, not a mount failure.
+    grep -q 'module loaded=0|Loading of module with unavailable key is rejected' "$RUNNER"
+    grep -q 'the target kernel never loaded btrfs' "$RUNNER"
 }
 
 @test "ext4 stays the sealed default until #35 is proven green" {

--- a/tests/unit/btrfs-phase2.bats
+++ b/tests/unit/btrfs-phase2.bats
@@ -58,6 +58,22 @@ setup() {
     grep -q 'inst_multiple -o btrfs' "$MODSETUP"
 }
 
+@test "the filesystem axis reaches the deployer from every harness layer" {
+    # WOOTC_E2E_FILESYSTEM → wootc-config.txt → run-wootc-e2e.ps1 →
+    # setup-wootc.ps1 → wootc.filesystem= karg. A break in any hop silently
+    # runs the btrfs cell on the default filesystem and calls it green.
+    grep -q 'WOOTC_E2E_FILESYSTEM' "$REPO_ROOT/tests/e2e/run-e2e.sh"
+    grep -q "printf 'Filesystem=%s" "$REPO_ROOT/tests/e2e/run-e2e.sh"
+    grep -q '\$setupArgs.Filesystem = \$cfg.Filesystem' "$REPO_ROOT/tests/e2e/oem/run-wootc-e2e.ps1"
+    grep -q 'wootc.filesystem=\$Filesystem' "$REPO_ROOT/tests/e2e/setup-wootc.ps1"
+    grep -q '\[ValidateSet("xfs", "ext4", "btrfs", "auto")\]' "$REPO_ROOT/tests/e2e/setup-wootc.ps1"
+    # Workflow plumbing: the reusable job takes it, the matrix passes it.
+    grep -q 'WOOTC_E2E_FILESYSTEM: \${{ inputs.filesystem }}' "$REPO_ROOT/.github/workflows/e2e-hosted.yml"
+    grep -q 'filesystem: \${{ matrix.filesystem }}' "$REPO_ROOT/.github/workflows/e2e-matrix.yml"
+    # And the matrix actually exercises btrfs on the proven baseline.
+    grep -Pq 'smoke\tbluefin-lts-win11pro-btrfs\t.*filesystem=btrfs' "$REPO_ROOT/tests/e2e/matrix.tsv"
+}
+
 @test "ext4 stays the sealed default until #35 is proven green" {
     # btrfs remains reachable via wootc.filesystem=btrfs; flipping the sealed
     # default is an E2E decision (a green btrfs matrix run), not a code one.

--- a/tests/unit/btrfs-phase2.bats
+++ b/tests/unit/btrfs-phase2.bats
@@ -118,6 +118,22 @@ setup() {
     grep -q 'the target kernel never loaded btrfs' "$RUNNER"
 }
 
+@test "the Phase-2 → Windows reboot requires the guest to actually go down" {
+    # A guest-exec RPC accepting `systemctl reboot` only proves a process
+    # spawned. On bonito nothing happened: Phase 2 sat at its login prompt
+    # while the harness waited 10 minutes for Windows (runs 30700616717 /
+    # 30704513401). The harness must watch the Linux agent go silent, force
+    # a QEMU reset if it does not, and then assert WINDOWS answered — a
+    # Phase 2 that never went down satisfies a bare QGA wait instantly.
+    grep -q "systemctl reboot || systemctl reboot -ff" "$RUNNER"
+    grep -q 'still answering QGA 45s after the reboot request' "$RUNNER"
+    # The forced reset drains the HMP banner first (record-video.sh's proven
+    # pattern), never a blind sendall.
+    grep -q 's.recv(4096); s.sendall(b"system_reset' "$RUNNER"
+    reboot_line=$(grep -n 'Rebooting Phase 2 Linux' "$RUNNER" | head -1 | cut -d: -f1)
+    awk -v s="$reboot_line" 'NR>s && NR<s+40' "$RUNNER" | grep -q 'qga_wait_windows 600'
+}
+
 @test "ext4 stays the sealed default until #35 is proven green" {
     # btrfs remains reachable via wootc.filesystem=btrfs; flipping the sealed
     # default is an E2E decision (a green btrfs matrix run), not a code one.

--- a/tests/unit/btrfs-phase2.bats
+++ b/tests/unit/btrfs-phase2.bats
@@ -125,13 +125,21 @@ setup() {
     # 30704513401). The harness must watch the Linux agent go silent, force
     # a QEMU reset if it does not, and then assert WINDOWS answered — a
     # Phase 2 that never went down satisfies a bare QGA wait instantly.
+    #
+    # "Go down" must mean the LINUX agent specifically. guest-ping answers for
+    # whichever agent is up, so watching only for it to fail cannot tell a
+    # wedged Phase 2 from a Windows that already came back, and the reset then
+    # power-cuts the returning Windows (run 30710282779). The reset is now
+    # gated on a positively identified Linux agent; the discriminator itself is
+    # covered in phase2-windows-return.bats.
     grep -q "systemctl reboot || systemctl reboot -ff" "$RUNNER"
-    grep -q 'still answering QGA 45s after the reboot request' "$RUNNER"
+    grep -q 'Phase 2 Linux is STILL answering QGA after the reboot request' "$RUNNER"
+    grep -q 'qga_linux_probe' "$RUNNER"
     # The forced reset drains the HMP banner first (record-video.sh's proven
     # pattern), never a blind sendall.
     grep -q 's.recv(4096); s.sendall(b"system_reset' "$RUNNER"
     reboot_line=$(grep -n 'Rebooting Phase 2 Linux' "$RUNNER" | head -1 | cut -d: -f1)
-    awk -v s="$reboot_line" 'NR>s && NR<s+40' "$RUNNER" | grep -q 'qga_wait_windows 600'
+    awk -v s="$reboot_line" 'NR>s && NR<s+60' "$RUNNER" | grep -q 'qga_wait_windows 600'
 }
 
 @test "ext4 stays the sealed default until #35 is proven green" {

--- a/tests/unit/deployer-dso-closure.bats
+++ b/tests/unit/deployer-dso-closure.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+# The deployer's shared-object closure resolver must work in the DEPLOYER
+# INITRAMFS, not merely on a developer's full Fedora userland.
+#
+# Context (bluefin-dakota-win11pro, run 30707067821): every closure builder in
+# deploy.sh resolved libraries with
+#     ldd "$bin" | awk '{for(i=1;i<=NF;i++) if ($i ~ /^\//) print $i}'
+# and `ldd` is a glibc-common SHELL SCRIPT that dracut never installed —
+# module-setup.sh names every binary the initramfs gets, and ldd was not one
+# of them. Under `set -o pipefail` the missing script failed the pipeline with
+# 127, the ERR trap named the *awk* stage, and the loop saw nothing:
+#     [wootc] ABORT: line 1281: awk '{for(i=1;i<=NF;i++) ...}' (exit 127)
+#     [FAIL] qga: ldd on the deployer's qemu-ga surfaced no dynamic loader
+# run-e2e.sh aborts the deploy on the first [FAIL] on the serial, so the cell
+# died 11 minutes in on a line that was never fatal to the deployer itself.
+#
+# Both halves are covered here: the resolver may not depend on ldd (or on any
+# text tool), and a best-effort stager may not shout [FAIL] when its own
+# caller carries on with a [WARN].
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DEPLOY="${DEPLOY:-$REPO_ROOT/payload/deployer/deploy.sh}"
+    MODSETUP="$REPO_ROOT/payload/deployer/module-setup.sh"
+}
+
+extract_fn() {
+    awk "/^$1\(\) \{/,/^\}/" "$DEPLOY"
+}
+
+# A PATH holding ONLY what the stagers legitimately need — deliberately
+# without ldd and without awk, which is the deployer initramfs's actual
+# userland for this code path.
+minimal_path() {
+    local d="$BATS_TEST_TMPDIR/minpath" t p
+    mkdir -p "$d"
+    for t in bash sh install rm chmod ln cat; do
+        p="$(type -P "$t")" || return 1
+        ln -sf "$p" "$d/$t"
+    done
+    printf '%s\n' "$d"
+}
+
+@test "find_ldso locates the dynamic loader this deployer runs on" {
+    run bash -c "set -euo pipefail; $(extract_fn find_ldso); find_ldso"
+    [ "$status" -eq 0 ]
+    [ -x "$output" ]
+}
+
+@test "the closure resolves with neither ldd nor awk on PATH" {
+    mp="$(minimal_path)"
+    # Prove the premise: this PATH really is the initramfs's, not the host's.
+    run env -i PATH="$mp" bash -c 'command -v ldd; command -v awk'
+    [ -z "$output" ]
+
+    run env -i PATH="$mp" bash -c "
+        set -euo pipefail
+        $(extract_fn find_ldso)
+        $(extract_fn dso_closure)
+        dso_closure '$(type -P bash)'
+    "
+    [ "$status" -eq 0 ]
+    # A real closure: libc plus the loader, every entry an existing file.
+    echo "$output" | grep -q '/libc\.so'
+    echo "$output" | grep -qE '/(ld-linux|ld64\.so|ld\.so)'
+    while read -r lib; do [ -f "$lib" ]; done <<< "$output"
+}
+
+@test "the loader is preferred over ldd, so a broken ldd cannot break staging" {
+    shim="$BATS_TEST_TMPDIR/shim"
+    mkdir -p "$shim"
+    printf '#!/bin/sh\necho "ldd: command not found" >&2\nexit 127\n' > "$shim/ldd"
+    chmod +x "$shim/ldd"
+    run env PATH="$shim:$PATH" bash -c "
+        set -euo pipefail
+        $(extract_fn find_ldso)
+        $(extract_fn dso_closure)
+        dso_closure '$(type -P bash)'
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '/libc\.so'
+}
+
+@test "a binary with no closure still reports none — no phantom loader" {
+    # The callers read "no loader in the output" as "no self-contained closure
+    # is possible" and delete the half-staged tree. Emitting the loader
+    # unconditionally would make that verdict lie for a shell script.
+    scr="$BATS_TEST_TMPDIR/script.sh"
+    printf '#!/bin/sh\nexit 0\n' > "$scr"
+    chmod +x "$scr"
+    run bash -c "
+        set -uo pipefail
+        $(extract_fn find_ldso)
+        $(extract_fn dso_closure)
+        dso_closure '$scr'
+    "
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "the fallback qemu-ga stages end-to-end with no ldd in the initramfs" {
+    # The exact regression: same function, same absent ldd, must now finish.
+    mp="$(minimal_path)"
+    root="$BATS_TEST_TMPDIR/root"
+    fake="$BATS_TEST_TMPDIR/fakebin"
+    mkdir -p "$root" "$fake"
+    cp "$(type -P true)" "$fake/qemu-ga"
+    chmod 0755 "$fake/qemu-ga"
+
+    run env -i DEPLOY_ROOT="$root" PATH="$fake:$mp" bash -c "
+        set -euo pipefail
+        log() { echo \"\$*\"; }
+        err() { echo \"\$*\" >&2; }
+        $(extract_fn find_ldso)
+        $(extract_fn dso_closure)
+        $(extract_fn stage_qemu_ga_into_target)
+        stage_qemu_ga_into_target
+    "
+    [ "$status" -eq 0 ]
+    [ -x "$root/var/usrlocal/bin/qemu-ga" ]
+    [ -f "$root/etc/systemd/system/wootc-qemu-ga.service" ]
+    # The closure is real: a loader landed next to the binary.
+    run bash -c "ls '$root/var/usrlocal/lib/wootc-qga' | grep -cE '^(ld-linux|ld64\.so|ld\.so)'"
+    [ "$output" -ge 1 ]
+}
+
+@test "no call site pipes ldd into awk any more" {
+    run grep -nE '^[^#]*ldd .*\| *awk' "$DEPLOY"
+    [ "$status" -ne 0 ]
+    # And every closure builder goes through the one resolver.
+    [ "$(grep -c '^dso_closure() {' "$DEPLOY")" -eq 1 ]
+    [ "$(grep -c '^[^#]*dso_closure "' "$DEPLOY")" -ge 3 ]
+}
+
+@test "best-effort stagers warn, they do not [FAIL]" {
+    # run-e2e.sh: `grep -qE "fatal|panic|kernel panic|\[FAIL\]"` on the
+    # deployer serial ends the deploy immediately. Both of these functions
+    # have callers that continue on failure with a [WARN], so a [FAIL] inside
+    # them turns a survivable condition into a dead 90-minute cell.
+    for fn in stage_qemu_ga_into_target stage_ntfs3g_closure; do
+        # Comments may explain the rule; code may not break it.
+        run bash -c "awk \"/^${fn}\\(\\) \\{/,/^\\}/\" '$DEPLOY' \
+            | grep -vE '^[[:space:]]*#' | grep -n '\[FAIL\]'"
+        [ "$status" -ne 0 ]
+    done
+    # The callers really are the forgiving kind this asserts.
+    grep -q 'no fallback qemu-ga staged' "$DEPLOY"
+    [ "$(grep -c 'no ntfs-3g stageable' "$DEPLOY")" -ge 3 ]
+}
+
+@test "the initramfs also carries ldd, as the second path" {
+    grep -qE '^[[:space:]]*inst_multiple -o .*\bldd\b' "$MODSETUP"
+}

--- a/tests/unit/deployer-fail-marker.bats
+++ b/tests/unit/deployer-fail-marker.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+# `[FAIL]` on the deployer serial is a KILL SWITCH, not a log level.
+#
+# run-e2e.sh's deploy monitor ends the run on the first match of
+#     grep -qE "fatal|panic|kernel panic|\[FAIL\]"
+# in a serial chunk. So any [FAIL] deploy.sh prints on a path that then
+# CONTINUES is a landmine: the deployer carries on believing the condition was
+# survivable, while the harness has already killed the cell and recorded a
+# generic "Deployer error" for it.
+#
+# fedora-gnome-win11pro, run 30707068814, is that shape end to end. The
+# deployer's fallback-qemu-ga stager hit
+#     [FAIL] qga: ldd ... surfaced no dynamic loader
+# returned 1, and its caller absorbed it with
+#     [WARN] no fallback qemu-ga staged; Phase 2 is reachable only if the
+#            image ships its own agent
+# — an explicitly survivable outcome. The run died anyway, 26 minutes in, on
+# the [FAIL] one line above the [WARN] that forgave it.
+#
+# That instance was fixed by hand (deployer-dso-closure.bats). Five more
+# non-terminating [FAIL] sites were still armed in the same file. This suite
+# makes the invariant structural instead of remembered:
+#
+#     every [FAIL] deploy.sh prints must end the deploy.
+#
+# Marker choice is therefore a real decision, made once per site:
+#   * fatal        → keep [FAIL], and exit
+#   * survivable   → [WARN], and let the downstream observable be the verdict
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DEPLOY="${DEPLOY:-$REPO_ROOT/payload/deployer/deploy.sh}"
+    E2E="$REPO_ROOT/tests/e2e/run-e2e.sh"
+    SCANNER="$BATS_TEST_TMPDIR/scan.awk"
+    cat > "$SCANNER" <<'AWK'
+# Print every [FAIL] emission that does NOT terminate the branch it lives in.
+# Indentation delimits the branch: the first following line indented LESS than
+# the [FAIL] closes it (fi / else / done / esac / }). Blank and comment lines
+# are skipped — their indentation says nothing about block structure.
+function indent(s,   n) { n = match(s, /[^ \t]/); return n ? n - 1 : -1 }
+{ line[NR] = $0 }
+END {
+    for (i = 1; i <= NR; i++) {
+        l = line[i]
+        if (l !~ /\[FAIL\]/) continue
+        strip = l; sub(/^[ \t]+/, "", strip)
+        if (strip ~ /^#/) continue
+        ind = indent(l); ok = 0
+        for (j = i + 1; j <= NR; j++) {
+            n = line[j]
+            s = n; sub(/^[ \t]+/, "", s)
+            if (s == "" || s ~ /^#/) continue
+            if (indent(n) < ind) break
+            if (s ~ /^exit[ \t]+[1-9]/ || s ~ /^return[ \t]+[1-9]/) { ok = 1; break }
+        }
+        if (!ok) printf "%d: %s\n", i, strip
+    }
+}
+AWK
+}
+
+@test "deploy.sh is syntactically valid" {
+    run bash -n "$DEPLOY"
+    [ "$status" -eq 0 ]
+}
+
+@test "the premise holds: run-e2e.sh really does kill the deploy on [FAIL]" {
+    # If this ever stops being true, the rest of this suite is enforcing a
+    # constraint nothing needs — so pin it rather than assume it.
+    run grep -nE 'grep -qE "fatal\|panic\|kernel panic\|\\\[FAIL\\\]"' "$E2E"
+    [ "$status" -eq 0 ]
+    # …and that the match is what breaks the monitor loop.
+    run bash -c "grep -A4 'fatal|panic|kernel panic' '$E2E' | grep -c 'break'"
+    [ "$output" -ge 1 ]
+}
+
+@test "every [FAIL] in deploy.sh terminates the deploy" {
+    run awk -f "$SCANNER" "$DEPLOY"
+    [ "$status" -eq 0 ]
+    if [ -n "$output" ]; then
+        printf 'non-terminating [FAIL] site(s) — each one silently kills a\n' >&2
+        printf 'whole cell via run-e2e.sh while the deployer carries on:\n' >&2
+        printf '%s\n' "$output" >&2
+        printf 'Fix: exit 1 if it is fatal, or say [WARN] if it is not.\n' >&2
+        false
+    fi
+}
+
+@test "the scanner is not vacuous — a planted non-fatal [FAIL] is caught" {
+    # The dominant bug class in this repo is a check that would pass even if
+    # the thing it asserts never happened. Break the code, confirm it goes red.
+    planted="$BATS_TEST_TMPDIR/planted.sh"
+    {
+        echo 'if [[ -n "$x" ]]; then'
+        echo '    err "  [FAIL] something advisory"'
+        echo 'fi'
+    } > "$planted"
+    run awk -f "$SCANNER" "$planted"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'something advisory'
+
+    # …and that the same site with an exit is accepted, so it is not simply
+    # flagging every [FAIL] it sees.
+    {
+        echo 'if [[ -n "$x" ]]; then'
+        echo '    err "  [FAIL] something fatal"'
+        echo '    exit 1'
+        echo 'fi'
+    } > "$planted"
+    run awk -f "$SCANNER" "$planted"
+    [ -z "$output" ]
+}
+
+@test "a [FAIL] behind a return needs every call site to exit" {
+    # build_phase2_initrd is the one function that prints [FAIL] and returns
+    # rather than exiting; the scanner accepts `return 1` for exactly that
+    # shape, so the guarantee has to be completed at the call sites.
+    sites=$(grep -cE '^[^#]*[^_a-z]build_phase2_initrd "' "$DEPLOY")
+    [ "$sites" -ge 3 ]
+    # Each call site is a conditional whose failure arm exits within 8 lines
+    # (the composefs one reports through an else branch, so it needs the room).
+    run bash -c "grep -A8 -E '^[^#]*[^_a-z]build_phase2_initrd \"' '$DEPLOY' \
+        | grep -c 'exit 1'"
+    [ "$output" -ge "$sites" ]
+}
+
+@test "the six sites this suite was written for stayed downgraded" {
+    # Named pins: a future edit that reintroduces [FAIL] on any of these
+    # survivable conditions rearms the exact landmine, and the generic scan
+    # above would only say "line N" long after the reasoning was lost.
+    grep -q '\[WARN\] Phase-2 initramfs has no losetup' "$DEPLOY"
+    grep -q '\[WARN\] dracut 99wootc-boot module source tree not found' "$DEPLOY"
+    grep -q '\[WARN\] Phase-3 request bridge units missing' "$DEPLOY"
+    grep -q '\[WARN\] wootc-host-bind.service install failed' "$DEPLOY"
+    grep -q '\[WARN\] wootc-passthrough.service install failed' "$DEPLOY"
+    # The problem summary keeps [FAIL] — it IS the verdict — and now exits on
+    # its own terms instead of leaving the kill to the harness.
+    run bash -c "grep -A6 '\[FAIL\] Phase-2 setup completed with' '$DEPLOY' \
+        | grep -c '^[[:space:]]*exit 1'"
+    [ "$output" -eq 1 ]
+}

--- a/tests/unit/e2e-failure-ledger.bats
+++ b/tests/unit/e2e-failure-ledger.bats
@@ -131,6 +131,27 @@ setup() {
     [ -z "$output" ]
 }
 
+@test "a probe for something absent cannot print a [FAIL] that aborted nothing" {
+    # -E propagates the ERR trap into command substitutions, so under pipefail
+    # an optional probe whose first stage legitimately fails still prints
+    #     [FAIL] run-e2e.sh aborted: awk '/inet /{...}' (exit 1)
+    # while the run carries on. That happened on every hosted cell (no
+    # tailscale0) — run 30707067821 — and the matrix takes the LAST [FAIL] as
+    # the verdict, so on a silent failure this becomes the recorded reason.
+    run bash -c 'set -Eeuo pipefail
+        trap "printf \"[FAIL] aborted: %s\n\" \"\$BASH_COMMAND\" >&2" ERR
+        for x in $(ip -4 addr show nosuchdev0 2>/dev/null | awk "{print \$2}"); do :; done
+        echo done'
+    [[ "$output" == *"[FAIL]"* ]]   # the shape being guarded against
+
+    # The mirror probe is the instance that shipped it; both of its optional
+    # `ip` calls must be guarded, in code and not merely in a comment.
+    for probe in 'addr show tailscale0' 'route get 1\.1\.1\.1'; do
+        run grep -cE "^[^#]*ip -4 $probe.*\|\| true" "$E2E"
+        [ "$output" -ge 1 ]
+    done
+}
+
 @test "log helpers do not mangle Windows paths" {
     # `echo -e` interprets escapes in the MESSAGE, so C:\OEM\run-wootc-e2e.ps1
     # printed as C:\OEMun-wootc-e2e.ps1 (\r became a carriage return) in the one

--- a/tests/unit/phase2-clean-ntfs-umount.bats
+++ b/tests/unit/phase2-clean-ntfs-umount.bats
@@ -1,0 +1,361 @@
+#!/usr/bin/env bats
+# Phase 2 must hand the Windows volume back CLOSED, not merely stop using it.
+#
+# The bug (run 30704513401, `fedora-gnome-win11pro` and
+# `fedora-gnome-win11pro-btrfs`, identical traces — so not a flake): Phase-2
+# Linux boots, passes every passthrough and user-data check, and reboots. Its
+# root lives on a loop device backed by root.disk, a file on the rw NTFS mount
+# at /run/initramfs/wootc-host, so the stack pins itself and systemd's last
+# pass gives up verbatim:
+#
+#     Failed to remount '/run/initramfs/wootc-host' read-only: Device or
+#         resource busy
+#     Not all file systems unmounted, 1 left.
+#     Not all loop devices detached, 1 left.
+#     Cannot finalize remaining file systems, loop devices, continuing.
+#     reboot: machine restart
+#
+# Windows then shows a desktop for ~26s, reboots itself, loops the boot
+# manager three or four times and dies in Startup Repair — so the harness's
+# QGA wait for the Windows return times out at 10 minutes. Every cell that
+# mounts the host volume with kernel ntfs3 failed this way; the cells that
+# fall back to the ntfs-3g FUSE driver did not, which is why the bug looked
+# image-specific rather than structural.
+#
+# The escape hatch is systemd's switch_root_initramfs(): with an executable
+# /run/initramfs/shutdown, PID 1 pivots back into an initramfs where / is no
+# longer the loop device. dracut normally fills /run/initramfs from
+# /boot/initramfs-$(uname -r).img — a file that DOES NOT EXIST on ostree or
+# composefs, so dracut-initramfs-restore no-ops and no pivot ever happens.
+# Hence two hooks: pre-pivot stages /run/initramfs from the live initramfs,
+# and shutdown unmounts the volume once the loop is detached.
+#
+# The tests below run both hooks for real. A hook that is only grepped is a
+# hook nobody has proven works, and these two get exactly one shot per boot.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    MODDIR="$REPO_ROOT/platform/dracut/99wootc-boot"
+    STAGE="$MODDIR/wootc-stage-shutdown.sh"
+    UMOUNT_HOOK="$MODDIR/wootc-umount-host.sh"
+    MODSETUP="$MODDIR/module-setup.sh"
+    DEPLOY="$REPO_ROOT/payload/deployer/deploy.sh"
+    DEPMOD="$REPO_ROOT/payload/deployer/module-setup.sh"
+    CFILE="$REPO_ROOT/payload/deployer/Containerfile"
+}
+
+# ── Static wiring ───────────────────────────────────────────────────────────
+
+@test "both hooks are syntactically valid and safe to SOURCE" {
+    run bash -n "$STAGE";        [ "$status" -eq 0 ]
+    run bash -n "$UMOUNT_HOOK";  [ "$status" -eq 0 ]
+    run bash -n "$MODSETUP";     [ "$status" -eq 0 ]
+    run bash -n "$DEPLOY";       [ "$status" -eq 0 ]
+    # dracut sources hooks (`. "$__f"`). A top-level `exit` in the pre-pivot
+    # hook would take dracut-pre-pivot down with it and abort the boot.
+    run grep -nE '^[[:space:]]*exit( |$)' "$STAGE"
+    [ "$status" -ne 0 ]
+    run grep -nE '^[[:space:]]*exit( |$)' "$UMOUNT_HOOK"
+    [ "$status" -ne 0 ]
+}
+
+@test "the dracut module registers both hooks under the exact expected names" {
+    grep -q 'inst_hook pre-pivot 99 "\$moddir/wootc-stage-shutdown.sh"' "$MODSETUP"
+    grep -q 'inst_hook shutdown 50 "\$moddir/wootc-umount-host.sh"' "$MODSETUP"
+    # inst_hook dfatals on a missing SOURCE but says nothing about a hook that
+    # failed to land, and an absent shutdown hook is invisible until Windows
+    # will not boot. The module must verify the installed paths.
+    grep -q 'lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh' "$MODSETUP"
+    grep -q 'lib/dracut/hooks/shutdown/50-wootc-umount-host.sh' "$MODSETUP"
+    grep -q 'dfatal .*did not install into the initramfs' "$MODSETUP"
+    # `reboot -f -d -n` does not sync; the hooks call it themselves.
+    grep -qE 'inst_multiple .*\bsync\b' "$MODSETUP"
+}
+
+@test "the early-cpio overlay carries both hooks, and refuses to build without them" {
+    # The branches that cannot regenerate the target initramfs get their hooks
+    # from stage_wootc_overlay, not from dracut — so assert against that
+    # function's body, not against the file. The same two path strings also
+    # appear in build_phase2_initrd's gate, and a file-wide grep would happily
+    # pass on an overlay builder that stages nothing.
+    local overlay_fn
+    overlay_fn=$(awk '/^stage_wootc_overlay\(\) \{/,/^\}/' "$DEPLOY")
+    echo "$overlay_fn" | grep -q 'usr/lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh'
+    echo "$overlay_fn" | grep -q 'usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh'
+    echo "$overlay_fn" | grep -q 'wootc/99wootc-boot/wootc-stage-shutdown.sh'
+    echo "$overlay_fn" | grep -q 'wootc/99wootc-boot/wootc-umount-host.sh'
+    grep -q 'carries no Phase-2 shutdown hooks' "$DEPLOY"
+    # /usr/lib, never a real /lib: an early cpio creating /lib as a directory
+    # collides with the base initrd's /lib -> usr/lib symlink.
+    run grep -nE '\$ovl/lib/dracut/hooks' "$DEPLOY"
+    [ "$status" -ne 0 ]
+    # And the files have to reach the deployer initramfs to be stageable.
+    grep -q 'inst /usr/lib/wootc/99wootc-boot/wootc-stage-shutdown.sh' "$DEPMOD"
+    grep -q 'inst /usr/lib/wootc/99wootc-boot/wootc-umount-host.sh' "$DEPMOD"
+    grep -q 'wootc-stage-shutdown.sh' "$CFILE"
+    grep -q 'wootc-umount-host.sh' "$CFILE"
+}
+
+@test "the overlay completeness gate actually rejects a hookless overlay" {
+    # Behavioural, against the real build_phase2_initrd: a mutation that drops
+    # the shutdown hooks must be fatal BEFORE anything is packed.
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    ovl="$BATS_TEST_TMPDIR/ovl"
+    mkdir -p "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants" \
+             "$ovl/usr/lib/wootc" \
+             "$ovl/usr/lib/dracut/hooks/pre-pivot" \
+             "$ovl/usr/lib/dracut/hooks/shutdown"
+    echo unit > "$ovl/usr/lib/systemd/system/wootc-attach.service"
+    ln -sf ../wootc-attach.service \
+        "$ovl/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
+    printf '#!/bin/bash\n' > "$ovl/usr/lib/wootc/wootc-attach-loop.sh"
+    install -m0755 "$STAGE" "$ovl/usr/lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh"
+    install -m0755 "$UMOUNT_HOOK" "$ovl/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
+    chmod +x "$ovl/usr/lib/wootc/wootc-attach-loop.sh"
+    ( cd "$BATS_TEST_TMPDIR" && echo x > tool && find . | cpio -o -H newc --quiet ) \
+        > "$BATS_TEST_TMPDIR/base.img" 2>/dev/null
+
+    build() {
+        bash -c "
+            log() { echo \"LOG: \$*\"; }
+            err() { echo \"ERR: \$*\" >&2; }
+            $(awk '/^build_phase2_initrd\(\) \{/,/^\}/' "$DEPLOY")
+            build_phase2_initrd '$ovl' '$BATS_TEST_TMPDIR/base.img' '$1'
+        "
+    }
+
+    run build "$BATS_TEST_TMPDIR/ok.img"
+    [ "$status" -eq 0 ]
+
+    rm "$ovl/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
+    run build "$BATS_TEST_TMPDIR/bad.img"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q 'no Phase-2 shutdown hooks'
+    [ ! -e "$BATS_TEST_TMPDIR/bad.img" ]
+}
+
+# ── Behavioural: the pre-pivot staging hook ─────────────────────────────────
+
+# A miniature initramfs: /shutdown, a couple of tool dirs, the shutdown hook
+# where dracut puts it, and a module tree that must NOT be copied.
+make_fake_initramfs() { # <root>
+    local r="$1"
+    mkdir -p "$r/usr/bin" "$r/usr/sbin" "$r/etc" \
+             "$r/usr/lib/dracut/hooks/shutdown" \
+             "$r/usr/lib/dracut/hooks/pre-pivot" \
+             "$r/usr/lib/modules/6.1.0/kernel" \
+             "$r/usr/lib/firmware"
+    printf '#!/bin/sh\n' > "$r/shutdown"
+    chmod +x "$r/shutdown"
+    printf '#!/bin/sh\n' > "$r/usr/bin/bash"; chmod +x "$r/usr/bin/bash"
+    echo x > "$r/etc/fstab"
+    ln -sf usr/lib "$r/lib"
+    install -m0755 "$UMOUNT_HOOK" "$r/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
+    head -c 200000 /dev/zero > "$r/usr/lib/modules/6.1.0/kernel/big.ko"
+    head -c 200000 /dev/zero > "$r/usr/lib/firmware/blob.bin"
+}
+
+make_fixtures() { # <dst> <host-mounted:yes|no> <memavail-kB>
+    FIX="$BATS_TEST_TMPDIR/fix"
+    mkdir -p "$FIX"
+    MOUNTS="$FIX/mounts"
+    MEMINFO="$FIX/meminfo"
+    {
+        echo "proc /proc proc rw 0 0"
+        [ "$2" = yes ] && echo "/dev/sda3 $1/wootc-host ntfs3 rw 0 0"
+    } > "$MOUNTS"
+    printf 'MemTotal:       4000000 kB\nMemAvailable:   %s kB\n' "$3" > "$MEMINFO"
+}
+
+run_stage() { # <root> <dst>
+    env WOOTC_STAGE_ROOT="$1" WOOTC_STAGE_DST="$2" \
+        WOOTC_STAGE_MOUNTS="$MOUNTS" WOOTC_STAGE_MEMINFO="$MEMINFO" \
+        bash -c ". '$STAGE'"
+}
+
+@test "behavioral: nothing is staged when the host NTFS is not mounted" {
+    root="$BATS_TEST_TMPDIR/r1"; dst="$BATS_TEST_TMPDIR/d1"
+    make_fake_initramfs "$root"; mkdir -p "$dst"
+    make_fixtures "$dst" no 2000000
+    run run_stage "$root" "$dst"
+    [ "$status" -eq 0 ]
+    # Not a wootc boot: the pivot must not be armed on somebody else's system.
+    [ ! -e "$dst/shutdown" ]
+    [ -z "$(ls -A "$dst")" ]
+}
+
+@test "behavioral: a Phase-2 boot stages an initramfs that systemd will pivot into" {
+    root="$BATS_TEST_TMPDIR/r2"; dst="$BATS_TEST_TMPDIR/d2"
+    make_fake_initramfs "$root"
+    # The live rw NTFS mount lives INSIDE the directory being staged.
+    mkdir -p "$dst/wootc-host/wootc/disks"
+    echo rootdisk > "$dst/wootc-host/wootc/disks/root.disk"
+    make_fixtures "$dst" yes 2000000
+
+    run run_stage "$root" "$dst"
+    [ "$status" -eq 0 ]
+    # systemd's exact predicate for switch_root_initramfs().
+    [ -x "$dst/shutdown" ]
+    # ...and something in there that unmounts the volume once we are pivoted.
+    [ -f "$dst/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh" ]
+    [ -x "$dst/usr/bin/bash" ]
+    [ -L "$dst/lib" ]
+    # Mount points systemd needs to move /proc, /sys, /dev, /run across.
+    [ -d "$dst/proc" ] && [ -d "$dst/sys" ] && [ -d "$dst/dev" ] && [ -d "$dst/run" ]
+    # The volume we are protecting is untouched.
+    [ -f "$dst/wootc-host/wootc/disks/root.disk" ]
+    # Modules and firmware are never copied — not copied-then-deleted, which
+    # would transiently double the biggest thing in RAM mid-shutdown.
+    [ ! -e "$dst/usr/lib/modules" ]
+    [ ! -e "$dst/usr/lib/firmware" ]
+    [ -d "$dst/usr/lib/dracut" ]
+}
+
+@test "behavioral: an initramfs with no /shutdown arms nothing (fail-safe)" {
+    root="$BATS_TEST_TMPDIR/r3"; dst="$BATS_TEST_TMPDIR/d3"
+    make_fake_initramfs "$root"
+    rm "$root/shutdown"
+    mkdir -p "$dst/wootc-host"; echo keep > "$dst/wootc-host/sentinel"
+    make_fixtures "$dst" yes 2000000
+
+    run run_stage "$root" "$dst"
+    [ "$status" -eq 0 ]
+    # Without an executable /run/initramfs/shutdown systemd simply does not
+    # pivot, which is exactly today's behaviour — a half-staged tree must
+    # never be left behind pretending otherwise.
+    [ ! -e "$dst/shutdown" ]
+    [ ! -e "$dst/usr" ]
+    # And the cleanup must never delete into the Windows volume.
+    [ -f "$dst/wootc-host/sentinel" ]
+}
+
+@test "behavioral: a staged tree carrying no umount hook is reverted" {
+    root="$BATS_TEST_TMPDIR/r4"; dst="$BATS_TEST_TMPDIR/d4"
+    make_fake_initramfs "$root"
+    rm "$root/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
+    mkdir -p "$dst/wootc-host"; echo keep > "$dst/wootc-host/sentinel"
+    make_fixtures "$dst" yes 2000000
+
+    run run_stage "$root" "$dst"
+    [ "$status" -eq 0 ]
+    # Pivoting into an initramfs that does NOT unmount the volume is worse
+    # than not pivoting: same dirty NTFS, plus a whole extra shutdown path.
+    [ ! -e "$dst/shutdown" ]
+    [ -f "$dst/wootc-host/sentinel" ]
+    echo "$output" | grep -q 'reverting'
+}
+
+@test "behavioral: staging is skipped rather than risking OOM on a low-memory box" {
+    root="$BATS_TEST_TMPDIR/r5"; dst="$BATS_TEST_TMPDIR/d5"
+    make_fake_initramfs "$root"; mkdir -p "$dst/wootc-host"
+    make_fixtures "$dst" yes 100000
+
+    run run_stage "$root" "$dst"
+    [ "$status" -eq 0 ]
+    [ ! -e "$dst/shutdown" ]
+    echo "$output" | grep -q 'skipping the initramfs staging'
+}
+
+@test "behavioral: an already-populated /run/initramfs is left alone" {
+    root="$BATS_TEST_TMPDIR/r6"; dst="$BATS_TEST_TMPDIR/d6"
+    make_fake_initramfs "$root"
+    mkdir -p "$dst/wootc-host"
+    printf '#!/bin/sh\n' > "$dst/shutdown"; chmod +x "$dst/shutdown"
+    echo original > "$dst/marker"
+    make_fixtures "$dst" yes 2000000
+
+    run run_stage "$root" "$dst"
+    [ "$status" -eq 0 ]
+    [ -f "$dst/marker" ]
+    [ ! -e "$dst/usr" ]
+}
+
+# ── Behavioural: the shutdown hook ──────────────────────────────────────────
+
+make_stubs() { # <umount-exit-code>
+    STUBS="$BATS_TEST_TMPDIR/stubs.$1.$RANDOM"
+    STUBLOG="$STUBS/log"
+    mkdir -p "$STUBS"
+    : > "$STUBLOG"
+    cat > "$STUBS/umount" <<EOF
+#!/bin/sh
+echo "umount \$*" >> "$STUBLOG"
+[ "\$1" = "-l" ] && exit 0
+exit $1
+EOF
+    cat > "$STUBS/losetup" <<EOF
+#!/bin/sh
+echo "losetup \$*" >> "$STUBLOG"
+EOF
+    cat > "$STUBS/sync" <<EOF
+#!/bin/sh
+echo "sync" >> "$STUBLOG"
+EOF
+    chmod +x "$STUBS"/umount "$STUBS"/losetup "$STUBS"/sync
+}
+
+run_umount_hook() { # <mounts-file> <final|"">
+    env PATH="$STUBS:$PATH" WOOTC_SHUTDOWN_MOUNTS="$1" final="$2" \
+        bash -c ". '$UMOUNT_HOOK'"
+}
+
+@test "behavioral: the volume is found at the path dracut's shutdown.sh leaves it" {
+    # shutdown.sh does `mount --move /oldroot/run /oldsys/run`, and its own
+    # umount_a() only considers mount points containing "oldroot" — so
+    # /oldsys/... is invisible to dracut and this hook is the only thing that
+    # will ever unmount it.
+    make_stubs 0
+    m="$BATS_TEST_TMPDIR/m-oldsys"
+    printf '/dev/sda3 /oldsys/run/initramfs/wootc-host ntfs3 rw 0 0\n' > "$m"
+    run run_umount_hook "$m" ""
+    [ "$status" -eq 0 ]
+    grep -q 'umount /oldsys/run/initramfs/wootc-host' "$STUBLOG"
+    grep -q '^sync' "$STUBLOG"
+    echo "$output" | grep -q 'unmounted the Windows host NTFS'
+}
+
+@test "behavioral: the other post-pivot spellings are found too" {
+    for path in /oldroot/run/initramfs/wootc-host /run/initramfs/wootc-host /wootc-host; do
+        make_stubs 0
+        m="$BATS_TEST_TMPDIR/m-any"
+        printf '/dev/sda3 %s ntfs3 rw 0 0\n' "$path" > "$m"
+        run run_umount_hook "$m" ""
+        [ "$status" -eq 0 ]
+        grep -q "umount $path" "$STUBLOG"
+    done
+}
+
+@test "behavioral: a busy volume asks to be retried instead of being abandoned" {
+    # shutdown.sh re-runs a non-zero hook up to 40 times, sweeping umounts and
+    # `losetup -D` in between — which is exactly how the loop backing root.disk
+    # eventually goes away. Returning 0 here would throw that budget away.
+    make_stubs 32
+    m="$BATS_TEST_TMPDIR/m-busy"
+    printf '/dev/sda3 /oldsys/run/initramfs/wootc-host ntfs3 rw 0 0\n' > "$m"
+    run run_umount_hook "$m" ""
+    [ "$status" -eq 1 ]
+    ! echo "$output" | grep -q 'lazy-detached'
+}
+
+@test "behavioral: the final pass syncs and lazy-detaches rather than leaving it mounted" {
+    make_stubs 32
+    m="$BATS_TEST_TMPDIR/m-final"
+    printf '/dev/sda3 /oldsys/run/initramfs/wootc-host ntfs3 rw 0 0\n' > "$m"
+    run run_umount_hook "$m" "final"
+    [ "$status" -eq 0 ]
+    grep -q 'umount -l /oldsys/run/initramfs/wootc-host' "$STUBLOG"
+    grep -q '^sync' "$STUBLOG"
+    # A lazy detach is NOT a clean close; the serial log must say so, or the
+    # next Windows boot's chkdsk looks like a fresh mystery.
+    echo "$output" | grep -q 'WARN'
+    echo "$output" | grep -q 'dirty volume'
+}
+
+@test "behavioral: a boot with no host NTFS mounted is a no-op, not an unmount" {
+    make_stubs 0
+    m="$BATS_TEST_TMPDIR/m-none"
+    printf 'proc /proc proc rw 0 0\n/dev/sda2 /oldroot xfs rw 0 0\n' > "$m"
+    run run_umount_hook "$m" ""
+    [ "$status" -eq 0 ]
+    [ ! -s "$STUBLOG" ]
+}

--- a/tests/unit/phase2-early-cpio.bats
+++ b/tests/unit/phase2-early-cpio.bats
@@ -118,12 +118,21 @@ run_helpers() { # <bash-snippet> — with the extracted helpers + stubs loaded
 
 make_overlay() { # <dir> — a complete wootc overlay tree
     mkdir -p "$1/usr/lib/systemd/system/initrd-root-device.target.wants" \
-             "$1/usr/lib/wootc"
+             "$1/usr/lib/wootc" \
+             "$1/usr/lib/dracut/hooks/pre-pivot" \
+             "$1/usr/lib/dracut/hooks/shutdown"
     echo unit > "$1/usr/lib/systemd/system/wootc-attach.service"
     ln -sf ../wootc-attach.service \
         "$1/usr/lib/systemd/system/initrd-root-device.target.wants/wootc-attach.service"
     printf '#!/bin/bash\n' > "$1/usr/lib/wootc/wootc-attach-loop.sh"
     chmod +x "$1/usr/lib/wootc/wootc-attach-loop.sh"
+    # The Phase-2 shutdown pair, without which build_phase2_initrd refuses to
+    # pack — a Phase 2 that boots but hands Windows back a mounted rw NTFS.
+    # See tests/unit/phase2-clean-ntfs-umount.bats.
+    printf '#!/bin/bash\n' > "$1/usr/lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh"
+    printf '#!/bin/sh\n' > "$1/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
+    chmod +x "$1/usr/lib/dracut/hooks/pre-pivot/99-wootc-stage-shutdown.sh" \
+             "$1/usr/lib/dracut/hooks/shutdown/50-wootc-umount-host.sh"
 }
 
 make_base_initrd() { # <out> [tools...] — a gzip cpio shipping the named tools

--- a/tests/unit/phase2-early-cpio.bats
+++ b/tests/unit/phase2-early-cpio.bats
@@ -92,6 +92,9 @@ run_helpers() { # <bash-snippet> — with the extracted helpers + stubs loaded
         log() { echo \"LOG: \$*\"; }
         err() { echo \"ERR: \$*\" >&2; }
         $(extract_fn stage_ntfs3g_closure)
+        $(extract_fn _initrd_segment_end)
+        $(extract_fn _initrd_skip_padding)
+        $(extract_fn list_initrd_members)
         $(extract_fn build_phase2_initrd)
         $1
     "
@@ -159,6 +162,69 @@ make_base_initrd() { # <out> [tools...] — a gzip cpio shipping the named tools
     run run_helpers "build_phase2_initrd '$ovl' '$BATS_TEST_TMPDIR/base3.img' '$BATS_TEST_TMPDIR/out3.img'"
     [ "$status" -ne 0 ]
     [ ! -e "$BATS_TEST_TMPDIR/out3.img" ]
+}
+
+prepend_microcode() { # <initrd> — make it a real-world image: uncompressed
+    # early-cpio (microcode) + 512-byte pad + the compressed main archive,
+    # which is what every Fedora/bootc initramfs actually is.
+    local img="$1"
+    local tree="$BATS_TEST_TMPDIR/early-tree"
+    rm -rf "$tree"; mkdir -p "$tree/kernel/x86/microcode"
+    : > "$tree/early_cpio"
+    head -c 2048 /dev/urandom > "$tree/kernel/x86/microcode/GenuineIntel.bin"
+    ( cd "$tree" && find . | cpio -o -H newc --quiet ) > "$img.early"
+    # dracut pads the early segment out to a 512-byte boundary.
+    local pad=$(( (512 - ($(wc -c < "$img.early") % 512)) % 512 ))
+    (( pad > 0 )) && head -c "$pad" /dev/zero >> "$img.early"
+    cat "$img.early" "$img" > "$img.concat"
+    mv "$img.concat" "$img"
+    rm -f "$img.early"
+}
+
+@test "behavioral: a microcode early-cpio does not hide the real initrd (#76)" {
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    # `cpio -it` stops at the first TRAILER!!!, so listing the raw image
+    # yields the microcode segment and nothing else — five paths, no /usr.
+    # Reading that as "the initrd lacks bash/losetup/udevadm/mount" failed
+    # every dakota deploy (run 30700616717) on an initrd holding all four.
+    ovl="$BATS_TEST_TMPDIR/ovl-uc"; make_overlay "$ovl"
+    base="$BATS_TEST_TMPDIR/base-uc.img"
+    make_base_initrd "$base" bash losetup udevadm mount
+    prepend_microcode "$base"
+    # Guard the premise: the naive single-archive listing really is blind here.
+    run bash -c "cpio -it --quiet < '$base'"
+    [ "$status" -eq 0 ]
+    ! echo "$output" | grep -q bash
+    echo "$output" | grep -q microcode
+
+    run run_helpers "build_phase2_initrd '$ovl' '$base' '$BATS_TEST_TMPDIR/out-uc.img'"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'base initrd verified'
+}
+
+@test "behavioral: a real absence is still fatal behind an early-cpio" {
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    # The segment walk must not turn the gate into a rubber stamp.
+    ovl="$BATS_TEST_TMPDIR/ovl-uc2"; make_overlay "$ovl"
+    base="$BATS_TEST_TMPDIR/base-uc2.img"
+    make_base_initrd "$base" losetup udevadm mount
+    prepend_microcode "$base"
+    run run_helpers "build_phase2_initrd '$ovl' '$base' '$BATS_TEST_TMPDIR/out-uc2.img'"
+    [ "$status" -ne 0 ]
+    echo "$output" | grep -q 'lacks: bash'
+}
+
+@test "behavioral: a microcode-only image is unverifiable, not a failure" {
+    command -v cpio >/dev/null || skip "cpio unavailable"
+    # No bin/ tree anywhere in the listing means the probe saw no rootfs —
+    # WARN, never a fatal verdict about tools it never looked at.
+    ovl="$BATS_TEST_TMPDIR/ovl-uc3"; make_overlay "$ovl"
+    base="$BATS_TEST_TMPDIR/base-uc3.img"
+    : > "$base"
+    prepend_microcode "$base"
+    run run_helpers "build_phase2_initrd '$ovl' '$base' '$BATS_TEST_TMPDIR/out-uc3.img'"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q 'unverified'
 }
 
 @test "behavioral: an unlistable base initrd warns but does not fail the deploy" {

--- a/tests/unit/phase2-early-cpio.bats
+++ b/tests/unit/phase2-early-cpio.bats
@@ -91,6 +91,8 @@ run_helpers() { # <bash-snippet> — with the extracted helpers + stubs loaded
         set -e
         log() { echo \"LOG: \$*\"; }
         err() { echo \"ERR: \$*\" >&2; }
+        $(extract_fn find_ldso)
+        $(extract_fn dso_closure)
         $(extract_fn stage_ntfs3g_closure)
         $(extract_fn _initrd_segment_end)
         $(extract_fn _initrd_skip_padding)

--- a/tests/unit/phase2-windows-return.bats
+++ b/tests/unit/phase2-windows-return.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+# phase2-windows-return.bats — never power-cut the thing you are verifying.
+#
+# The Phase-2 → Windows step asks the guest to reboot and then has to decide
+# whether the guest actually went. Its fallback for "it didn't" is a QEMU
+# `system_reset`, which is a hard power cut with no sync — appropriate for a
+# wedged Phase-2 scratch root, catastrophic for a Windows that is mid-boot.
+#
+# The old detector only watched for guest-ping to FAIL:
+#
+#     for _ in $(seq 1 9); do sleep 5; qga_probe || { seen=true; break; }; done
+#     [ "$seen" = true ] || system_reset
+#
+# guest-ping is OS-agnostic — it answers for whichever agent is up. So the
+# detector could not distinguish the two states it exists to separate:
+#
+#     Phase 2 never rebooted          -> an agent answers  -> reset is correct
+#     Phase 2 rebooted, Windows back  -> an agent answers  -> reset is a DISASTER
+#
+# Run 30710282779 (fedora-gnome-win11pro-btrfs) is the second one. Every Linux
+# assertion passed, the exitrd handed C: back cleanly ("wootc: shutdown:
+# unmounted the Windows host NTFS at /oldsys/run/initramfs/wootc-host"), the
+# serial shows "reboot: machine restart" two seconds after the request, and the
+# firmware then loaded Boot0003 "Windows Boot Manager". The harness meanwhile
+# burned 110 blind seconds inside a retrying `qga_call exec`, opened its eyes on
+# the WINDOWS agent, called it a Phase 2 that had not rebooted, and system_reset
+# it. The firmware looped Boot0003 twice more and the guest sat in recovery
+# until the 10-minute Windows budget expired:
+#
+#     [FAIL] Windows QGA did not become available within 10 minutes
+#
+# A run that had already succeeded was destroyed by its own fallback and
+# reported as a product failure. This is the house failure class — status taken
+# from a proxy ("something answers") instead of the observable ("*Linux*
+# answers") — so the guard is: reset ONLY on a positively identified Linux
+# agent, and treat every other reading as hands-off.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    E2E="${E2E:-$REPO_ROOT/tests/e2e/run-e2e.sh}"
+}
+
+extract_fn() { sed -n "/^$1() {$/,/^}$/p" "$E2E"; }
+
+# The Phase-2 → Windows return block, verbatim.
+return_block() {
+    sed -n '/step "Rebooting Phase 2 Linux and verifying return to Windows/,/pass "One-shot Phase 2 boot consumed/p' "$E2E"
+}
+
+# Run p2_reboot_observe with the three probes stubbed. $1..$3 are shell
+# snippets for qga_probe / qga_windows_probe / qga_linux_probe.
+observe_with() {
+    run bash -c "
+        set -uo pipefail
+        WOOTC_E2E_P2_REBOOT_POLL_S=0
+        qga_probe() { $1; }
+        qga_windows_probe() { $2; }
+        qga_linux_probe() { $3; }
+        $(extract_fn p2_reboot_observe)
+        p2_reboot_observe 4
+    "
+}
+
+@test "run-e2e.sh is syntactically valid" {
+    run bash -n "$E2E"
+    [ "$status" -eq 0 ]
+}
+
+@test "guest-ping is OS-agnostic, so it cannot stand alone as a down-detector" {
+    # This is the premise of the whole file: qga_probe asks `ping`, which any
+    # agent answers. If it ever grows an OS discriminator of its own, the
+    # reasoning below needs revisiting.
+    extract_fn qga_probe | grep -q 'qga_call ping'
+    ! extract_fn qga_probe | grep -qE 'uname|Windows_NT'
+}
+
+@test "a positive Linux discriminator exists alongside the Windows one" {
+    # qga_windows_probe has always existed; its mirror is what was missing.
+    extract_fn qga_windows_probe | grep -q 'Windows_NT'
+    extract_fn qga_linux_probe | grep -q 'uname -s'
+    extract_fn qga_linux_probe | grep -q 'Linux'
+}
+
+@test "no agent answering is read as 'down'" {
+    observe_with 'return 1' 'return 1' 'return 1'
+    [ "$status" -eq 0 ]
+    [ "$output" = "down" ]
+}
+
+@test "a Windows agent answering is read as 'windows', not as a live Phase 2" {
+    # Run 30710282779 exactly: Linux is gone, Windows pings and runs PowerShell.
+    observe_with 'return 0' 'return 0' 'return 1'
+    [ "$status" -eq 0 ]
+    [ "$output" = "windows" ]
+}
+
+@test "a Linux agent still answering is read as 'linux'" {
+    # The bonito case (30700616717 / 30704513401): request accepted, nothing
+    # happened, Phase 2 sat at its login prompt. This is the ONE case a reset
+    # is the right answer to.
+    observe_with 'return 0' 'return 1' 'return 0'
+    [ "$status" -eq 0 ]
+    [ "$output" = "linux" ]
+}
+
+@test "an agent that identifies as neither is read as 'unknown', never as Linux" {
+    # A Windows agent whose PowerShell is not up yet pings but cannot answer
+    # $env:OS. Guessing "Linux" here is what costs a run, so it must not.
+    observe_with 'return 0' 'return 1' 'return 1'
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+}
+
+@test "the observation stops the moment Windows is seen, without draining the budget" {
+    # Every extra poll after Windows is home is time the old code spent walking
+    # toward a reset.
+    run bash -c "
+        set -uo pipefail
+        WOOTC_E2E_P2_REBOOT_POLL_S=0
+        C=$BATS_TEST_TMPDIR/calls
+        : > \"\$C\"
+        qga_probe() { echo p >> \"\$C\"; return 0; }
+        qga_windows_probe() { return 0; }
+        qga_linux_probe() { return 1; }
+        $(extract_fn p2_reboot_observe)
+        p2_reboot_observe 9 >/dev/null
+        wc -l < \"\$C\"
+    "
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | tr -d ' ')" = "1" ]
+}
+
+@test "system_reset in the Phase-2 return is reachable only from the 'linux' verdict" {
+    # The load-bearing assertion. Find the case label governing every
+    # system_reset in this block; anything but `linux)` is a run-killer.
+    # Match the monitor write itself, not the word in prose — the whole point is
+    # which branch actually pulls the plug.
+    local labels
+    labels=$(return_block | awk '
+        /^[[:space:]]*[a-z*]+\)[[:space:]]*$/ { gsub(/[[:space:]()]/, "", $0); label=$0 }
+        /monitor\.sock/ { print (label == "" ? "UNGUARDED" : label) }
+    ')
+    [ -n "$labels" ]
+    while read -r l; do [ "$l" = "linux" ]; done <<< "$labels"
+}
+
+@test "the verdict is computed before the reset, from p2_reboot_observe" {
+    return_block | grep -q 'case "$(p2_reboot_observe)" in'
+    local verdict_line reset_line
+    verdict_line=$(return_block | grep -n 'p2_reboot_observe' | head -1 | cut -d: -f1)
+    reset_line=$(return_block | grep -n 'monitor\.sock' | head -1 | cut -d: -f1)
+    [ -n "$verdict_line" ] && [ -n "$reset_line" ]
+    [ "$verdict_line" -lt "$reset_line" ]
+}
+
+@test "the reboot request is bounded so it cannot eat the observation window" {
+    # qga_call retries three times at a 60s timeout by default and collapses to
+    # a single try at <=5s. Unbounded, the request burned ~110s of the very
+    # window the observation needs — which is how the observation ended up
+    # looking at Windows in the first place.
+    local t
+    t=$(return_block | grep -E "WOOTC_QGA_CALL_TIMEOUT=[0-9]+ qga_call exec .*systemctl reboot" \
+        | grep -oE 'WOOTC_QGA_CALL_TIMEOUT=[0-9]+' | grep -oE '[0-9]+$')
+    [ -n "$t" ]
+    [ "$t" -le 5 ]
+}
+
+@test "the Windows return is still asserted with the OS discriminator afterwards" {
+    # Skipping the reset must not become "assume it worked".
+    return_block | grep -q 'qga_wait_windows 600'
+}
+
+@test "the old ping-only shape really would have reset run 30710282779" {
+    # Non-vacuity: with the same stubs the new code calls 'windows', the shape
+    # this file replaced concludes "still up" and fires the reset. Without this,
+    # every assertion above could be passing for free.
+    run bash -c '
+        set -uo pipefail
+        qga_probe() { return 0; }   # Windows answering guest-ping
+        seen=false
+        for _ in $(seq 1 9); do
+            if ! qga_probe; then seen=true; break; fi
+        done
+        [ "$seen" != true ] && echo would-reset || echo would-not-reset
+    '
+    [ "$status" -eq 0 ]
+    [ "$output" = "would-reset" ]
+}

--- a/tests/unit/phase2-windows-return.bats
+++ b/tests/unit/phase2-windows-return.bats
@@ -53,11 +53,12 @@ observe_with() {
     run bash -c "
         set -uo pipefail
         WOOTC_E2E_P2_REBOOT_POLL_S=0
+        WOOTC_E2E_P2_REBOOT_TRIES=4
         qga_probe() { $1; }
         qga_windows_probe() { $2; }
         qga_linux_probe() { $3; }
         $(extract_fn p2_reboot_observe)
-        p2_reboot_observe 4
+        p2_reboot_observe
     "
 }
 
@@ -117,13 +118,14 @@ observe_with() {
     run bash -c "
         set -uo pipefail
         WOOTC_E2E_P2_REBOOT_POLL_S=0
+        WOOTC_E2E_P2_REBOOT_TRIES=9
         C=$BATS_TEST_TMPDIR/calls
         : > \"\$C\"
         qga_probe() { echo p >> \"\$C\"; return 0; }
         qga_windows_probe() { return 0; }
         qga_linux_probe() { return 1; }
         $(extract_fn p2_reboot_observe)
-        p2_reboot_observe 9 >/dev/null
+        p2_reboot_observe >/dev/null
         wc -l < \"\$C\"
     "
     [ "$status" -eq 0 ]

--- a/tests/unit/qga-real-root.bats
+++ b/tests/unit/qga-real-root.bats
@@ -37,6 +37,8 @@ run_stager() {
         set -euo pipefail
         log() { echo \"\$*\"; }
         err() { echo \"\$*\" >&2; }
+        $(extract_fn find_ldso)
+        $(extract_fn dso_closure)
         $(extract_fn stage_qemu_ga_into_target)
         stage_qemu_ga_into_target
     "
@@ -106,6 +108,8 @@ run_stager() {
         set -uo pipefail
         log() { echo \"\$*\"; }
         err() { echo \"\$*\" >&2; }
+        $(extract_fn find_ldso)
+        $(extract_fn dso_closure)
         $(extract_fn stage_qemu_ga_into_target)
         stage_qemu_ga_into_target
     "

--- a/tests/unit/qga-real-root.bats
+++ b/tests/unit/qga-real-root.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# The fallback guest agent must land where the BOOTED system looks, not merely
+# where the write succeeds.
+#
+# Context (run 30703716667, bluefin-dakota-win11pro): the deployer wrote
+# qemu-ga to $DEPLOY_ROOT/usr/bin and its unit to
+# $DEPLOY_ROOT/usr/lib/systemd/system, logged
+#   [PASS] qemu-guest-agent installed from deployer into target
+# and Phase 2 then booted dakota to a login prompt with no such binary and no
+# such unit anywhere in it: the sealed composefs image is mounted over /usr,
+# so the deployment directory's own /usr is shadowed at runtime. The harness
+# reported "the Phase-2 guest agent never answered".
+#
+# Every assertion here is about the runtime view: /etc and /var (proven
+# runtime-visible under composefs by wootc-passthrough.service running from
+# /var/usrlocal/bin in that same boot), never /usr.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    DEPLOY="${DEPLOY:-$REPO_ROOT/payload/deployer/deploy.sh}"
+}
+
+extract_fn() {
+    awk "/^$1\(\) \{/,/^\}/" "$DEPLOY"
+}
+
+# Run stage_qemu_ga_into_target for real against a throwaway deployment tree,
+# with a dynamically linked stand-in for qemu-ga so the closure logic (ldd,
+# loader, exec-verification) is exercised rather than mocked.
+run_stager() {
+    DEPLOY_ROOT="$BATS_TEST_TMPDIR/root"
+    FAKE_BIN="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$DEPLOY_ROOT" "$FAKE_BIN"
+    cp "$(type -P true)" "$FAKE_BIN/qemu-ga"
+    chmod 0755 "$FAKE_BIN/qemu-ga"
+    run env DEPLOY_ROOT="$DEPLOY_ROOT" PATH="$FAKE_BIN:$PATH" bash -c "
+        set -euo pipefail
+        log() { echo \"\$*\"; }
+        err() { echo \"\$*\" >&2; }
+        $(extract_fn stage_qemu_ga_into_target)
+        stage_qemu_ga_into_target
+    "
+}
+
+@test "the staged agent is reachable from the booted root, not from /usr" {
+    run_stager
+    [ "$status" -eq 0 ]
+
+    # The two paths a composefs runtime actually keeps.
+    [ -x "$DEPLOY_ROOT/var/usrlocal/bin/qemu-ga" ]
+    [ -f "$DEPLOY_ROOT/etc/systemd/system/wootc-qemu-ga.service" ]
+
+    # Enabled the way systemd enables things, and the link must RESOLVE:
+    # the old code symlinked into /etc but pointed at /usr, which dangles the
+    # moment the composefs image shadows the deployment's /usr.
+    [ -L "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-qemu-ga.service" ]
+    [ -e "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-qemu-ga.service" ]
+
+    # Nothing may be placed under the deployment's /usr: that is the write
+    # that silently disappeared.
+    run bash -c "find '$DEPLOY_ROOT/usr' -type f 2>/dev/null"
+    [ -z "$output" ]
+}
+
+@test "the unit's ExecStart points at the file that was actually staged" {
+    run_stager
+    [ "$status" -eq 0 ]
+    exec_start=$(sed -n 's/^ExecStart=\([^ ]*\).*/\1/p' \
+        "$DEPLOY_ROOT/etc/systemd/system/wootc-qemu-ga.service")
+    [ "$exec_start" = "/var/usrlocal/bin/qemu-ga" ]
+    [ -x "$DEPLOY_ROOT$exec_start" ]
+
+    # And the wrapper points at a closure that is really there: binary,
+    # loader, libraries (agent-lessons §8: never the deployer's binary
+    # against the target's libraries).
+    loader=$(sed -n 's|^exec /\([^ ]*\) --library-path.*|\1|p' \
+        "$DEPLOY_ROOT/var/usrlocal/bin/qemu-ga")
+    [ -n "$loader" ]
+    [ -f "$DEPLOY_ROOT/$loader" ]
+    [ -f "$DEPLOY_ROOT/var/usrlocal/lib/wootc-qga/qemu-ga" ]
+}
+
+@test "the fallback stands down when the image ships its own agent" {
+    run_stager
+    [ "$status" -eq 0 ]
+    unit="$DEPLOY_ROOT/etc/systemd/system/wootc-qemu-ga.service"
+    # Evaluated in the booted real root, the only place where "does this
+    # image have qemu-ga" is observable. A chroot probe at deploy time reports
+    # "absent" for EVERY composefs image, because that /usr is empty.
+    grep -q '^ConditionPathExists=!/usr/bin/qemu-ga$' "$unit"
+    grep -q '^ConditionPathExists=!/usr/sbin/qemu-ga$' "$unit"
+    # Its own name, so it can never mask an image-provided
+    # qemu-guest-agent.service via /etc precedence.
+    [ ! -e "$DEPLOY_ROOT/etc/systemd/system/qemu-guest-agent.service" ]
+}
+
+@test "an unstageable closure fails loudly and leaves nothing half-installed" {
+    # A stand-in with no dynamic loader (a shell script) is the negative
+    # control: ldd surfaces no loader, so no self-contained closure exists.
+    DEPLOY_ROOT="$BATS_TEST_TMPDIR/root2"
+    FAKE_BIN="$BATS_TEST_TMPDIR/bin2"
+    mkdir -p "$DEPLOY_ROOT" "$FAKE_BIN"
+    printf '#!/bin/sh\nexit 0\n' > "$FAKE_BIN/qemu-ga"
+    chmod 0755 "$FAKE_BIN/qemu-ga"
+    run env DEPLOY_ROOT="$DEPLOY_ROOT" PATH="$FAKE_BIN:$PATH" bash -c "
+        set -uo pipefail
+        log() { echo \"\$*\"; }
+        err() { echo \"\$*\" >&2; }
+        $(extract_fn stage_qemu_ga_into_target)
+        stage_qemu_ga_into_target
+    "
+    [ "$status" -ne 0 ]
+    [ ! -e "$DEPLOY_ROOT/var/usrlocal/lib/wootc-qga" ]
+    [ ! -e "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-qemu-ga.service" ]
+}
+
+@test "the deployer no longer installs the agent into the shadowed /usr" {
+    run grep -nE '^[^#]*DEPLOY_ROOT/usr(/bin/qemu-ga|/lib/systemd/system/qemu)' "$DEPLOY"
+    [ "$status" -ne 0 ]
+    # And the composefs early-cpio overlay stages no agent either: that tree
+    # is the INITRAMFS and is discarded at switch-root, so a qemu-ga in it
+    # cannot put an agent in the booted system.
+    run grep -nE '^[^#]*\$OVL[^ ]*qemu' "$DEPLOY"
+    [ "$status" -ne 0 ]
+}
+
+@test "the real-root stager is called from the post-install stage" {
+    [ "$(grep -c '^stage_qemu_ga_into_target() {' "$DEPLOY")" -eq 1 ]
+    grep -qE '^[^#]*[!;] *stage_qemu_ga_into_target;' "$DEPLOY"
+}


### PR DESCRIPTION
The btrfs Phase-2 fix that merged in #75 has no way to be exercised by the hosted matrix: the harness had bootloader/composefs axes but no filesystem one, so `wootc.filesystem=btrfs` could not reach the deployer from a workflow dispatch.

This plumbs the axis through every layer:

- `WOOTC_E2E_FILESYSTEM` env in `run-e2e.sh` → `Filesystem=` in `wootc-config.txt`
- `run-wootc-e2e.ps1` passes a non-auto value to `setup-wootc.ps1`
- `setup-wootc.ps1` gains a `-Filesystem` param (`xfs|ext4|btrfs|auto`) and appends `wootc.filesystem=` to the deployer kargs
- `e2e-hosted.yml` gains a `filesystem` input wired to the env
- `e2e-matrix.yml` parses a `filesystem=<fs>` opt from `matrix.tsv` and forwards it
- new smoke cell **`bluefin-lts-win11pro-btrfs`** — the proven baseline image forced onto btrfs, which is exactly the #35 repro

`auto`/empty keeps the deployer's own default at every hop, so all existing cells are byte-for-byte unchanged in behavior.

Guarded by a new `btrfs-phase2.bats` test asserting every hop of the chain — a break in any layer would silently run the btrfs cell on the default filesystem and call it green.

Once this lands (or directly from this branch via `workflow_dispatch`), the E2E ladder from `docs/finish-plan.md` runs as: matrix `tier=smoke` (covers dakota + btrfs + baselines), then `tier=full grep=arch-gnome` / `grep=debian-gnome` for marlin/flounder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_


---

**Also in this branch (matrix fallout):** the `bluefin-dakota-win11pro` cell in run 30700616717 died at the Phase-2 gate with `the target's base initrd lacks: bash losetup udevadm mount`. An initramfs is a concatenation — uncompressed early-cpio segments (microcode) then the compressed main archive — and `cpio -it` stops at the first `TRAILER!!!`, so the check listed the microcode segment, saw no `/usr`, and called that proof. `build_phase2_initrd` now walks the whole segment chain and only trusts a listing that contains a `bin/` tree:

```bash
if [[ $(dd if="$img" bs=1 skip="$off" count=6 status=none) == 070701 ]]; then
    tail -c +$((off + 1)) "$img" | cpio -it --quiet   # this segment
    end=$(_initrd_segment_end "$img" "$off")          # newc header arithmetic
    off=$(_initrd_skip_padding "$img" "$end" "$size") # then the next one
    continue
fi
```

Three new `phase2-early-cpio.bats` cases cover it, and they go red against the old single-archive listing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
