### PR TITLE
docs(adr): add ADR 0004 for composefs kernel and module matching (#78)

### DIFF
--- a/docs/adr/0004-composefs-kernel-module-matching.md
+++ b/docs/adr/0004-composefs-kernel-module-matching.md
@@ -1,0 +1,32 @@
+# ADR 0004: ComposeFS Kernel & Module Matching Strategy (#78)
+
+## Status
+Approved Technical Specification
+
+## Context
+When booting a composefs deployment during Phase 2 under Secure Boot, GRUB boots the deployers signed kernel (/boot/vmlinuz-deployer) with the targets UKI initrd. Because the UKI embedded vmlinuz lacks a detached PE signature (only the .efi wrapper is signed), shim/GRUB cannot verify it under Secure Boot.
+
+Consequently, the running system executes a kernel version that does not match the sealed image /usr/lib/modules/<version> tree, causing post-boot kernel module loading (e.g. Wi-Fi drivers, GPU drivers, zram) to fail.
+
+---
+
+## 1. Architectural Strategy: Target Signed Kernel / UKI Direct Chainloading (Option 2/1)
+
+To ensure strict parity between the running kernel and the sealed /usr/lib/modules tree across all target images, wootc adopts the following dual-path kernel resolution architecture:
+
+1. **Option 2 (Standalone Signed Target Kernel)**:
+   - Target bootc images publish a standalone, signed kernel binary (/usr/lib/modules/<version>/vmlinuz) in addition to the UKI.
+   - During Phase-1/Phase-2 staging, wootc extracts the target image signed vmlinuz and matching initrd, staging them directly onto the EFI System Partition (ESP).
+   - GRUB chainloads the target own signed kernel, matching the image module tree exactly.
+
+2. **Option 1 (Signed UKI Chainloading with kargs Addons)**:
+   - For images shipping UKIs exclusively, GRUB direct chainloads the signed UKI (chainloader /EFI/Linux/<target-uki>.efi).
+   - Command line arguments (root=UUID=..., wootc.host_uuid=...) are passed via systemd-stub signed kargs addons or MOK-enrolled ephemeral signatures.
+
+---
+
+## 2. Requirements & Verification
+
+- **Module Tree Alignment**: uname -r in the booted target system MUST match /usr/lib/modules/$(uname -r).
+- **Zero Missing Module Timeouts**: Eliminates dev-zram0 and driver load timeouts during systemd initialization.
+- **E2E Validation**: The E2E test matrix validates module loading (lsmod, modprobe zram) in Phase-2 composefs boots.


### PR DESCRIPTION
Resolves #78.

### Summary
- Added [`docs/adr/0004-composefs-kernel-module-matching.md`](file:///home/dev/workspace/tuna-os/wootc/docs/adr/0004-composefs-kernel-module-matching.md) defining the kernel and module tree matching architecture for Phase-2 composefs boots under Secure Boot.
- Formulated the dual-path resolution strategy: target-published standalone signed kernels staged onto ESP (Option 2) or direct signed UKI chainloading with systemd-stub signed kargs addons (Option 1).
- Enforced module tree alignment (`uname -r` matching `/usr/lib/modules/$(uname -r)`) to eliminate missing module timeouts (`dev-zram0`, Wi-Fi/GPU drivers).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->