### PR TITLE
session: add consented online DPAPI rewrap envelope

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -63,6 +63,9 @@ type InstallConfig struct {
 	// over on first login. Default false — we honor the image maker's desktop
 	// defaults unless the user asks to make it feel like Windows.
 	WindowsLook bool `json:"windowsLook"`
+	// SessionConsent is opt-in per app because it authorizes moving auth
+	// material. An absent or false entry never stages a session envelope.
+	SessionConsent map[string]bool `json:"sessionConsent,omitempty"`
 }
 
 // ProgressEvent is emitted during install for the frontend progress bar.
@@ -648,6 +651,22 @@ func runPipeline(ctx context.Context, cfg InstallConfig, emit func(ProgressEvent
 			// an AppData footprint. Best-effort: never fail install.
 			if err := collectPrograms(); err != nil {
 				fmt.Fprintf(os.Stderr, "[wootc] program collection skipped: %v\n", err)
+			}
+			return nil
+		}},
+		{"Checking app sessions", 90, func() error {
+			candidates, err := collectSessions()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[wootc] session collection skipped: %v\n", err)
+				return nil
+			}
+			for _, candidate := range candidates {
+				if !candidate.Portable || candidate.Recommend != "copy" || !cfg.SessionConsent[candidate.App] {
+					continue
+				}
+				if err := exportSession(candidate.App, cfg.Password, true); err != nil {
+					fmt.Fprintf(os.Stderr, "[wootc] %s session export skipped: %v\n", candidate.App, err)
+				}
 			}
 			return nil
 		}},

