### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to wootc
+
+## Getting started
+
+1. Fork the repository and clone your fork.
+2. Read `AGENTS.md` first — it names the four project layers (Windows OEM,
+   QGA control plane, deployer initramfs, E2E test runner) and the docs to
+   read before touching each one, plus `docs/agent-lessons.md`, which
+   documents traps that have each cost a 60–90 minute VM run.
+3. Check `README.md`'s build/test matrix for current known-good vs. known-red
+   status before assuming a symptom is your change's fault.
+
+## Building and testing
+
+`just --list` shows all targets (requires `just`; the E2E targets also need
+`podman`, `qemu-img`, and `/dev/kvm`).
+
+The fast, no-container red-green loop for day-to-day changes:
+
+```bash
+just test          # or: tests/run.sh fast
+```
+
+This runs the bats unit suites (payload gates/transforms) plus `go test` for
+the cross-platform Go packages. Windows-tagged Go (`app/*_windows.go`) only
+builds on Windows by design, so this tier covers the platform-independent
+code.
+
+Containerized integration tests (User Data Bridge, WSL, go-native gates) run
+in a privileged Fedora container and need `podman`:
+
+```bash
+just test-slow      # or: tests/run.sh slow
+```
+
+Full hosted E2E (Windows 11 → wootc deployer → native Linux → Windows 11)
+runs on dedicated remote hosts and isn't something a contributor's local
+environment can reproduce — see `docs/RELEASING.md` for how matrix cells go
+green.
+
+## Before opening a PR
+
+- Run `just test` (fast tier) locally — it's fast enough to run on every
+  change.
+- If you're touching the E2E harness, the deployer, or the runners, read
+  `docs/agent-lessons.md` first; it exists because those traps are easy to
+  re-hit.
+- The heuristic that matters most in this codebase: **status derived from a
+  proxy rather than an observable is the dominant bug class here.** When
+  adding a check, ask what it would print if the thing it asserts never
+  happened, then break the code and confirm the test goes red.
+
+## License
+
+wootc is dual-licensed under GPL-2.0 and MIT (see `LICENSE-GPL-2.0` and
+`LICENSE-MIT`).
+
+## Getting help
+
+Questions or stuck? Open an issue, or ask on
+[Matrix #tunaos](https://matrix.to/#/%23tunaos:reilly.asia).


### PR DESCRIPTION
Ref tuna-os/tunaos#1362 (Hacktoberfest 2026 readiness).

wootc had no CONTRIBUTING.md anywhere in the repo (checked root and docs/).
That's a real blocker to seeding good-first-issue tasks here: the org's
Hacktoberfest curation checklist (tuna-os/tunaos docs/HACKTOBERFEST-2026.md)
requires every selected issue to link to a CONTRIBUTING.md, and wootc was
one of three zero-GFI-issue repos this issue flagged.

Grounded in what's actually in the repo, not generic boilerplate:
- Points to AGENTS.md and docs/agent-lessons.md as the required first reads
- Documents the actual `just test` / `tests/run.sh fast` / `tests/run.sh slow`
  tiers from the real justfile and tests/run.sh
- States the dual GPL-2.0/MIT license from the actual LICENSE files present
---
🐝 **Hive Agent**: `contributor` | **SHA:** `7ea631a`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/wootc/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->