### PR TITLE
feat(migration): add guided phone re-link flows for Signal, WhatsApp, and Telegram (#2)

### DIFF
--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -870,6 +870,7 @@ const APP_ICONS = {
 const SESSION_BADGE = {
   portable: { label: '✓ Signed in', cls: 'ok' },
   signin:   { label: 'Sign in once', cls: '' },
+  relink:   { label: 'Re-link needed (2 steps)', cls: '' },
   none:     { label: 'Re-link needed', cls: '' },
 };
 
@@ -877,15 +878,85 @@ function renderAppRow(a) {
   const row = el('div');
   row.style.cssText = 'display:flex;align-items:center;gap:12px;background:var(--bg-card);border:1.5px solid var(--border);border-radius:8px;padding:10px 16px';
   const badge = SESSION_BADGE[a.session] || SESSION_BADGE.signin;
-  row.innerHTML = `
+  
+  const left = el('div');
+  left.style.cssText = 'display:flex;align-items:center;gap:12px;flex:1;min-width:0';
+  left.innerHTML = `
     <span style="font-size:18px">${APP_ICONS[a.app] || '📦'}</span>
     <div style="flex:1;min-width:0">
       <div style="font-weight:600;font-size:13px;text-transform:capitalize">${a.app}</div>
       <div style="font-size:11.5px;color:var(--text-muted);margin-top:1px">${a.note || ''}</div>
     </div>
-    <span class="chip ${badge.cls}" style="flex-shrink:0">${badge.label}</span>
   `;
+  row.appendChild(left);
+
+  if (a.session === 'relink') {
+    const relinkBtn = btn('Re-link Guide', 'btn btn-ghost', () => openRelinkModal(a));
+    relinkBtn.style.fontSize = '12px';
+    relinkBtn.style.flexShrink = '0';
+    row.appendChild(relinkBtn);
+  }
+  
+  const chipSpan = el('span', `chip ${badge.cls}`);
+  chipSpan.style.flexShrink = '0';
+  chipSpan.textContent = badge.label;
+  row.appendChild(chipSpan);
   return row;
+}
+
+function openRelinkModal(a) {
+  const modal = el('div');
+  modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;z-index:1000;padding:20px';
+  const content = el('div');
+  content.style.cssText = 'background:var(--bg-card);border:1.5px solid var(--border);border-radius:12px;padding:20px;max-width:480px;width:100%;box-shadow:0 10px 25px rgba(0,0,0,0.5)';
+  
+  let title = 'Re-link Phone App';
+  let stepsHtml = '';
+
+  if (a.app === 'signal') {
+    title = 'Signal: Phone Re-link Steps';
+    stepsHtml = `
+      <ol style="margin:12px 0;padding-left:20px;font-size:13px;color:var(--text-dim);display:flex;flex-direction:column;gap:8px">
+        <li>Open Signal on your phone.</li>
+        <li>Go to <strong>Settings → Linked Devices</strong>.</li>
+        <li>Tap <strong>Link New Device</strong> and scan the QR code displayed in Signal Desktop.</li>
+      </ol>
+      <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">Note: Message history stays on your phone by design.</div>
+    `;
+  } else if (a.app === 'whatsapp') {
+    title = 'WhatsApp: Web Re-link Steps';
+    stepsHtml = `
+      <ol style="margin:12px 0;padding-left:20px;font-size:13px;color:var(--text-dim);display:flex;flex-direction:column;gap:8px">
+        <li>Open <strong>web.whatsapp.com</strong> in your browser.</li>
+        <li>Open WhatsApp on your phone and go to <strong>Settings → Linked Devices</strong>.</li>
+        <li>Tap <strong>Link a Device</strong> and scan the QR code on screen.</li>
+      </ol>
+    `;
+  } else if (a.app === 'telegram') {
+    title = 'Telegram: Re-link / Fallback Steps';
+    stepsHtml = `
+      <ol style="margin:12px 0;padding-left:20px;font-size:13px;color:var(--text-dim);display:flex;flex-direction:column;gap:8px">
+        <li>Open Telegram Desktop on Linux.</li>
+        <li>Scan the displayed QR code using Telegram on your phone (<strong>Settings → Devices → Link Desktop Device</strong>).</li>
+        <li>Alternatively, enter your phone number to receive a login code.</li>
+      </ol>
+    `;
+  } else {
+    stepsHtml = `<div style="font-size:13px;color:var(--text-dim);margin:12px 0">${a.note || 'Follow phone app settings to link device.'}</div>`;
+  }
+
+  content.innerHTML = `
+    <div style="font-weight:600;font-size:16px;margin-bottom:8px">${title}</div>
+    ${stepsHtml}
+  `;
+
+  const footer = el('div');
+  footer.style.cssText = 'display:flex;justify-content:flex-end;margin-top:16px';
+  const closeBtn = btn('Done', 'btn btn-primary', () => document.body.removeChild(modal));
+  footer.appendChild(closeBtn);
+  content.appendChild(footer);
+  modal.appendChild(content);
+  document.body.appendChild(modal);
 }
 
 function migrateAction(c) {

--- a/payload/migration/wootc-detect-apps
+++ b/payload/migration/wootc-detect-apps
@@ -104,12 +104,12 @@ if [[ -d "$TG" ]]; then
         add telegram org.telegram.desktop portable true \
             "Your session and chats moved — Telegram opens signed in."
     else
-        add telegram org.telegram.desktop portable false "Linux Telegram already has data; not overwritten."
+        add telegram org.telegram.desktop relink false \
+            "Linux Telegram already exists. Scan the QR code or enter phone code to link."
     fi
 fi
 
-# Signal Desktop — portable ONLY if the db key is still plaintext in
-# config.json (older installs). New installs DPAPI-encrypt it.
+# Signal Desktop — phone-linked app; guided re-link flow.
 SG="$W/AppData/Roaming/Signal"
 if [[ -d "$SG" ]]; then
     if [[ -f "$SG/config.json" ]] && grep -q '"key"' "$SG/config.json" && ! grep -q 'encryptedKey' "$SG/config.json"; then
@@ -120,15 +120,15 @@ if [[ -d "$SG" ]]; then
             add signal org.signal.Signal portable true "Message history moved (legacy key format)."
         fi
     else
-        add signal org.signal.Signal signin false \
-            "Signal locks its database to Windows. Re-link with your phone (Settings > Linked Devices); history stays on the phone."
+        add signal org.signal.Signal relink false \
+            "Signal locks database to Windows. Re-link with your phone: Settings > Linked Devices > Scan QR."
     fi
 fi
 
-# WhatsApp — Store/UWP app; no official Linux client.
+# WhatsApp — Store/UWP app; guided web re-link flow.
 [[ -d "$W/AppData/Local/Packages" ]] && ls "$W/AppData/Local/Packages" 2>/dev/null | grep -qi whatsapp && \
-    add whatsapp "" signin false \
-        "No official Linux app. Use web.whatsapp.com — scan the QR with your phone and chats appear."
+    add whatsapp "" relink false \
+        "No official Linux app. Open web.whatsapp.com and scan the QR with Linked Devices."
 
 # Thunderbird — profiles are portable like Firefox's.
 TB="$W/AppData/Roaming/Thunderbird"


### PR DESCRIPTION
Resolves #2.

### Summary
- Added phone-linked application session migration re-link flows for Signal, WhatsApp, and Telegram in `payload/migration/wootc-detect-apps` and the migration dashboard (`app/frontend/src/main.js`).
- Implemented step-by-step re-link guidance modals detailing phone device linking steps (Settings → Linked Devices → Scan QR code).
- Updated per-app dashboard status chips (`✓ Signed in`, `Re-link needed (2 steps)`, `Sign in once`).
- Verified syntax checks (`node --check app/frontend/src/main.js` and `go test ./app/...`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->