### PR TITLE
migration: front bridges with outcomes and controls

### DIFF
--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -1,5 +1,5 @@
 import '../src/style.css';
-import { GetImages, GetSystemInfo, StartInstall, CancelInstall, GetStatus, Reboot, ExistingInstallFound, GetMode, GetMigrationCategories, ConvertCategory, ImportBrowserData, GetAppMigrations, GetOfficeMigration, GetBranding, CreateDataPartition, GetUninstallInfo, UninstallWith, GetVMCapability, BootInVM, DefragDrive, GetFreshVMCapability, TryInVMFresh, InstallPreviewForReal, E2EDriveDirective, E2EDriveReport, GetSupportPolicy } from '../wailsjs/go/main/App';
+import { GetImages, GetSystemInfo, StartInstall, CancelInstall, GetStatus, Reboot, ExistingInstallFound, GetMode, GetMigrationCategories, ConvertCategory, ImportBrowserData, GetAppMigrations, GetOfficeMigration, SetSessionConsent, ReinstallApps, GetMigrationProfile, SetMigrationProfile, GetLookMigration, GetBranding, CreateDataPartition, GetUninstallInfo, UninstallWith, GetVMCapability, BootInVM, DefragDrive, GetFreshVMCapability, TryInVMFresh, InstallPreviewForReal, E2EDriveDirective, E2EDriveReport, GetSupportPolicy } from '../wailsjs/go/main/App';
 import { EventsOn } from '../wailsjs/runtime/runtime';
 import { fmtSize } from './lib/format.js';
 import { el, btn, chip, warningBanner, inputField } from './lib/ui.js';
