### PR TITLE
fix: replace invalid packageRules ignore with enabled: false

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "major"
       ],
       "automerge": false,
-      "ignore": true
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes #147. Renovate's own bot filed this issue: `Invalid configuration option: packageRules[1].ignore`, halting all Renovate PRs for the repo as a precaution.

`ignore` is not a valid `packageRules`-level key in Renovate's schema. The rule's own comment states its intent precisely: *"ignore prevents PR creation"* for fedora base-image major bumps — that's exactly what `enabled: false` does inside a `packageRule` (fully disables Renovate management for matched deps), unlike `automerge: false` alone, which still proposes a PR.

Same fix already applied/verified across sibling repos (tacklebox#213/#220) hitting the identical copy-pasted rule. Unrelated to #159 (also open against this repo, a script-injection/secrets fix) — different branch, different concern.

## Test plan

- [x] `python3 -c "import json; json.load(open('renovate.json'))"` — valid JSON
- [x] `npx -p renovate renovate-config-validator` — `Config validated successfully`

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_