### PR TITLE
session: decrypt Chromium encrypted_value blobs (v10 wire format)

### DIFF
--- a/app/session_chromium_value.go
+++ b/app/session_chromium_value.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"errors"
+	"fmt"
+)
+
+// Chromium per-value decryption (docs/session-migration.md, tuna-os/wootc#1
+// item 1, second half). sealSessionPayload/openSessionPayload (in
+// session_rewrap.go) move the DPAPI-recovered os_crypt master KEY across the
+// vault-derived envelope. This file is the next step: using that key to
+// decrypt an individual Cookies/Local Storage value, once it's been copied
+// (byte-for-byte, alongside the app's other plain files) to the target.
+//
+// This does NOT do the remaining, larger pieces of "target-side rewrite":
+// enumerating a live SQLite/LevelDB file and re-encrypting values under the
+// Linux keyring. Both need testing against a real Chrome/Edge install this
+// environment can't provide -- see the issue for why that's explicitly
+// unclaimed. What's implemented here is the one sub-step whose correctness
+// doesn't depend on a live browser: the wire format itself.
+//
+// Format (stable across Chrome/Chromium/Electron since ~2013, documented
+// publicly and implemented identically by every major cookie-extraction
+// tool -- e.g. browser_cookie3, chrome-cookies-secure): the `encrypted_value`
+// BLOB column in Cookies' `cookies` table, and each value in Local Storage's
+// LevelDB, is:
+//
+//	[3-byte ASCII prefix "v10" or "v11"] [12-byte GCM nonce] [ciphertext] [16-byte GCM tag]
+//
+// AES-256-GCM, no associated data. "v11" additionally authenticates a
+// platform-specific static string as AAD on some Chrome versions/platforms;
+// only "v10" (no AAD) is implemented here, since that's the form actually
+// reachable from this DPAPI-recovered-key path -- see decryptChromiumValue's
+// doc comment for what happens on an unrecognized prefix (a clear error, not
+// a silent wrong answer).
+
+const (
+	chromiumValuePrefixLen = 3
+	chromiumValueNonceLen  = 12
+)
+
+// decryptChromiumValue decrypts one Cookies/Local Storage encrypted_value
+// blob using the os_crypt master key recovered via DPAPI (chromiumMasterKey)
+// and carried across the vault-sealed envelope (openSessionPayload).
+//
+// Returns a descriptive error rather than guessing on anything unexpected:
+// an unsupported prefix, a too-short blob, or a failed GCM tag check all
+// fail closed. A "v11" prefix is reported as unsupported rather than
+// attempted -- some Chrome versions add platform-specific associated data
+// to v11 that isn't documented consistently enough to implement without a
+// real browser to verify against; better to skip that value than produce
+// a plausible-looking wrong plaintext.
+func decryptChromiumValue(key []byte, blob []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("os_crypt key must be 32 bytes, got %d", len(key))
+	}
+	if len(blob) < chromiumValuePrefixLen {
+		return nil, errors.New("blob too short for version prefix")
+	}
+	prefix := string(blob[:chromiumValuePrefixLen])
+	if prefix != "v10" {
+		return nil, fmt.Errorf("unsupported encrypted_value prefix %q", prefix)
+	}
+	rest := blob[chromiumValuePrefixLen:]
+	if len(rest) < chromiumValueNonceLen {
+		return nil, errors.New("blob too short for nonce")
+	}
+	nonce, ciphertext := rest[:chromiumValueNonceLen], rest[chromiumValueNonceLen:]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open encrypted_value: %w", err)
+	}
+	return plaintext, nil
+}

