### PR TITLE
ci: move off Blacksmith to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
 
   gui-cdp-windows:
     if: ${{ vars.WOOTC_CDP_ENABLED == 'true' }}
-    runs-on: [self-hosted, Windows]
+    runs-on: windows-latest
     env:
       WOOTC_CDP_URL: ${{ vars.WOOTC_CDP_URL }}
     steps:

--- a/.github/workflows/e2e-kvm.yml
+++ b/.github/workflows/e2e-kvm.yml
@@ -9,16 +9,18 @@ concurrency:
   group: e2e-kvm-pages
   cancel-in-progress: false
 
-# Runs on Runs-On (self-hosted-in-AWS autoscaler), on the build-kvm runner
-# profile defined in .github/runs-on.yml — nested-virt: true on a c8i/m8i/r8i
-# instance for hardware-accelerated KVM.
+# Needs a KVM-capable self-hosted runner (nested virt is NOT available on
+# GitHub-hosted runners). Wire the kanpur KVM host as an org runner with the
+# "kvm" label, then set the KVM_E2E_ENABLED org variable to "true".
+# Job is gated off by default so dispatch doesn't hang on an unmatched label.
 
 on:
   workflow_dispatch:        # manual trigger
 
 jobs:
   e2e:
-    runs-on: runs-on=${{ github.run_id }}/runner=build-kvm
+    if: ${{ vars.KVM_E2E_ENABLED == 'true' }}
+    runs-on: [self-hosted, kvm]
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## What & why
Blacksmith runner fleet was removed from the org (458 runners deleted). The org is now on GitHub **Team** (60 concurrent GitHub-hosted slots, standard runners free for public repos). Every workflow still targeting Blacksmith labels would hang forever.

**Special cases:** `[self-hosted, Windows]` GUI job → `windows-latest` (still var-gated off). `e2e-kvm.yml` used RunsOn nested-virt (impossible on GitHub-hosted) — now gated behind `KVM_E2E_ENABLED` org var and pointed at a future `kvm`-labelled kanpur runner so dispatch doesn't hang.

## Verification
- No functional `blacksmith`/`runner=build-*`/RunsOn references remain in this repo's workflows.
- ACTIONS_RUNNER_LABEL repo var deleted in tromso/xfce-linux (was resolving to the dead Blacksmith ephemeral label).
- No required-check job names changed, so branch-protection contexts are unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->