### PR TITLE
security: remove secrets: inherit, fix two script-injection sites in E2E workflows

### DIFF
--- a/.github/workflows/e2e-gui.yml
+++ b/.github/workflows/e2e-gui.yml
@@ -38,7 +38,11 @@ jobs:
       phase3: true
       use_base_image: true
       require_podman_major: ${{ inputs.require_podman_major || '' }}
-    secrets: inherit
+    # No secrets: block — e2e-hosted.yml only uses secrets.GITHUB_TOKEN, which
+    # every job gets automatically. `secrets: inherit` exposed every repo
+    # secret to this job for no reason; the other three callers of this
+    # reusable workflow (e2e-matrix.yml, e2e-nightly.yml, release.yml) already
+    # call it with no secrets: block at all. See #153.
 
   publish:
     needs: run

--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -106,6 +106,17 @@ jobs:
       - name: Pull pre-installed Windows base image (if present)
         if: ${{ inputs.use_base_image }}
         continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Expression results interpolated into shell, not passed as $-vars,
+          # let a value containing "/`/$() break out of the TAG= assignment
+          # and execute arbitrary shell on the runner. win_version/win_edition/
+          # bitlocker are workflow_call inputs — currently only repo-controlled
+          # callers, but the hazard is the same class as inputs.image below.
+          # See #154.
+          WOOTC_E2E_WIN_VERSION_TAG: ${{ inputs.win_version }}
+          WOOTC_E2E_WIN_EDITION_TAG: ${{ inputs.win_edition || 'pro' }}
+          WOOTC_E2E_BITLOCKER_TAG: ${{ inputs.bitlocker }}
         run: |
           set -euo pipefail
           VERSION=1.2.0
@@ -116,8 +127,8 @@ jobs:
           # Tag includes the EDITION: the product key selects the edition inside the
           # ISO and is folded into the snapshot correctness key, so a pro-primed
           # snapshot can never serve a home cell (it would be silently rejected).
-          TAG="${{ inputs.win_version }}-${{ inputs.win_edition || 'pro' }}-bl-${{ inputs.bitlocker }}"
-          echo "${{ env.GITHUB_TOKEN }}" | \
+          TAG="${WOOTC_E2E_WIN_VERSION_TAG}-${WOOTC_E2E_WIN_EDITION_TAG}-bl-${WOOTC_E2E_BITLOCKER_TAG}"
+          echo "$GITHUB_TOKEN" | \
             oras login ghcr.io -u "${{ github.actor }}" --password-stdin
           sudo mkdir -p /mnt/wootc-snapshot && sudo chown "$USER" /mnt/wootc-snapshot
           if oras pull "${PKG}:${TAG}" -o /mnt/wootc-snapshot; then
@@ -126,9 +137,6 @@ jobs:
           else
             echo "No base image ${PKG}:${TAG}; run-e2e.sh will do a full install"
           fi
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Build the real wootc.exe the GUI-driven run drives. Ubuntu runners
       # ship Go + Node; the wails frontend is a plain vite build, and the
       # binary cross-compiles GOOS=windows. Drive mode needs no CDP/webview
@@ -194,6 +202,10 @@ jobs:
           # WOOTC_E2E_SNAPSHOT_IN is set by the pull step above on a cache hit.
           # Drive mode gate for the app's E2E bindings (inert otherwise).
           WOOTC_E2E_DRIVE: ${{ inputs.gui_install && '1' || '' }}
+          # Passed as a $-var, not interpolated into the run: block, so a
+          # value containing "/`/$() in this attacker-influenceable
+          # workflow_dispatch input cannot execute shell on the runner. See #154.
+          WOOTC_E2E_IMAGE: ${{ inputs.image }}
         run: |
           cd tests/e2e
           FLAGS=""
@@ -203,7 +215,7 @@ jobs:
           # ENTIRE matrix finishes, so without this a failing cell cannot be
           # diagnosed for hours — the evidence artifact is the only way in.
           set -o pipefail
-          bash run-e2e.sh "${{ inputs.image }}" $FLAGS 2>&1 | tee /tmp/run-e2e-console.log
+          bash run-e2e.sh "$WOOTC_E2E_IMAGE" $FLAGS 2>&1 | tee /tmp/run-e2e-console.log
 
       - name: Collect evidence
         if: always()


### PR DESCRIPTION
Fixes #153, #154.

Two real findings, both in the E2E GUI-driven publish path, both reachable from a `workflow_dispatch` input.

## #153 — `secrets: inherit`

`e2e-gui.yml` called `e2e-hosted.yml` with `secrets: inherit`, exposing every repository secret. Checked what the called workflow actually uses before touching anything:

```
$ grep -n 'secrets\.' .github/workflows/e2e-hosted.yml
131:          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Exactly one line — `GITHUB_TOKEN`, which every job/`workflow_call` gets automatically regardless of `inherit`. The other three callers of this same reusable workflow (`e2e-matrix.yml`, `e2e-nightly.yml`, `release.yml`) already call it with **no** `secrets:` block at all. Removing it here isn't a new pattern — it brings `e2e-gui.yml` in line with its own siblings.

## #154 — script injection

Two `run:` blocks interpolated GitHub Actions expressions directly into shell instead of passing them as `$`-variables:

```bash
TAG="${{ inputs.win_version }}-${{ inputs.win_edition || 'pro' }}-bl-${{ inputs.bitlocker }}"
bash run-e2e.sh "${{ inputs.image }}" $FLAGS
```

GHA performs this substitution as raw text *before* the shell ever sees it, so a value containing `"`/`` ` ``/`$()` breaks out of the assignment or the quoted argument and executes on the runner. `inputs.image` is directly attacker-controlled via `workflow_dispatch` (default `ghcr.io/projectbluefin/bluefin:lts`, but dispatchable with anything) — and before the #153 fix, that execution happened with every repo secret in scope.

Fixed both by moving the inputs into each step's own `env:` block and referencing them as `"$VAR"` in the shell — the same pattern this file already uses for `WOOTC_E2E_WIN_VERSION` et al. two steps down. Also normalized the adjacent `echo "${{ env.GITHUB_TOKEN }}"` to `echo "$GITHUB_TOKEN"`, the same inconsistency, already on the line I was touching.

## Verification

Not just "it parses" — checked the fix actually holds:

- Both files re-parse as valid YAML.
- `grep -n '\${{ inputs\.' e2e-hosted.yml` restricted to `run:`/`TAG=`/`run-e2e.sh` contexts → empty. No interpolation sites remain.
- **Behavior unchanged for legitimate input**: reproduced the exact `TAG=` construction and the `run-e2e.sh` invocation with representative values — output matches the pre-fix form exactly (`11-pro-bl-off`; `bash run-e2e.sh ghcr.io/projectbluefin/bluefin:lts --phase3 --gui-install`).
- **Proved the attack is actually blocked, not just moved**: fed the payload `lts"; touch /tmp/PWNED; echo "` through both shapes.
  - Old direct-interpolation shape: the quotes visibly break — `touch /tmp/PWNED` lands as bare shell syntax outside the string.
  - New env-var shape: the entire payload is treated as one inert quoted argument. No file created.

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_