--- a/app/session_chromium_value_test.go
+++ b/app/session_chromium_value_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"testing"
+)
+
+// sealChromiumValue builds a synthetic "v10"-format encrypted_value blob the
+// same way real Chromium does, so tests exercise decryptChromiumValue
+// against the actual wire format rather than a round-trip through its own
+// logic only.
+func sealChromiumValue(t *testing.T, key, plaintext []byte) []byte {
+	t.Helper()
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("gcm: %v", err)
+	}
+	nonce := make([]byte, chromiumValueNonceLen)
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	out := append([]byte("v10"), nonce...)
+	return gcm.Seal(out, nonce, plaintext, nil)
+}
+
+func testChromiumKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	return key
+}
+
+func TestDecryptChromiumValueRoundTrip(t *testing.T) {
+	key := testChromiumKey(t)
+	plaintext := []byte("session-cookie-value-abc123")
+	blob := sealChromiumValue(t, key, plaintext)
+
+	got, err := decryptChromiumValue(key, blob)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("decrypt = %q, want %q", got, plaintext)
+	}
+}
+
+func TestDecryptChromiumValueEmptyPlaintext(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte{})
+
+	got, err := decryptChromiumValue(key, blob)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("decrypt = %q, want empty", got)
+	}
+}
+
+func TestDecryptChromiumValueRejectsWrongKey(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte("token"))
+
+	wrongKey := testChromiumKey(t)
+	if _, err := decryptChromiumValue(wrongKey, blob); err == nil {
+		t.Error("expected error decrypting with the wrong key")
+	}
+}
+
+func TestDecryptChromiumValueRejectsTamperedCiphertext(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte("token"))
+	tampered := bytes.Clone(blob)
+	tampered[len(tampered)-1] ^= 0xFF // flip a byte in the GCM tag
+
+	if _, err := decryptChromiumValue(key, tampered); err == nil {
+		t.Error("expected error decrypting tampered blob")
+	}
+}
+
+func TestDecryptChromiumValueRejectsWrongKeyLength(t *testing.T) {
+	blob := sealChromiumValue(t, testChromiumKey(t), []byte("token"))
+	if _, err := decryptChromiumValue([]byte("too-short"), blob); err == nil {
+		t.Error("expected error for a non-32-byte key")
+	}
+}
+
+func TestDecryptChromiumValueRejectsUnsupportedPrefix(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte("token"))
+	blob[0], blob[1], blob[2] = 'v', '1', '1'
+
+	if _, err := decryptChromiumValue(key, blob); err == nil {
+		t.Error("expected error for an unsupported v11 prefix")
+	}
+}
+
+func TestDecryptChromiumValueRejectsShortBlob(t *testing.T) {
+	if _, err := decryptChromiumValue(testChromiumKey(t), []byte("v1")); err == nil {
+		t.Error("expected error for a blob too short for the version prefix")
+	}
+	if _, err := decryptChromiumValue(testChromiumKey(t), []byte("v10")); err == nil {
+		t.Error("expected error for a blob with a prefix but no nonce")
+	}
+	if _, err := decryptChromiumValue(testChromiumKey(t), nil); err == nil {
+		t.Error("expected error for a nil blob")
+	}
+}

--- a/docs/session-migration.md
+++ b/docs/session-migration.md
@@ -64,6 +64,19 @@ work is deliberately separate because Chrome, Edge, and Spotify differ in
 database layout and token invalidation behavior. Discord and Slack remain
 re-link-only even when DPAPI can read their key.
 
+`decryptChromiumValue` (`app/session_chromium_value.go`) implements the one
+sub-step of that whose correctness doesn't depend on a live browser: given
+the os_crypt key recovered from the envelope, it decrypts a single Cookies
+`encrypted_value` (or Local Storage value) in Chromium's documented `v10`
+wire format — `"v10" | 12-byte nonce | ciphertext | GCM tag`, AES-256-GCM.
+Tested against synthetically-sealed fixtures, not a real browser. Still
+unclaimed: enumerating a real Cookies SQLite/Local Storage LevelDB file,
+`v11`-prefixed values (which add platform-specific associated data on some
+Chrome versions — not documented consistently enough to implement blind),
+and the actual libsecret/kwallet write on the target. Those need a real
+Chrome/Edge install and a Linux D-Bus session to verify against, neither
+of which this change had access to.
+
 Until that consumer completes and records `imported`, the dashboard must show
 re-link/sign-in guidance rather than a signed-in result. A staged key is an
 implementation artifact, not evidence that a token transplant succeeded.


### PR DESCRIPTION
## Summary

Advances #1's "target-side: rewrite the Linux app's store and re-encrypt under libsecret/kwallet" checklist item, scoped to the one sub-piece whose correctness doesn't depend on a live browser install or a D-Bus session — neither of which is available in this environment.

`sealSessionPayload`/`openSessionPayload` (`session_rewrap.go`) already carry the DPAPI-recovered os_crypt master **key** across the vault-sealed envelope. What was still missing: using that key to decrypt an individual Cookies/Local Storage **value**. Chrome's `encrypted_value` format is public, stable, and identically implemented by every major cookie-extraction tool:

```
"v10" | 12-byte GCM nonce | ciphertext | 16-byte GCM tag
```

AES-256-GCM, no associated data. `decryptChromiumValue` implements exactly that — and fails closed (clear error, not a guess) on a short blob, a `v11` prefix, a wrong key length, or a failed GCM tag check.

`v11` is deliberately **not** attempted: some Chrome versions authenticate additional platform-specific associated data under that prefix, and the contract isn't documented consistently enough to implement without a real browser to verify the result against.

## Testing

Tested against synthetically-sealed `v10` fixtures built with the same primitives Chrome itself uses (`sealChromiumValue` in the test file constructs them independently of `decryptChromiumValue`'s own logic) — round-trip, empty plaintext, wrong key, wrong key length, tampered ciphertext, unsupported prefix, and short-blob cases. `go test ./...` and `go vet ./...` pass; the existing `session_rewrap_test.go` suite is unaffected.

## Still unclaimed

Enumerating a real Cookies SQLite / Local Storage LevelDB file, `v11` support, and the actual libsecret/kwallet write on the target — all need a real Chrome/Edge/Spotify install and a Linux D-Bus session to verify against, which this environment doesn't have. Documented explicitly in `docs/session-migration.md` rather than left implicit.

Refs #1
---
🐝 **Hive Agent**: `contributor` | **SHA:** `26cc875`