@@ -15,6 +15,8 @@ const state = {
   categories: [],      // migration dashboard rows
   apps: [],            // detected app migrations
   office: null,        // MS Office → LibreOffice summary
+  migrationProfile: null,
+  look: null,
   converting: {},      // category id → percent while a conversion runs
   selected: null,      // selected Image
   config: {
@@ -155,14 +157,18 @@ async function init() {
 
 async function refreshCategories() {
   try {
-    const [cats, apps, office] = await Promise.all([
-      GetMigrationCategories(),
+    const [cats, apps, office, profile, look] = await Promise.all([
+      GetMigrationCategories().catch(() => []),
       GetAppMigrations().catch(() => []),
       GetOfficeMigration().catch(() => null),
+      GetMigrationProfile().catch(() => null),
+      GetLookMigration().catch(() => null),
     ]);
     state.categories = cats || [];
     state.apps = apps || [];
     state.office = office && office.present ? office : null;
+    state.migrationProfile = profile;
+    state.look = look;
   } catch (e) {
     console.error(e);
     state.categories = [];
@@ -785,7 +791,60 @@ function renderMigrateScreen() {
     al.style.cssText = 'display:flex;flex-direction:column;gap:8px';
     state.apps.forEach(a => al.appendChild(renderAppRow(a)));
     appsSection.appendChild(al);
+    const reinstall = btn('Reinstall detected apps', 'btn btn-ghost', async () => {
+      reinstall.disabled = true;
+      reinstall.textContent = 'Installing…';
+      try {
+        await ReinstallApps();
+        alert('The detected Flatpak apps were installed. App data and credentials were not copied.');
+      } catch (e) {
+        alert('Could not reinstall detected apps: ' + e);
+      } finally {
+        reinstall.disabled = false;
+        reinstall.textContent = 'Reinstall detected apps';
+      }
+    });
+    reinstall.style.cssText = 'font-size:12px;margin-top:8px';
+    appsSection.appendChild(reinstall);
     scroll.appendChild(appsSection);
+  }
+
+  if (state.migrationProfile) {
+    const profile = el('div');
+    profile.appendChild(sectionLabel('Windows profile mapping'));
+    const card = el('div');
+    card.style.cssText = 'background:var(--bg-card);border:1.5px solid var(--border);border-radius:8px;padding:12px 16px;display:flex;align-items:center;gap:10px';
+    const copy = el('div');
+    copy.style.flex = '1';
+    copy.innerHTML = `<div style="font-size:12.5px;font-weight:600">Linux <code>${state.migrationProfile.linuxUser || 'unknown'}</code> → Windows <code>${state.migrationProfile.windowsProfile || 'not mapped'}</code></div><div style="font-size:11.5px;color:var(--text-muted);margin-top:3px">${state.migrationProfile.note || ''}</div>`;
+    card.appendChild(copy);
+    const choose = btn('Choose', 'btn btn-ghost', async () => {
+      const value = prompt('Windows profile folder name:', state.migrationProfile.windowsProfile || '');
+      if (!value) return;
+      try { await SetMigrationProfile(value.trim()); await refreshCategories(); }
+      catch (e) { alert('Could not map that Windows profile: ' + e); }
+    });
+    choose.style.fontSize = '12px';
+    card.appendChild(choose);
+    profile.appendChild(card);
+    scroll.appendChild(profile);
+  }
+
+  if (state.look) {
+    const look = el('div');
+    look.appendChild(sectionLabel('Windows look'));
+    const card = el('div');
+    card.style.cssText = 'background:var(--bg-card);border:1.5px solid var(--border);border-radius:8px;padding:12px 16px';
+    const status = state.look.applied ? '✓ Applied to this Linux user' : state.look.available ? 'Ready to apply on first login' : 'Not collected';
+    card.innerHTML = `<div style="font-size:12.5px;font-weight:600">${status}</div><div style="font-size:11.5px;color:var(--text-muted);margin-top:3px">${state.look.note || ''}</div>`;
+    if (state.look.items?.length) {
+      const items = el('div');
+      items.style.cssText = 'display:flex;gap:6px;flex-wrap:wrap;margin-top:8px';
+      state.look.items.forEach(item => items.appendChild(chip(item, false)));
+      card.appendChild(items);
+    }
+    look.appendChild(card);
+    scroll.appendChild(look);
   }
 
   if (state.office) {
@@ -890,13 +949,31 @@ function renderAppRow(a) {
   `;
   row.appendChild(left);
 
+  if (a.consentAvailable) {
+    const consent = el('label');
+    consent.style.cssText = 'display:flex;align-items:center;gap:5px;font-size:11px;color:var(--text-muted);flex-shrink:0';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = !!a.consent;
+    checkbox.title = 'Allow session token copy when the Windows-online exporter supports this app';
+    checkbox.onchange = async () => {
+      checkbox.disabled = true;
+      try { await SetSessionConsent(a.app, checkbox.checked); a.consent = checkbox.checked; }
+      catch (e) { checkbox.checked = !checkbox.checked; alert('Could not save session consent: ' + e); }
+      finally { checkbox.disabled = false; }
+    };
+    consent.appendChild(checkbox);
+    consent.appendChild(document.createTextNode('Allow session copy'));
+    row.appendChild(consent);
+  }
+
   if (a.session === 'relink') {
     const relinkBtn = btn('Re-link Guide', 'btn btn-ghost', () => openRelinkModal(a));
     relinkBtn.style.fontSize = '12px';
     relinkBtn.style.flexShrink = '0';
     row.appendChild(relinkBtn);
   }
-  
+
   const chipSpan = el('span', `chip ${badge.cls}`);
   chipSpan.style.flexShrink = '0';
   chipSpan.textContent = badge.label;

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -155,14 +155,26 @@ async function init() {
   render();
 }
 
+// A missing Wails binding makes its generated wrapper throw synchronously, so
+// a plain `.catch()` on the call never runs and one absent optional method
+// would blank the whole dashboard. Degrade that section instead.
+async function optional(call, fallback) {
+  try {
+    return (await call()) ?? fallback;
+  } catch (e) {
+    console.error(e);
+    return fallback;
+  }
+}
+
 async function refreshCategories() {
   try {
     const [cats, apps, office, profile, look] = await Promise.all([
-      GetMigrationCategories().catch(() => []),
-      GetAppMigrations().catch(() => []),
-      GetOfficeMigration().catch(() => null),
-      GetMigrationProfile().catch(() => null),
-      GetLookMigration().catch(() => null),
+      optional(GetMigrationCategories, []),
+      optional(GetAppMigrations, []),
+      optional(GetOfficeMigration, null),
+      optional(GetMigrationProfile, null),
+      optional(GetLookMigration, null),
     ]);
     state.categories = cats || [];
     state.apps = apps || [];

--- a/app/frontend/wailsjs/go/main/App.d.ts
+++ b/app/frontend/wailsjs/go/main/App.d.ts
@@ -57,10 +57,41 @@ export interface BridgeCategory {
   reversible: boolean;
 }
 
+export interface AppMigration {
+  app: string;
+  flatpak: string;
+  session: 'portable' | 'signin' | 'relink' | 'none';
+  copied: boolean;
+  note: string;
+  consentAvailable: boolean;
+  consent: boolean;
+}
+
+export interface MigrationProfile {
+  linuxUser: string;
+  windowsProfile: string;
+  matched: boolean;
+  note: string;
+}
+
+export interface LookMigration {
+  available: boolean;
+  applied: boolean;
+  items: string[];
+  note: string;
+}
+
 export function GetMode(): Promise<'installer' | 'migration'>;
 export function GetMigrationCategories(): Promise<BridgeCategory[]>;
 export function ConvertCategory(id: string): Promise<void>;
 export function ImportBrowserData(): Promise<string>;
+export function GetAppMigrations(): Promise<AppMigration[]>;
+export function GetOfficeMigration(): Promise<any>;
+export function SetSessionConsent(app: string, consent: boolean): Promise<void>;
+export function ReinstallApps(): Promise<void>;
+export function GetMigrationProfile(): Promise<MigrationProfile>;
+export function SetMigrationProfile(profile: string): Promise<void>;
+export function GetLookMigration(): Promise<LookMigration>;
 export function GetImages(): Promise<Image[]>;
 export function GetSystemInfo(): Promise<SystemInfo>;
 export function StartInstall(cfg: InstallConfig): Promise<void>;

--- a/app/frontend/wailsjs/go/main/App.js
+++ b/app/frontend/wailsjs/go/main/App.js
@@ -99,6 +99,26 @@ export function GetOfficeMigration() {
   return window['go']['main']['App']['GetOfficeMigration']();
 }
 
+export function SetSessionConsent(arg1, arg2) {
+  return window['go']['main']['App']['SetSessionConsent'](arg1, arg2);
+}
+
+export function ReinstallApps() {
+  return window['go']['main']['App']['ReinstallApps']();
+}
+
+export function GetMigrationProfile() {
+  return window['go']['main']['App']['GetMigrationProfile']();
+}
+
+export function SetMigrationProfile(arg1) {
+  return window['go']['main']['App']['SetMigrationProfile'](arg1);
+}
+
+export function GetLookMigration() {
+  return window['go']['main']['App']['GetLookMigration']();
+}
+
 export function E2EDriveDirective() {
   return window['go']['main']['App']['E2EDriveDirective']();
 }

--- a/app/migration.go
+++ b/app/migration.go
@@ -55,17 +55,58 @@ func (a *App) ImportBrowserData() (string, error) {
 // AppMigration is one detected Windows application and the honest outcome
 // of migrating it (docs/session-migration.md).
 type AppMigration struct {
-	App     string `json:"app"`
-	Flatpak string `json:"flatpak"`
-	Session string `json:"session"` // portable | signin | none
-	Copied  bool   `json:"copied"`
-	Note    string `json:"note"`
+	App              string `json:"app"`
+	Flatpak          string `json:"flatpak"`
+	Session          string `json:"session"` // portable | signin | relink | none
+	Copied           bool   `json:"copied"`
+	Note             string `json:"note"`
+	ConsentAvailable bool   `json:"consentAvailable"`
+	Consent          bool   `json:"consent"`
 }
 
 // GetAppMigrations returns the per-app migration outcomes recorded by
 // wootc-detect-apps (bridge-apps.json).
 func (a *App) GetAppMigrations() ([]AppMigration, error) {
 	return appMigrations()
+}
+
+// SetSessionConsent records the user's explicit per-app choice. It does not
+// copy a token by itself; the Windows-online exporter consumes the same
+// decision when a supported install is staged.
+func (a *App) SetSessionConsent(app string, consent bool) error {
+	return setSessionConsent(app, consent)
+}
+
+// ReinstallApps installs the detected Flatpak counterparts without copying
+// their credentials or application data.
+func (a *App) ReinstallApps() error {
+	return reinstallApps()
+}
+
+type MigrationProfile struct {
+	LinuxUser      string `json:"linuxUser"`
+	WindowsProfile string `json:"windowsProfile"`
+	Matched        bool   `json:"matched"`
+	Note           string `json:"note"`
+}
+
+func (a *App) GetMigrationProfile() (MigrationProfile, error) {
+	return migrationProfile()
+}
+
+func (a *App) SetMigrationProfile(profile string) error {
+	return setMigrationProfile(profile)
+}
+
+type LookMigration struct {
+	Available bool     `json:"available"`
+	Applied   bool     `json:"applied"`
+	Items     []string `json:"items"`
+	Note      string   `json:"note"`
+}
+
+func (a *App) GetLookMigration() (LookMigration, error) {
+	return lookMigration()
 }
 
 // OfficeMigration summarizes what moved from MS Office to LibreOffice.

--- a/app/migration_linux.go
+++ b/app/migration_linux.go
@@ -22,6 +22,10 @@ import (
 
 var bridgeFolders = []string{"Documents", "Pictures", "Downloads", "Music", "Videos", "Desktop"}
 
+var tokenConsentApps = map[string]bool{
+	"chrome": true, "edge": true, "spotify": true,
+}
+
 func detectMode() string {
 	if isMounted("/run/wootc/host") {
 		return "migration"
@@ -46,7 +50,10 @@ func migrationCategories() ([]BridgeCategory, error) {
 	if err != nil {
 		return nil, err
 	}
-	winProfile := filepath.Join("/run/wootc/host/Users", u.Username)
+	winProfile, _, err := resolvedWindowsProfile(u)
+	if err != nil {
+		return nil, err
+	}
 	stateDir := filepath.Join(u.HomeDir, ".config", "wootc")
 
 	var cats []BridgeCategory
@@ -193,7 +200,98 @@ func appMigrations() ([]AppMigration, error) {
 	if err := unmarshalJSON(data, &parsed); err != nil {
 		return nil, err
 	}
+	consents := readSessionConsents(filepath.Join(u.HomeDir, ".config", "wootc", "session-consent.json"))
+	for i := range parsed.Apps {
+		parsed.Apps[i].ConsentAvailable = tokenConsentApps[parsed.Apps[i].App] && parsed.Apps[i].Session == "signin"
+		parsed.Apps[i].Consent = parsed.Apps[i].ConsentAvailable && consents[parsed.Apps[i].App]
+	}
 	return parsed.Apps, nil
+}
+
+func setSessionConsent(app string, consent bool) error {
+	u, err := currentUser()
+	if err != nil {
+		return err
+	}
+	apps, err := appMigrations()
+	if err != nil {
+		return err
+	}
+	allowed := false
+	for _, item := range apps {
+		if item.App == app && item.ConsentAvailable {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("session consent is not available for %q", app)
+	}
+	path := filepath.Join(u.HomeDir, ".config", "wootc", "session-consent.json")
+	consents := readSessionConsents(path)
+	if consent {
+		consents[app] = true
+	} else {
+		delete(consents, app)
+	}
+	return marshalJSONToFile(path, consents)
+}
+
+func readSessionConsents(path string) map[string]bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]bool{}
+	}
+	var consents map[string]bool
+	if unmarshalJSON(data, &consents) != nil || consents == nil {
+		return map[string]bool{}
+	}
+	return consents
+}
+
+func reinstallApps() error {
+	u, err := currentUser()
+	if err != nil {
+		return err
+	}
+	apps, err := appMigrations()
+	if err != nil {
+		return err
+	}
+	ids := make([]string, 0, len(apps))
+	seen := map[string]bool{}
+	for _, app := range apps {
+		if app.Flatpak == "" || seen[app.Flatpak] || !validFlatpakID(app.Flatpak) {
+			continue
+		}
+		seen[app.Flatpak] = true
+		ids = append(ids, app.Flatpak)
+	}
+	if len(ids) == 0 {
+		return fmt.Errorf("no reinstallable Flatpak apps were detected")
+	}
+	args := append([]string{"install", "--user", "-y", "flathub"}, ids...)
+	cmd := exec.Command("flatpak", args...)
+	cmd.Dir = u.HomeDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("flatpak install: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func validFlatpakID(id string) bool {
+	if id == "" {
+		return false
+	}
+	if strings.Contains(id, "..") || id[0] == '.' || id[len(id)-1] == '.' {
+		return false
+	}
+	for _, r := range id {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '.' && r != '-' && r != '_' {
+			return false
+		}
+	}
+	return strings.Contains(id, ".")
 }
 
 func officeMigration() (OfficeMigration, error) {
@@ -218,11 +316,126 @@ func importBrowserData() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	out, err := exec.Command("/var/usrlocal/bin/wootc-import-browser", u.Username).CombinedOutput()
+	_, winProfile, err := resolvedWindowsProfile(u)
+	if err != nil {
+		return "", err
+	}
+	out, err := exec.Command("/var/usrlocal/bin/wootc-import-browser", winProfile, u.Username).CombinedOutput()
 	if err != nil {
 		return string(out), fmt.Errorf("browser import: %w", err)
 	}
 	return string(out), nil
+}
+
+func migrationProfile() (MigrationProfile, error) {
+	u, err := currentUser()
+	if err != nil {
+		return MigrationProfile{}, err
+	}
+	_, profile, resolveErr := resolvedWindowsProfile(u)
+	if resolveErr != nil {
+		return MigrationProfile{LinuxUser: u.Username, Note: resolveErr.Error()}, nil
+	}
+	matched := strings.EqualFold(profile, u.Username)
+	note := "Windows profile is mapped automatically."
+	if !matched {
+		note = "Linux and Windows names differ; this profile is being used for the bridges."
+	}
+	return MigrationProfile{LinuxUser: u.Username, WindowsProfile: profile, Matched: matched, Note: note}, nil
+}
+
+func setMigrationProfile(profile string) error {
+	u, err := currentUser()
+	if err != nil {
+		return err
+	}
+	root := "/run/wootc/host/Users"
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("list Windows profiles: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && strings.EqualFold(entry.Name(), profile) {
+			path := filepath.Join(u.HomeDir, ".config", "wootc", "profile-map.json")
+			if err := marshalJSONToFile(path, map[string]string{"windowsProfile": entry.Name()}); err != nil {
+				return err
+			}
+			// Re-run the read-only app/Office collectors immediately so the
+			// dashboard reflects the newly selected profile without waiting for
+			// the next bridge-service restart.
+			if _, lookErr := exec.LookPath("wootc-detect-apps"); lookErr == nil {
+				if output, runErr := exec.Command("wootc-detect-apps", entry.Name(), u.Username).CombinedOutput(); runErr != nil {
+					return fmt.Errorf("refresh app bridge: %w: %s", runErr, strings.TrimSpace(string(output)))
+				}
+			}
+			if _, lookErr := exec.LookPath("wootc-office-bridge"); lookErr == nil {
+				if output, runErr := exec.Command("wootc-office-bridge", entry.Name(), u.Username).CombinedOutput(); runErr != nil {
+					return fmt.Errorf("refresh Office bridge: %w: %s", runErr, strings.TrimSpace(string(output)))
+				}
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("Windows profile %q was not found", profile)
+}
+
+func resolvedWindowsProfile(u *user.User) (path, profile string, err error) {
+	root := "/run/wootc/host/Users"
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return "", "", fmt.Errorf("Windows profiles are unavailable: %w", err)
+	}
+	var profiles []string
+	for _, entry := range entries {
+		if entry.IsDir() && entry.Name() != "Public" && entry.Name() != "Default" && entry.Name() != "Default User" && entry.Name() != "All Users" {
+			profiles = append(profiles, entry.Name())
+		}
+	}
+	mapPath := filepath.Join(u.HomeDir, ".config", "wootc", "profile-map.json")
+	var mapping struct {
+		WindowsProfile string `json:"windowsProfile"`
+	}
+	if data, readErr := os.ReadFile(mapPath); readErr == nil && unmarshalJSON(data, &mapping) == nil {
+		for _, candidate := range profiles {
+			if strings.EqualFold(candidate, mapping.WindowsProfile) {
+				return filepath.Join(root, candidate), candidate, nil
+			}
+		}
+	}
+	for _, candidate := range profiles {
+		if strings.EqualFold(candidate, u.Username) {
+			return filepath.Join(root, candidate), candidate, nil
+		}
+	}
+	if len(profiles) == 1 {
+		return filepath.Join(root, profiles[0]), profiles[0], nil
+	}
+	return "", "", fmt.Errorf("could not map Linux user %q to one Windows profile; choose a profile in Migration settings", u.Username)
+}
+
+func lookMigration() (LookMigration, error) {
+	u, err := currentUser()
+	if err != nil {
+		return LookMigration{}, err
+	}
+	path, _, resolveErr := resolvedWindowsProfile(u)
+	if resolveErr != nil {
+		return LookMigration{Note: resolveErr.Error()}, nil
+	}
+	slurp := filepath.Join(path, "..", "..", "wootc", "install", "slurp", "slurp.json")
+	data, err := os.ReadFile(slurp)
+	if err != nil {
+		return LookMigration{Note: "Windows look was not selected during install."}, nil
+	}
+	var raw map[string]any
+	if err := unmarshalJSON(data, &raw); err != nil {
+		return LookMigration{}, err
+	}
+	items := make([]string, 0, len(raw))
+	for key := range raw {
+		items = append(items, key)
+	}
+	return LookMigration{Available: true, Applied: fileExists(filepath.Join(u.HomeDir, ".config", "wootc", "look-applied")), Items: items, Note: "Windows look settings are applied once per Linux user and can be skipped from the migration chooser."}, nil
 }
 
 // ── small fs helpers ─────────────────────────────────────────────────────────

--- a/app/migration_linux_test.go
+++ b/app/migration_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidFlatpakID(t *testing.T) {
+	for _, id := range []string{"org.mozilla.firefox", "com.visualstudio.code"} {
+		if !validFlatpakID(id) {
+			t.Errorf("expected valid Flatpak ID %q", id)
+		}
+	}
+	for _, id := range []string{"", "org/foo", "..", "org.example;rm"} {
+		if validFlatpakID(id) {
+			t.Errorf("expected invalid Flatpak ID %q", id)
+		}
+	}
+}
+
+func TestReadSessionConsentsFailClosed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session-consent.json")
+	if err := os.WriteFile(path, []byte(`{"chrome":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !readSessionConsents(path)["chrome"] {
+		t.Fatal("expected consent to be read")
+	}
+	if got := readSessionConsents(filepath.Join(t.TempDir(), "missing")); len(got) != 0 {
+		t.Fatalf("missing consent file = %#v", got)
+	}
+}

--- a/app/migration_notlinux.go
+++ b/app/migration_notlinux.go
@@ -30,6 +30,26 @@ func appMigrations() ([]AppMigration, error) {
 	return nil, fmt.Errorf("migration dashboard is only available on the installed Linux system")
 }
 
+func setSessionConsent(string, bool) error {
+	return fmt.Errorf("session consent is only available on the installed Linux system")
+}
+
+func reinstallApps() error {
+	return fmt.Errorf("app reinstall is only available on the installed Linux system")
+}
+
+func migrationProfile() (MigrationProfile, error) {
+	return MigrationProfile{}, fmt.Errorf("profile mapping is only available on the installed Linux system")
+}
+
+func setMigrationProfile(string) error {
+	return fmt.Errorf("profile mapping is only available on the installed Linux system")
+}
+
+func lookMigration() (LookMigration, error) {
+	return LookMigration{}, fmt.Errorf("look migration is only available on the installed Linux system")
+}
+
 func officeMigration() (OfficeMigration, error) {
 	return OfficeMigration{}, fmt.Errorf("migration dashboard is only available on the installed Linux system")
 }

--- a/payload/migration/wootc-mount-user-dirs
+++ b/payload/migration/wootc-mount-user-dirs
@@ -317,22 +317,51 @@ fi
 
 # App-data bridge: per-user detection + portable-state copy (best-effort).
 if command -v wootc-detect-apps >/dev/null; then
+    # The Linux account name is not guaranteed to equal the Windows profile
+    # directory. Prefer an explicit dashboard mapping, then an exact match,
+    # then the sole discovered profile. This keeps app and Office bridges on
+    # the same profile mapping as the folder bridge.
+    profile_for_linux() {
+        local linuxuser="$1" home mapped candidate
+        home=$(getent passwd "$linuxuser" | cut -d: -f6)
+        mapped=""
+        if command -v jq >/dev/null && [[ -f "$home/.config/wootc/profile-map.json" ]]; then
+            mapped=$(jq -r '.windowsProfile // empty' "$home/.config/wootc/profile-map.json" 2>/dev/null || true)
+        fi
+        if [[ -n "$mapped" ]]; then
+            for candidate in "${real_profiles[@]}"; do
+                [[ "$(basename "$candidate")" == "$mapped" ]] && { basename "$candidate"; return 0; }
+            done
+        fi
+        for candidate in "${real_profiles[@]}"; do
+            [[ "$(basename "$candidate")" == "$linuxuser" ]] && { basename "$candidate"; return 0; }
+        done
+        if [[ "${#real_profiles[@]}" -eq 1 ]]; then
+            basename "${real_profiles[0]}"
+        fi
+    }
+
     shopt -s nullglob
     for userhome in /home/*/; do
         uname=$(basename "$userhome")
         uid=$(id -u "$uname" 2>/dev/null) || continue
         [[ "$uid" -ge 1000 ]] || continue
-        wootc-detect-apps "$uname" || log "app detection failed for $uname (non-fatal)"
+        winuser=$(profile_for_linux "$uname")
+        if [[ -z "$winuser" ]]; then
+            log "no Windows profile mapped for $uname; skipping app/Office bridge"
+            continue
+        fi
+        wootc-detect-apps "$winuser" "$uname" || log "app detection failed for $winuser → $uname (non-fatal)"
         if command -v wootc-office-bridge >/dev/null; then
             if sel_on "$uname" office; then
-                wootc-office-bridge "$uname" || log "office bridge failed for $uname (non-fatal)"
+                wootc-office-bridge "$winuser" "$uname" || log "office bridge failed for $winuser → $uname (non-fatal)"
             else
                 log "office: skipped for $uname (turned off in the migration chooser)"
             fi
         fi
         # Copy the account picture + full name over (never the password).
         command -v wootc-identity >/dev/null && \
-            { wootc-identity apply "$uname" "$uname" >/dev/null || log "identity copy failed for $uname (non-fatal)"; }
+            { wootc-identity apply "$winuser" "$uname" >/dev/null || log "identity copy failed for $winuser → $uname (non-fatal)"; }
     done
     shopt -u nullglob
 fi

--- a/tests/gui/mock-backend.js
+++ b/tests/gui/mock-backend.js
@@ -37,6 +37,23 @@ function makeApp(mock) {
     GetMigrationCategories: () => P(mock.categories || []),
     GetAppMigrations: () => P(mock.apps || []),
     GetOfficeMigration: () => P(mock.office || { present: false }),
+    // Session consent is a recorded opt-in only — the mock just remembers it.
+    SetSessionConsent: (app, consent) => {
+      const list = mock.apps || [];
+      const hit = list.find((a) => a.app === app);
+      if (hit) hit.consent = consent;
+      return P();
+    },
+    ReinstallApps: () => P(),
+    GetMigrationProfile: () => P(mock.migrationProfile || null),
+    SetMigrationProfile: (profile) => {
+      if (mock.migrationProfile) {
+        mock.migrationProfile.windowsProfile = profile;
+        mock.migrationProfile.matched = true;
+      }
+      return P();
+    },
+    GetLookMigration: () => P(mock.look || null),
     ConvertCategory: () => P(),
     ImportBrowserData: () => P('ok'),
     CreateDataPartition: () => P({ letter: 'D', label: 'wootc-data', freeGB: 60, encrypted: false }),


### PR DESCRIPTION
Closes #3

Fronts the existing migration bridges with an actionable, honest dashboard:

- shows per-app outcome badges, including signed-in, sign-in-once, and relink-needed states
- adds default-off per-app session-copy consent persistence for supported Chromium candidates
- adds a validated Reinstall detected apps action for manifest-listed Flatpaks
- adds an Office bridge summary and Windows-look availability/applied state
- resolves Linux-to-Windows profile mappings by explicit mapping, exact match, or safe single-profile fallback
- lets users choose a profile and immediately refreshes app and Office bridge results
- passes the same mapping into app detection, Office, identity, and browser import helpers

Consent is only a recorded opt-in; the dashboard never copies credentials itself. The Windows-online exporter remains the component responsible for any supported token rewrap.

Validation:
- `go test ./...`
- Windows amd64 compile via `GOOS=windows GOARCH=amd64 go test -c`
- `node --check frontend/src/main.js`
- `bash -n payload/migration/wootc-mount-user-dirs`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->