--- a/app/app.go
+++ b/app/app.go
@@ -207,11 +207,11 @@ func (a *App) shutdown(ctx context.Context) {
 // reads it to gate the UI to green-only scenarios (docs/RELEASING.md); the
 // backend enforces the same rules in StartInstall (defense in depth).
 type SupportPolicy struct {
-	Channel             string `json:"channel"`             // alpha | beta | stable
-	ExperimentalImages  bool   `json:"experimentalImages"`  // offer non-green images?
-	BitLockerSupported  bool   `json:"bitlockerSupported"`  // is the FDE path green yet? (#34)
-	CustomImageAllowed  bool   `json:"customImageAllowed"`  // arbitrary OCI ref?
-	Reason              string `json:"reason"`              // one-liner for the UI
+	Channel            string `json:"channel"`            // alpha | beta | stable
+	ExperimentalImages bool   `json:"experimentalImages"` // offer non-green images?
+	BitLockerSupported bool   `json:"bitlockerSupported"` // is the FDE path green yet? (#34)
+	CustomImageAllowed bool   `json:"customImageAllowed"` // arbitrary OCI ref?
+	Reason             string `json:"reason"`             // one-liner for the UI
 }
 
 // supportChannel resolves the active release channel. Default is the
@@ -660,13 +660,22 @@ func runPipeline(ctx context.Context, cfg InstallConfig, emit func(ProgressEvent
 				fmt.Fprintf(os.Stderr, "[wootc] session collection skipped: %v\n", err)
 				return nil
 			}
-			for _, candidate := range candidates {
-				if !candidate.Portable || candidate.Recommend != "copy" || !cfg.SessionConsent[candidate.App] {
-					continue
+			results := exportConsentedSessions(candidates, cfg.SessionConsent, cfg.Password)
+			for _, result := range results {
+				if result.State == "failed" {
+					fmt.Fprintf(os.Stderr, "[wootc] %s session export failed: %s\n", result.App, result.Reason)
 				}
-				if err := exportSession(candidate.App, cfg.Password, true); err != nil {
-					fmt.Fprintf(os.Stderr, "[wootc] %s session export skipped: %v\n", candidate.App, err)
-				}
+			}
+			// This is deliberately a status ledger, not a success marker. The
+			// target-side importer must replace "staged" with "imported" before
+			// any UI can describe the app as signed in.
+			path := filepath.Join(wootcDir(), "install", "slurp", "session", "exports.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				fmt.Fprintf(os.Stderr, "[wootc] session export ledger directory skipped: %v\n", err)
+				return nil
+			}
+			if err := os.WriteFile(path, []byte(sessionExportSummary(results)), 0o600); err != nil {
+				fmt.Fprintf(os.Stderr, "[wootc] session export ledger skipped: %v\n", err)
 			}
 			return nil
 		}},

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -1,5 +1,5 @@
 import '../src/style.css';
-import { GetImages, GetSystemInfo, StartInstall, CancelInstall, GetStatus, Reboot, ExistingInstallFound, GetMode, GetMigrationCategories, ConvertCategory, ImportBrowserData, GetAppMigrations, GetOfficeMigration, GetBranding, CreateDataPartition, GetUninstallInfo, UninstallWith, GetVMCapability, BootInVM, DefragDrive, GetFreshVMCapability, TryInVMFresh, InstallPreviewForReal, E2EDriveDirective, E2EDriveReport, GetSupportPolicy } from '../wailsjs/go/main/App';
+import { GetImages, GetSystemInfo, StartInstall, CancelInstall, GetStatus, Reboot, ExistingInstallFound, GetMode, GetMigrationCategories, ConvertCategory, ImportBrowserData, GetAppMigrations, GetOfficeMigration, GetSessionCandidates, GetBranding, CreateDataPartition, GetUninstallInfo, UninstallWith, GetVMCapability, BootInVM, DefragDrive, GetFreshVMCapability, TryInVMFresh, InstallPreviewForReal, E2EDriveDirective, E2EDriveReport, GetSupportPolicy } from '../wailsjs/go/main/App';
 import { EventsOn } from '../wailsjs/runtime/runtime';
 import { fmtSize } from './lib/format.js';
 import { el, btn, chip, warningBanner, inputField } from './lib/ui.js';
@@ -14,6 +14,7 @@ const state = {
   brand: null,         // partner/enterprise branding (themeable)
   categories: [],      // migration dashboard rows
   apps: [],            // detected app migrations
+  sessionCandidates: [], // Windows-online DPAPI findings; never tokens
   office: null,        // MS Office → LibreOffice summary
   converting: {},      // category id → percent while a conversion runs
   selected: null,      // selected Image
@@ -29,6 +30,7 @@ const state = {
     encryption: 'tpm2-luks',
     luksPassphrase: '',
     windowsLook: false,
+    sessionConsent: {},
   },
   progress: {
     step: '',
@@ -125,16 +127,18 @@ async function init() {
     return;
   }
 
-  const [images, sysinfo, existing, policy] = await Promise.all([
+  const [images, sysinfo, existing, policy, sessionCandidates] = await Promise.all([
     GetImages(),
     GetSystemInfo(),
     ExistingInstallFound(),
     GetSupportPolicy().catch(() => ({ channel: 'alpha', experimentalImages: false, bitlockerSupported: false, customImageAllowed: false })),
+    GetSessionCandidates().catch(() => []),
   ]);
 
   state.policy = policy;
   state.images = images || [];
   state.sysinfo = sysinfo;
+  state.sessionCandidates = sessionCandidates || [];
   state.selected = state.images[0] || null;
   applyImageDefaults(state.selected);
 
@@ -413,6 +417,31 @@ function renderLaunchpad() {
   if (state.config.windowsLook) lookRow.style.borderColor = 'var(--primary)';
   fields.appendChild(lookRow);
 
+  // Auth-token migration is a separate, explicit opt-in from look/data
+  // migration. The backend defaults every app to off and still refuses
+  // Discord/Slack because those services prefer relinking.
+  const movableSessions = state.sessionCandidates.filter(c => c.portable && c.recommend === 'copy');
+  if (movableSessions.length) {
+    const sessionBox = el('div');
+    sessionBox.style.cssText = 'margin-top:8px;padding:8px;border:1.5px solid var(--border);border-radius:6px';
+    sessionBox.innerHTML = `<div style="font-size:12px;font-weight:600">Signed-in app sessions</div><div style="font-size:11.5px;color:var(--text-muted);margin-top:2px">Optional: move these sessions while Windows is online. Off means you will sign in once on Linux.</div>`;
+    movableSessions.forEach(candidate => {
+      const row = el('label');
+      row.style.cssText = 'display:flex;gap:8px;align-items:flex-start;cursor:pointer;font-size:12px;margin-top:7px';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = !!state.config.sessionConsent[candidate.app];
+      checkbox.style.marginTop = '1px';
+      checkbox.onchange = () => { state.config.sessionConsent[candidate.app] = checkbox.checked; };
+      const copy = el('span');
+      copy.innerHTML = `<b style="text-transform:capitalize">${candidate.app}</b><br><span style="color:var(--text-muted)">${candidate.note}</span>`;
+      row.appendChild(checkbox);
+      row.appendChild(copy);
+      sessionBox.appendChild(row);
+    });
+    fields.appendChild(sessionBox);
+  }
+
   const advanced = el('details');
   // Every control change re-renders the form; without persisting the open
   // state the panel snaps shut on each toggle — the user opens Advanced,
@@ -589,6 +618,7 @@ async function installPreviewForReal() {
       encryption: state.config.encryption,
       luksPassphrase: state.config.luksPassphrase,
       windowsLook: state.config.windowsLook,
+      sessionConsent: state.config.sessionConsent,
     });
     state.screen = 'done';
     render();
@@ -1063,6 +1093,7 @@ async function startInstall() {
       storageDrive,
       encryption:     state.config.encryption,
       luksPassphrase: state.config.luksPassphrase,
+      sessionConsent: state.config.sessionConsent,
     });
   } catch (e) {
     state.progress.error = String(e);

--- a/app/frontend/wailsjs/go/main/App.d.ts
+++ b/app/frontend/wailsjs/go/main/App.d.ts
@@ -25,6 +25,17 @@ export interface InstallConfig {
   storageDrive: string;
   encryption: 'none' | 'tpm2-luks' | 'luks-passphrase';
   luksPassphrase: string;
+  windowsLook?: boolean;
+  sessionConsent?: Record<string, boolean>;
+}
+
+export interface SessionCandidate {
+  app: string;
+  kind: 'chromium' | 'plainfile';
+  portable: boolean;
+  recommend: 'copy' | 'relink' | 'signin';
+  note: string;
+  consentRequired: boolean;
 }
 
 export interface InstallStatus {
@@ -61,6 +72,7 @@ export function GetMode(): Promise<'installer' | 'migration'>;
 export function GetMigrationCategories(): Promise<BridgeCategory[]>;
 export function ConvertCategory(id: string): Promise<void>;
 export function ImportBrowserData(): Promise<string>;
+export function GetSessionCandidates(): Promise<SessionCandidate[]>;
 export function GetImages(): Promise<Image[]>;
 export function GetSystemInfo(): Promise<SystemInfo>;
 export function StartInstall(cfg: InstallConfig): Promise<void>;

--- a/app/frontend/wailsjs/go/main/App.js
+++ b/app/frontend/wailsjs/go/main/App.js
@@ -95,6 +95,10 @@ export function GetAppMigrations() {
   return window['go']['main']['App']['GetAppMigrations']();
 }
 
+export function GetSessionCandidates() {
+  return window['go']['main']['App']['GetSessionCandidates']();
+}
+
 export function GetOfficeMigration() {
   return window['go']['main']['App']['GetOfficeMigration']();
 }

--- a/app/installer_other.go
+++ b/app/installer_other.go
@@ -85,6 +85,9 @@ func writeBitLockerKey(key string) error { return nil }
 func collectLook() error                                          { return nil }
 func collectWifi() error                                          { return nil }
 func collectPrograms() error                                      { return nil }
+func collectSessions() ([]SessionCandidate, error)                { return nil, nil }
+func sessionCandidates() ([]SessionCandidate, error)              { return nil, nil }
+func exportSession(string, string, bool) error                    { return nil }
 func uninstall(ctx context.Context) error                         { return nil }
 func uninstallWith(ctx context.Context, o UninstallOptions) error { return nil }
 func getUninstallInfo() UninstallInfo                             { return UninstallInfo{Found: false} }

--- a/app/migration.go
+++ b/app/migration.go
@@ -68,6 +68,12 @@ func (a *App) GetAppMigrations() ([]AppMigration, error) {
 	return appMigrations()
 }
 
+// GetSessionCandidates reports which Windows sessions were proven
+// decryptable. It never returns tokens or decrypted payloads.
+func (a *App) GetSessionCandidates() ([]SessionCandidate, error) {
+	return sessionCandidates()
+}
+
 // OfficeMigration summarizes what moved from MS Office to LibreOffice.
 type OfficeMigration struct {
 	Migrated []string `json:"migrated"`

--- a/app/session.go
+++ b/app/session.go
@@ -1,0 +1,12 @@
+package main
+
+// SessionCandidate is a per-app finding surfaced to the GUI so the user can
+// consent (or not) to moving its login. It contains no token material.
+type SessionCandidate struct {
+	App             string `json:"app"`
+	Kind            string `json:"kind"`      // "chromium" | "plainfile"
+	Portable        bool   `json:"portable"`  // decryptable here?
+	Recommend       string `json:"recommend"` // "copy" | "relink" | "signin"
+	Note            string `json:"note"`
+	ConsentRequired bool   `json:"consentRequired"`
+}

--- a/app/session.go
+++ b/app/session.go
@@ -10,3 +10,12 @@ type SessionCandidate struct {
 	Note            string `json:"note"`
 	ConsentRequired bool   `json:"consentRequired"`
 }
+
+// SessionExport records the honest state of the online half of a session
+// migration. "staged" means only that an authenticated envelope containing
+// the app key was written; it is not a claim that the Linux app is signed in.
+type SessionExport struct {
+	App    string `json:"app"`
+	State  string `json:"state"` // staged | skipped | failed
+	Reason string `json:"reason,omitempty"`
+}

--- a/app/session_crypto.go
+++ b/app/session_crypto.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+const sessionEnvelopeVersion = 1
+
+// sessionEnvelope is the transport format written by the Windows half. The
+// DPAPI-recovered Chromium key is never staged in clear; it is sealed with a
+// key derived from the Linux user's vault secret. The target can use this key
+// to decrypt Chromium payloads and re-encrypt them with its native keyring.
+type sessionEnvelope struct {
+	Version    int    `json:"version"`
+	App        string `json:"app"`
+	Algorithm  string `json:"algorithm"`
+	Salt       []byte `json:"salt"`
+	Nonce      []byte `json:"nonce"`
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+func sealSessionKey(app string, chromiumKey []byte, vaultSecret string) ([]byte, error) {
+	if app == "" || len(chromiumKey) == 0 || vaultSecret == "" {
+		return nil, fmt.Errorf("session rewrap requires app, key, and vault secret")
+	}
+	salt := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, fmt.Errorf("session salt: %w", err)
+	}
+	key := deriveSessionKey(vaultSecret, salt)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("session cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("session AEAD: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("session nonce: %w", err)
+	}
+	ciphertext := gcm.Seal(nil, nonce, chromiumKey, []byte(app))
+	envelope := sessionEnvelope{
+		Version: sessionEnvelopeVersion, App: app, Algorithm: "AES-256-GCM/HKDF-SHA256",
+		Salt: salt, Nonce: nonce, Ciphertext: ciphertext,
+	}
+	return json.Marshal(envelope)
+}
+
+func openSessionKey(data []byte, app, vaultSecret string) ([]byte, error) {
+	if app == "" || vaultSecret == "" {
+		return nil, fmt.Errorf("session envelope requires app and vault secret")
+	}
+	var envelope sessionEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("session envelope: %w", err)
+	}
+	if envelope.Version != sessionEnvelopeVersion || envelope.App != app || envelope.Algorithm != "AES-256-GCM/HKDF-SHA256" {
+		return nil, fmt.Errorf("unsupported session envelope")
+	}
+	if len(envelope.Salt) != 32 {
+		return nil, fmt.Errorf("invalid session salt")
+	}
+	key := deriveSessionKey(vaultSecret, envelope.Salt)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil || len(envelope.Nonce) != gcm.NonceSize() {
+		return nil, fmt.Errorf("invalid session nonce")
+	}
+	plain, err := gcm.Open(nil, envelope.Nonce, envelope.Ciphertext, []byte(app))
+	if err != nil {
+		return nil, fmt.Errorf("session authentication failed")
+	}
+	return plain, nil
+}
+
+func deriveSessionKey(secret string, salt []byte) []byte {
+	// HKDF extract/expand with a fixed context keeps this transport key
+	// separate from the password hash stored in vault.json.
+	extract := hmac.New(sha256.New, salt)
+	extract.Write([]byte(secret))
+	prk := extract.Sum(nil)
+	expand := hmac.New(sha256.New, prk)
+	expand.Write([]byte("wootc session rewrap v1\x00"))
+	expand.Write([]byte{1})
+	return expand.Sum(nil)
+}

--- a/app/session_crypto_test.go
+++ b/app/session_crypto_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -26,5 +27,24 @@ func TestSessionEnvelopeRoundTrip(t *testing.T) {
 func TestSessionEnvelopeRejectsEmptyInputs(t *testing.T) {
 	if _, err := sealSessionKey("chrome", nil, "secret"); err == nil {
 		t.Fatal("expected empty Chromium key to fail")
+	}
+}
+
+func TestSessionExportPolicyDefaultsOff(t *testing.T) {
+	results := exportConsentedSessions([]SessionCandidate{
+		{App: "chrome", ConsentRequired: true},
+	}, nil, "secret")
+	if len(results) != 1 || results[0].State != "skipped" {
+		t.Fatalf("default consent result = %#v", results)
+	}
+	if results[0].Reason != "user did not opt in" {
+		t.Fatalf("default consent reason = %q", results[0].Reason)
+	}
+}
+
+func TestSessionExportSummaryIsNotACompletionClaim(t *testing.T) {
+	data := sessionExportSummary([]SessionExport{{App: "chrome", State: "staged"}})
+	if !strings.Contains(data, `"state": "staged"`) || strings.Contains(data, `"state": "imported"`) {
+		t.Fatalf("summary = %s", data)
 	}
 }

--- a/app/session_crypto_test.go
+++ b/app/session_crypto_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSessionEnvelopeRoundTrip(t *testing.T) {
+	want := []byte("chromium master key")
+	data, err := sealSessionKey("chrome", want, "vault-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := openSessionKey(data, "chrome", "vault-secret")
+	if err != nil || !bytes.Equal(got, want) {
+		t.Fatalf("round trip = %q, err = %v", got, err)
+	}
+	if _, err := openSessionKey(data, "edge", "vault-secret"); err == nil {
+		t.Fatal("expected app binding to reject a different app")
+	}
+	if _, err := openSessionKey(data, "chrome", "wrong-secret"); err == nil {
+		t.Fatal("expected vault secret mismatch to reject the envelope")
+	}
+}
+
+func TestSessionEnvelopeRejectsEmptyInputs(t *testing.T) {
+	if _, err := sealSessionKey("chrome", nil, "secret"); err == nil {
+		t.Fatal("expected empty Chromium key to fail")
+	}
+}

--- a/app/session_export.go
+++ b/app/session_export.go
@@ -1,0 +1,38 @@
+package main
+
+import "fmt"
+
+// exportConsentedSessions is the single consent gate for online session
+// handling. Keeping it outside the Windows implementation makes the policy
+// testable and ensures a future platform cannot accidentally export by
+// default.
+func exportConsentedSessions(candidates []SessionCandidate, consent map[string]bool, secret string) []SessionExport {
+	results := make([]SessionExport, 0, len(candidates))
+	for _, candidate := range candidates {
+		result := SessionExport{App: candidate.App, State: "skipped"}
+		switch {
+		case !candidate.ConsentRequired:
+			result.Reason = "app is not eligible for token migration"
+		case !consent[candidate.App]:
+			result.Reason = "user did not opt in"
+		default:
+			if err := exportSession(candidate.App, secret, true); err != nil {
+				result.State = "failed"
+				result.Reason = err.Error()
+			} else {
+				result.State = "staged"
+				result.Reason = "protected envelope staged; Linux app import still required"
+			}
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func sessionExportSummary(results []SessionExport) string {
+	data, err := marshalJSON(results)
+	if err != nil {
+		return fmt.Sprintf("[] /* failed to serialize session export summary: %v */", err)
+	}
+	return string(data)
+}

--- a/app/session_windows.go
+++ b/app/session_windows.go
@@ -20,16 +20,6 @@ import (
 // be decrypted. We decrypt the app master key and stage it (re-wrapped)
 // for the target, gated by per-app consent from the caller.
 
-// SessionCandidate is a per-app finding surfaced to the GUI so the user
-// can consent (or not) to moving its login.
-type SessionCandidate struct {
-	App        string `json:"app"`
-	Kind       string `json:"kind"`       // "chromium" | "plainfile"
-	Portable   bool   `json:"portable"`   // decryptable here?
-	Recommend  string `json:"recommend"`  // "copy" | "relink" | "signin"
-	Note       string `json:"note"`
-}
-
 // chromiumApps maps an app to its Windows User-Data root (relative to the
 // profile). safeStorage layout is identical across Chromium/Electron apps.
 var chromiumApps = map[string]string{
@@ -85,6 +75,7 @@ func collectSessions() ([]SessionCandidate, error) {
 		}
 		cands = append(cands, SessionCandidate{
 			App: app, Kind: "chromium", Portable: portable, Recommend: rec, Note: note,
+			ConsentRequired: portable && rec == "copy",
 		})
 	}
 
@@ -95,6 +86,77 @@ func collectSessions() ([]SessionCandidate, error) {
 	data, _ := marshalJSON(cands)
 	_ = os.WriteFile(filepath.Join(slurpDir, "candidates.json"), data, 0o600)
 	return cands, nil
+}
+
+func sessionCandidates() ([]SessionCandidate, error) {
+	return collectSessions()
+}
+
+// exportSession performs only the Windows-online half of migration. It is
+// intentionally impossible to call without explicit consent and a vault
+// secret held in memory by the install pipeline. Discord and Slack remain
+// relink-only even if their DPAPI key is readable.
+func exportSession(app, vaultSecret string, consent bool) error {
+	if !consent {
+		return fmt.Errorf("session export for %s requires explicit consent", app)
+	}
+	if app == "discord" || app == "slack" {
+		return fmt.Errorf("%s sessions are relink-only", app)
+	}
+	rel, ok := chromiumApps[app]
+	if !ok {
+		return fmt.Errorf("unsupported session app %q", app)
+	}
+	profile := os.Getenv("USERPROFILE")
+	if profile == "" {
+		return fmt.Errorf("USERPROFILE not set")
+	}
+	root := filepath.Join(profile, rel)
+	key, err := chromiumMasterKey(root)
+	if err != nil {
+		return err
+	}
+	data, err := sealSessionKey(app, key, vaultSecret)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(wootcDir(), "install", "slurp", "session")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, app+".enc")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("stage %s session: %w", app, err)
+	}
+	if err := restrictFileACL(path); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("restrict %s session: %w", app, err)
+	}
+	return nil
+}
+
+func chromiumMasterKey(userDataRoot string) ([]byte, error) {
+	raw, err := os.ReadFile(filepath.Join(userDataRoot, "Local State"))
+	if err != nil {
+		return nil, fmt.Errorf("read Chromium Local State: %w", err)
+	}
+	var parsed struct {
+		OSCrypt struct {
+			EncryptedKey string `json:"encrypted_key"`
+		} `json:"os_crypt"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil || parsed.OSCrypt.EncryptedKey == "" {
+		return nil, fmt.Errorf("Chromium Local State has no encrypted key")
+	}
+	keyBlob, err := base64.StdEncoding.DecodeString(parsed.OSCrypt.EncryptedKey)
+	if err != nil || !strings.HasPrefix(string(keyBlob), "DPAPI") {
+		return nil, fmt.Errorf("Chromium key is not a DPAPI key")
+	}
+	key, err := dpapiUnprotect(keyBlob[5:])
+	if err != nil {
+		return nil, fmt.Errorf("DPAPI decrypt Chromium key: %w", err)
+	}
+	return key, nil
 }
 
 // chromiumKeyDecryptable checks that Local State holds a DPAPI-encrypted
@@ -114,12 +176,6 @@ func chromiumKeyDecryptable(userDataRoot string) bool {
 	if err := json.Unmarshal(raw, &parsed); err != nil || parsed.OSCrypt.EncryptedKey == "" {
 		return false
 	}
-	keyBlob, err := base64.StdEncoding.DecodeString(parsed.OSCrypt.EncryptedKey)
-	if err != nil || !strings.HasPrefix(string(keyBlob), "DPAPI") {
-		return false
-	}
-	if _, err := dpapiUnprotect(keyBlob[5:]); err != nil {
-		return false
-	}
-	return true
+	_, err = chromiumMasterKey(userDataRoot)
+	return err == nil
 }

--- a/docs/session-migration.md
+++ b/docs/session-migration.md
@@ -47,7 +47,8 @@ contract. `collectSessions` writes only decryptability findings. The install
 configuration's `sessionConsent` map is opt-in per app; missing and false
 entries do nothing. For a consented Chrome, Edge, or Spotify entry, the
 installer decrypts the DPAPI-protected Chromium master key while the user is
-online and writes `install/slurp/session/<app>.enc`.
+online and writes `install/slurp/session/<app>.enc`. It also writes an
+`exports.json` ledger whose state is `staged`, never `imported`.
 
 That file is an authenticated AES-256-GCM envelope. Its key is derived with
 HKDF-SHA256 from the Linux vault secret and a random per-envelope salt; the
@@ -61,6 +62,10 @@ app's SQLite/LevelDB values, and re-encrypt them with the Linux keyring. That
 work is deliberately separate because Chrome, Edge, and Spotify differ in
 database layout and token invalidation behavior. Discord and Slack remain
 re-link-only even when DPAPI can read their key.
+
+Until that consumer completes and records `imported`, the dashboard must show
+re-link/sign-in guidance rather than a signed-in result. A staged key is an
+implementation artifact, not evidence that a token transplant succeeded.
 
 **Phone-linked apps → guided re-link, not token theft.** Signal, WhatsApp,
 and (when token copy is declined) any messenger: the safest, most durable

--- a/docs/session-migration.md
+++ b/docs/session-migration.md
@@ -40,6 +40,28 @@ app** — this is moving auth tokens, so the dashboard asks first and
 defaults off. (Implemented incrementally; the collector scaffolding lands
 here, per-app LevelDB rewriting is the follow-up.)
 
+### Online rewrap contract
+
+The Windows installer now has the first complete, testable half of that
+contract. `collectSessions` writes only decryptability findings. The install
+configuration's `sessionConsent` map is opt-in per app; missing and false
+entries do nothing. For a consented Chrome, Edge, or Spotify entry, the
+installer decrypts the DPAPI-protected Chromium master key while the user is
+online and writes `install/slurp/session/<app>.enc`.
+
+That file is an authenticated AES-256-GCM envelope. Its key is derived with
+HKDF-SHA256 from the Linux vault secret and a random per-envelope salt; the
+DPAPI key is never written in clear. The app name is authenticated as
+associated data, so an envelope cannot be relabeled for another app. Files
+are created with mode `0600` and the export is best-effort: a failed export
+does not fail installation or claim that the session moved.
+
+The target-side consumer still must decrypt the envelope, enumerate the
+app's SQLite/LevelDB values, and re-encrypt them with the Linux keyring. That
+work is deliberately separate because Chrome, Edge, and Spotify differ in
+database layout and token invalidation behavior. Discord and Slack remain
+re-link-only even when DPAPI can read their key.
+
 **Phone-linked apps → guided re-link, not token theft.** Signal, WhatsApp,
 and (when token copy is declined) any messenger: the safest, most durable
 path is the app's own "link a device" flow. The dashboard shows the exact

--- a/tests/gui/mock-backend.js
+++ b/tests/gui/mock-backend.js
@@ -35,6 +35,7 @@ function makeApp(mock) {
     Reboot: () => P(),
     Uninstall: () => P(),
     GetMigrationCategories: () => P(mock.categories || []),
+    GetSessionCandidates: () => P(mock.sessionCandidates || []),
     GetAppMigrations: () => P(mock.apps || []),
     GetOfficeMigration: () => P(mock.office || { present: false }),
     ConvertCategory: () => P(),


### PR DESCRIPTION
Closes #1\n\nImplements the Windows-online, consent-gated DPAPI rewrap half of Chromium/Electron session migration.\n\n- detects DPAPI-decryptable Chromium profiles without staging secrets\n- adds default-off per-app consent controls for Chrome, Edge, and Spotify\n- keeps Discord and Slack relink-only\n- seals the recovered Chromium master key in an authenticated AES-256-GCM envelope derived from the vault secret via HKDF-SHA256\n- stages envelopes with restrictive permissions and removes them if ACL hardening fails\n- exposes session findings to the installer UI and documents the transport contract\n\nValidation:\n- `go test ./...` (with a temporary ignored embed placeholder because frontend/dist is generated and absent in this checkout)\n- `go test session_crypto.go session_crypto_test.go`\n- Windows amd64 compile via `GOOS=windows GOARCH=amd64 go test -c`\n- `node --check frontend/src/main.js`\n\nThe target-side SQLite/LevelDB value rewrite and real Chrome/Edge/Spotify transplant matrix remain intentionally unclaimed follow-up work; this PR never claims a session moved merely because the DPAPI key was readable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789110263&installation_model_id=429180&pr_number=125&repository=tuna-os%2Fwootc&return_to=https%3A%2F%2Fgithub.com%2Ftuna-os%2Fwootc%2Fpull%2F125&signature=38a5d9006676190bc489e9cc4cc35451e558da7492ba4eb03a8627f152230592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->