### PR TITLE
docs(adr): add ADR 0003 for OneDrive Files On-Demand migration (#65)

### DIFF
--- a/docs/adr/0003-onedrive-files-on-demand-migration.md
+++ b/docs/adr/0003-onedrive-files-on-demand-migration.md
@@ -1,0 +1,33 @@
+# ADR 0003: OneDrive Files On-Demand Migration & Hydration Strategy (#65)
+
+## Status
+Approved RFC / Architecture Specification
+
+## Context
+Windows users frequently have user shell folders (Documents, Pictures, Desktop) redirected to **OneDrive** with **Files On-Demand** active, meaning files exist as un-hydrated cloud reparse points (`FILE_ATTRIBUTE_REPARSE_POINT` / `FILE_ATTRIBUTE_OFFLINE`).
+
+---
+
+## 1. Architectural Split: Hydrate in Phase 1, Mount in Phase 2
+
+Migration of OneDrive user folders is strictly partitioned into two independent phases:
+
+| Phase | Timing | Mechanism & Guarantee |
+|---|---|---|
+| **Phase 1: Phase-1 Hydration (Data Survival)** | Online in Windows prior to reboot | Resolves paths via `HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders`. Uses supported Windows shell pin attribute commands (`attrib -U +P /s <folder>`) to hydrate cloud-only files locally while the Windows OneDrive client is authenticated. **Guarantees offline file availability on Linux without needing login credentials.** |
+| **Phase 2: Post-Boot Cloud Integration (Cloud Sync)** | First boot in Linux | Offers optional first-boot cloud sync tools (e.g. `onedriver` FUSE client for native OneDrive UX, `rclone` for multi-provider coverage). **Optional, skippable, and never required for local file access.** |
+
+---
+
+## 2. Consent, Measurement & Capacity Checks
+
+1. **Pre-Flight Measurement**:
+   - `app/clouddrive_windows.go` queries `HKCU\Software\Microsoft\OneDrive\Accounts` to calculate `LocalBytes` and `CloudOnly` sizes.
+2. **Honest Capacity Gate**:
+   - Compares required hydration `CloudOnly` bytes against available space in `root.disk`.
+   - If hydration size exceeds `root.disk` capacity or total disk budget, wootc presents an explicit disclosure screen:
+     - **Option 1**: Hydrate selected folders/subsets.
+     - **Option 2**: Proceed with local-only files (skip un-hydrated cloud files).
+     - **Option 3**: Cancel without altering Windows files or pinning state.
+3. **Idempotency**:
+   - `attrib -U +P` execution is idempotent per file. Hydration progress markers ensure interrupted runs resume quickly without re-scanning fully hydrated files.


### PR DESCRIPTION
Resolves #65.

### Summary
- Added [`docs/adr/0003-onedrive-files-on-demand-migration.md`](file:///home/dev/workspace/tuna-os/wootc/docs/adr/0003-onedrive-files-on-demand-migration.md) specifying the Phase-1 hydration and Phase-2 cloud integration architecture for OneDrive Files On-Demand.
- Defined Phase-1 pin attribute hydration (`attrib -U +P /s`) using live authenticated Windows session state to ensure offline file availability on Linux without credential prompting.
- Formualized pre-flight consent, disk capacity verification against `root.disk`, and hydration idempotency rules.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->