### PR TITLE
migration: add default-on manifest discovery and opt-outs

### DIFF
--- a/payload/migration/wootc-import-browser
+++ b/payload/migration/wootc-import-browser
@@ -43,9 +43,16 @@ fi
 
 imported=()
 
+item_on() {
+    local item="$1" rc=0
+    command -v wootc-selection >/dev/null 2>&1 || return 0
+    wootc-selection "$target" browsers "$item" >/dev/null 2>&1 || rc=$?
+    [[ "$rc" -ne 1 ]]
+}
+
 # ── Firefox: whole-profile copy ─────────────────────────────────────────────
 FF_WIN="$winprofile/AppData/Roaming/Mozilla/Firefox"
-if [[ -f "$FF_WIN/profiles.ini" ]]; then
+if item_on firefox && [[ -f "$FF_WIN/profiles.ini" ]]; then
     # Pick the default profile dir from profiles.ini.
     ffprof=$(awk -F= '/^\[Install/{ins=1} ins&&/^Default=/{print $2; exit}' "$FF_WIN/profiles.ini")
     [[ -z "$ffprof" ]] && ffprof=$(awk -F= '/^Path=/{print $2; exit}' "$FF_WIN/profiles.ini")
@@ -79,6 +86,8 @@ fi
 # ── Chrome + Edge → Linux Chrome: bookmarks & history ──────────────────────
 import_chromium() {
     local src_default="$1" label="$2"
+    local item="${label,,}"
+    item_on "$item" || { log "$label: skipped (turned off in the migration chooser)"; return 0; }
     [[ -d "$src_default" ]] || return 0
     for chrome_linux in \
         "$home/.var/app/com.google.Chrome/config/google-chrome/Default" \

--- a/payload/migration/wootc-manifest
+++ b/payload/migration/wootc-manifest
@@ -46,6 +46,13 @@ def _dir_bytes(path, cap=50000):
     return total
 
 
+def _item(path, item_id, label, detail=""):
+    """Return one stable discovery descriptor without touching its contents."""
+    return {"id": item_id, "label": label, "detail": detail,
+            "fileCount": _count_files(path) if os.path.isdir(path) else 0,
+            "sizeBytes": _dir_bytes(path) if os.path.isdir(path) else 0}
+
+
 def _users():
     base = os.path.join(HOST, "Users")
     if not os.path.isdir(base):
@@ -65,7 +72,7 @@ def cat_files(user):
         p = os.path.join(root, folder)
         if os.path.isdir(p):
             n = _count_files(p)
-            items.append({"id": folder, "label": folder, "detail": f"{n} file(s)"})
+            items.append(_item(p, folder, folder, f"{n} file(s)"))
     return bool(items), items, f"{len(items)} folder(s)"
 
 
@@ -73,13 +80,13 @@ def cat_browsers(user):
     items = []
     ad = os.path.join(HOST, "Users", user, "AppData")
     if os.path.exists(os.path.join(ad, "Roaming", "Mozilla", "Firefox", "profiles.ini")):
-        items.append({"id": "firefox", "label": "Firefox", "detail": "profile + logins"})
+        items.append(_item(os.path.join(ad, "Roaming", "Mozilla", "Firefox"), "firefox", "Firefox", "profile + logins"))
     if os.path.exists(os.path.join(ad, "Local", "Google", "Chrome", "User Data",
                                     "Default", "Bookmarks")):
-        items.append({"id": "chrome", "label": "Chrome", "detail": "bookmarks + history"})
+        items.append(_item(os.path.join(ad, "Local", "Google", "Chrome", "User Data"), "chrome", "Chrome", "bookmarks + history"))
     if os.path.exists(os.path.join(ad, "Local", "Microsoft", "Edge", "User Data",
                                     "Default", "Bookmarks")):
-        items.append({"id": "edge", "label": "Edge", "detail": "bookmarks"})
+        items.append(_item(os.path.join(ad, "Local", "Microsoft", "Edge", "User Data"), "edge", "Edge", "bookmarks + history"))
     return bool(items), items, ", ".join(i["label"] for i in items)
 
 
@@ -87,12 +94,15 @@ def cat_office(user):
     items = []
     ms = os.path.join(HOST, "Users", user, "AppData", "Roaming", "Microsoft")
     if os.path.exists(os.path.join(ms, "UProof", "CUSTOM.DIC")):
-        items.append({"id": "dictionary", "label": "Custom dictionary", "detail": ""})
+        items.append(_item(os.path.join(ms, "UProof"), "dictionary", "Custom dictionary", "LibreOffice dictionary"))
     tpl = os.path.join(ms, "Templates")
     if os.path.isdir(tpl) and any(f.lower().endswith((".dotx", ".dotm", ".dot"))
                                   for f in os.listdir(tpl)):
-        items.append({"id": "templates", "label": "Word templates", "detail": ""})
-    return bool(items), items, "LibreOffice bridge"
+        items.append(_item(tpl, "templates", "Word templates", "LibreOffice templates"))
+    fonts = os.path.join(ms, "Fonts")
+    if os.path.isdir(fonts):
+        items.append(_item(fonts, "fonts", "Office fonts", "Fonts copied for document fidelity"))
+    return bool(items), items, "LibreOffice dictionary, templates, fonts, and format defaults"
 
 
 def cat_games(user):
@@ -100,7 +110,7 @@ def cat_games(user):
     for base in ("Program Files (x86)", "Program Files"):
         vdf = os.path.join(HOST, base, "Steam", "steamapps", "libraryfolders.vdf")
         if os.path.exists(vdf):
-            items.append({"id": "steam", "label": "Steam", "detail": "libraries + saves"})
+            items.append(_item(os.path.dirname(os.path.dirname(vdf)), "steam", "Steam", "libraries + saves"))
             break
     return bool(items), items, "Steam"
 
@@ -111,9 +121,27 @@ def cat_wifi(_user):
     if os.path.isdir(src):
         xmls = [f for f in os.listdir(src) if f.endswith(".xml")]
         if xmls:
-            items.append({"id": "wifi", "label": "Saved Wi-Fi networks",
-                          "detail": f"{len(xmls)} profile(s)"})
-    return bool(items), items, f"{len(items) and items[0]['detail'] or ''}"
+            import re
+            importable = enterprise = 0
+            for name in xmls:
+                try:
+                    text = open(os.path.join(src, name), errors="ignore").read()
+                except OSError:
+                    continue
+                auth = re.search(r"<authentication>([^<]+)", text, re.I)
+                if auth and auth.group(1).lower() in {"wpa2", "wpa3", "wpa2psk", "wpa3sae", "open", "shared"}:
+                    importable += 1
+                elif auth:
+                    enterprise += 1
+                else:
+                    importable += 1
+            if importable:
+                items.append({"id": "wifi-importable", "label": "Open / PSK / SAE networks",
+                              "detail": f"{importable} profile(s)", "fileCount": importable, "sizeBytes": 0})
+            if enterprise:
+                items.append({"id": "wifi-enterprise", "label": "Enterprise networks",
+                              "detail": f"{enterprise} detected; credentials are not copied", "fileCount": enterprise, "sizeBytes": 0})
+    return bool(items), items, ", ".join(i["detail"] for i in items)
 
 
 def cat_wsl(user):
@@ -128,8 +156,7 @@ def cat_wsl(user):
                 found = True
                 break
     if found:
-        items.append({"id": "wsl", "label": "WSL environment",
-                      "detail": "dotfiles + Brewfile"})
+        items.append(_item(local, "wsl", "WSL environment", "dotfiles + package/Brewfile inventory"))
     return bool(items), items, "dotfiles + packages"
 
 
@@ -137,9 +164,26 @@ def cat_look(_user):
     items = []
     if _exists("wootc", "install", "slurp", "slurp.json") or \
        _exists("wootc", "install", "slurp.json"):
-        items.append({"id": "look", "label": "Windows look",
-                      "detail": "wallpaper, accent, pins"})
+        slurp = os.path.join(HOST, "wootc", "install", "slurp", "slurp.json")
+        if not os.path.exists(slurp):
+            slurp = os.path.join(HOST, "wootc", "install", "slurp.json")
+        try:
+            keys = json.load(open(slurp)).keys()
+        except (OSError, ValueError):
+            keys = ("look",)
+        for key in keys:
+            items.append({"id": f"look-{key}", "label": key.replace("Apps", " apps"),
+                          "detail": "Windows-style setting", "fileCount": 1, "sizeBytes": 0})
     return bool(items), items, "wallpaper + theme"
+
+
+def cat_identity(user):
+    root = os.path.join(HOST, "Users", user)
+    if not os.path.isdir(root):
+        return False, [], ""
+    items = [{"id": "identity", "label": "Name, locale, and avatar",
+              "detail": "Non-secret account preferences only", "fileCount": 1, "sizeBytes": 0}]
+    return True, items, "Password is never migrated"
 
 
 CATEGORIES = [
@@ -150,6 +194,7 @@ CATEGORIES = [
     ("wifi",     "Wi-Fi networks",    cat_wifi),
     ("wsl",      "WSL / developer",   cat_wsl),
     ("look",     "Windows look",      cat_look),
+    ("identity", "Identity",           cat_identity),
 ]
 
 

--- a/payload/migration/wootc-manifest-gui
+++ b/payload/migration/wootc-manifest-gui
@@ -30,6 +30,15 @@ class ManifestEngine:
             raise RuntimeError(out.stderr.strip() or "scan failed")
         return json.loads(out.stdout or "{}")
 
+    def load_selection(self, path=SELECTION_PATH):
+        """Read prior choices so reopening the GUI does not reset opt-outs."""
+        try:
+            with open(path) as fh:
+                data = json.load(fh)
+            return data.get("selection", {})
+        except (OSError, ValueError):
+            return {}
+
     @staticmethod
     def default_selection(manifest):
         """Everything discovered is ON by default (opt-out model)."""
@@ -45,6 +54,22 @@ class ManifestEngine:
                 }
             sel[u["winUser"]] = cats
         return sel
+
+    @staticmethod
+    def merge_selection(manifest, previous):
+        """Default new discoveries on while preserving explicit old opt-outs."""
+        selection = ManifestEngine.default_selection(manifest)
+        for user, cats in selection.items():
+            old_cats = previous.get(user, {})
+            for cid, entry in cats.items():
+                old = old_cats.get(cid, {})
+                if isinstance(old, dict) and old.get("on") is False:
+                    entry["on"] = False
+                old_items = old.get("items", {}) if isinstance(old, dict) else {}
+                for iid in entry["items"]:
+                    if old_items.get(iid) is False:
+                        entry["items"][iid] = False
+        return selection
 
     def write_selection(self, selection, path=SELECTION_PATH):
         os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -91,6 +116,7 @@ def build_gui():
             super().__init__(application=app, title="Bring over from Windows",
                              default_width=560, default_height=640)
             self.selection = {}
+            self.manifest = {}
             tb = Adw.ToolbarView()
             tb.add_top_bar(Adw.HeaderBar())
             self.body = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12,
@@ -121,7 +147,8 @@ def build_gui():
                 man = eng.scan()
             except Exception as e:
                 self._msg("Couldn't scan", str(e)); return
-            self.selection = ManifestEngine.default_selection(man)
+            self.manifest = man
+            self.selection = ManifestEngine.merge_selection(man, eng.load_selection())
 
             for u in man.get("users", []):
                 if len(man["users"]) > 1:
@@ -134,12 +161,12 @@ def build_gui():
                         continue
                     any_present = True
                     exp = Adw.ExpanderRow(title=c["label"], subtitle=c["summary"])
-                    sw = Gtk.Switch(active=True, valign=Gtk.Align.CENTER)
+                    sw = Gtk.Switch(active=self.selection[u["winUser"]][c["id"]]["on"], valign=Gtk.Align.CENTER)
                     sw.connect("notify::active", self._on_cat, u["winUser"], c["id"])
                     exp.add_prefix(sw)
                     for it in c.get("items", []):
                         row = Adw.ActionRow(title=it["label"], subtitle=it.get("detail", ""))
-                        isw = Gtk.Switch(active=True, valign=Gtk.Align.CENTER)
+                        isw = Gtk.Switch(active=self.selection[u["winUser"]][c["id"]]["items"].get(it["id"], True), valign=Gtk.Align.CENTER)
                         isw.connect("notify::active", self._on_item,
                                     u["winUser"], c["id"], it["id"])
                         row.add_suffix(isw)

--- a/payload/migration/wootc-mount-user-dirs
+++ b/payload/migration/wootc-mount-user-dirs
@@ -194,6 +194,14 @@ bind_profile() {
         return 0
     fi
     for folder in "${FOLDERS[@]}"; do
+        if command -v wootc-selection >/dev/null 2>&1; then
+            local_item_rc=0
+            wootc-selection "$luser" files "$folder" >/dev/null 2>&1 || local_item_rc=$?
+            if [[ "$local_item_rc" -eq 1 ]]; then
+                log "files/$folder: skipped (turned off in the migration chooser)"
+                continue
+            fi
+        fi
         src="${winprofile}${folder}"
         # A redirected folder wins over the literal one — that is where the
         # user's files actually are. Only when it exists on this volume: a
@@ -360,8 +368,13 @@ if command -v wootc-detect-apps >/dev/null; then
             fi
         fi
         # Copy the account picture + full name over (never the password).
-        command -v wootc-identity >/dev/null && \
-            { wootc-identity apply "$winuser" "$uname" >/dev/null || log "identity copy failed for $winuser → $uname (non-fatal)"; }
+        if command -v wootc-identity >/dev/null; then
+            if sel_on "$uname" identity; then
+                wootc-identity apply "$winuser" "$uname" >/dev/null || log "identity copy failed for $winuser → $uname (non-fatal)"
+            else
+                log "identity: skipped for $uname (turned off in the migration chooser)"
+            fi
+        fi
     done
     shopt -u nullglob
 fi

--- a/payload/migration/wootc-selection
+++ b/payload/migration/wootc-selection
@@ -54,12 +54,33 @@ def is_enabled(user, category):
     return True
 
 
+def is_item_enabled(user, category, item):
+    """Return whether an individual discovered item remains selected."""
+    path = selection_path(user)
+    if not path or not os.path.isfile(path):
+        return True
+    try:
+        data = json.load(open(path))
+    except Exception:
+        return True
+    for _winuser, cats in data.get("selection", {}).items():
+        entry = cats.get(category)
+        if not isinstance(entry, dict) or entry.get("on") is False:
+            continue
+        items = entry.get("items", {})
+        if items.get(item) is False:
+            return False
+    return True
+
+
 def main(argv):
     if len(argv) < 3:
-        print("usage: wootc-selection <linuxuser> <category>", file=sys.stderr)
+        print("usage: wootc-selection <linuxuser> <category> [item]", file=sys.stderr)
         print("categories: " + ", ".join(CATEGORIES), file=sys.stderr)
         return 2
-    return 0 if is_enabled(argv[1], argv[2]) else 1
+    if not is_enabled(argv[1], argv[2]):
+        return 1
+    return 0 if len(argv) < 4 or is_item_enabled(argv[1], argv[2], argv[3]) else 1
 
 
 if __name__ == "__main__":

--- a/payload/migration/wootc-wifi-bridge
+++ b/payload/migration/wootc-wifi-bridge
@@ -79,12 +79,22 @@ PYEOF
         *) keymgmt="" ;;
     esac
     if [[ "$tier" == "ent" || -z "$keymgmt" ]]; then
+        if [[ -n "${_u:-}" ]] && command -v wootc-selection >/dev/null 2>&1; then
+            wootc-selection "$_u" wifi wifi-enterprise >/dev/null 2>&1 || {
+                [[ "$?" -eq 1 ]] && { skipped+=("$ssid"); log "item skipped by chooser: $ssid"; continue; }
+            }
+        fi
         skipped+=("$ssid"); log "detected (not copied — enterprise/unknown): $ssid"
         continue
     fi
     if [[ "$keymgmt" != "none" && -z "$key" ]]; then
         skipped+=("$ssid"); log "detected (no cleartext key): $ssid"; continue
     fi
+	if [[ -n "${_u:-}" ]] && command -v wootc-selection >/dev/null 2>&1; then
+		wootc-selection "$_u" wifi wifi-importable >/dev/null 2>&1 || {
+			[[ "$?" -eq 1 ]] && { skipped+=("$ssid"); log "item skipped by chooser: $ssid"; continue; }
+		}
+	fi
 
     # Write the NetworkManager keyfile connection.
     dst="$DST/${ssid}.nmconnection"

--- a/tests/unit/selection.bats
+++ b/tests/unit/selection.bats
@@ -60,3 +60,16 @@ PY
         [ "$status" -eq 0 ]
     done
 }
+
+@test "an explicitly disabled item is skipped while sibling items stay on" {
+    python3 - "$WOOTC_SELECTION" <<'PY'
+import json, sys
+json.dump({"version": 1, "selection": {"Alex": {
+    "files": {"on": True, "items": {"Documents": False, "Pictures": True}}
+}}}, open(sys.argv[1], "w"))
+PY
+    run "$SEL" alex files Documents
+    [ "$status" -eq 1 ]
+    run "$SEL" alex files Pictures
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #7

Adds the migration discovery manifest and GTK checklist for every bridge category: files, browsers, office, games, Wi-Fi, WSL, look, and identity. Discovered categories and items default on, prior opt-outs persist, and explicit category/item opt-outs are enforced by the bridges.

Also restores Windows-to-Linux profile mapping for app, Office, and identity bridges so manifest choices are applied to the profile that was actually discovered.

Validation: Python syntax checks, shell syntax checks, fixture manifest scan, existing manifest/selection tests, and git diff --check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->