### PR TITLE
Session migration: add online Chromium DPAPI rewrap

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -63,6 +63,9 @@ type InstallConfig struct {
 	// over on first login. Default false — we honor the image maker's desktop
 	// defaults unless the user asks to make it feel like Windows.
 	WindowsLook bool `json:"windowsLook"`
+	// SessionConsent is opt-in per app because it authorizes moving auth
+	// material. An absent or false entry never stages a session envelope.
+	SessionConsent map[string]bool `json:"sessionConsent,omitempty"`
 }
 
 // ProgressEvent is emitted during install for the frontend progress bar.
@@ -204,11 +207,11 @@ func (a *App) shutdown(ctx context.Context) {
 // reads it to gate the UI to green-only scenarios (docs/RELEASING.md); the
 // backend enforces the same rules in StartInstall (defense in depth).
 type SupportPolicy struct {
-	Channel             string `json:"channel"`             // alpha | beta | stable
-	ExperimentalImages  bool   `json:"experimentalImages"`  // offer non-green images?
-	BitLockerSupported  bool   `json:"bitlockerSupported"`  // is the FDE path green yet? (#34)
-	CustomImageAllowed  bool   `json:"customImageAllowed"`  // arbitrary OCI ref?
-	Reason              string `json:"reason"`              // one-liner for the UI
+	Channel            string `json:"channel"`            // alpha | beta | stable
+	ExperimentalImages bool   `json:"experimentalImages"` // offer non-green images?
+	BitLockerSupported bool   `json:"bitlockerSupported"` // is the FDE path green yet? (#34)
+	CustomImageAllowed bool   `json:"customImageAllowed"` // arbitrary OCI ref?
+	Reason             string `json:"reason"`             // one-liner for the UI
 }
 
 // supportChannel resolves the active release channel. Default is the
@@ -648,6 +651,31 @@ func runPipeline(ctx context.Context, cfg InstallConfig, emit func(ProgressEvent
 			// an AppData footprint. Best-effort: never fail install.
 			if err := collectPrograms(); err != nil {
 				fmt.Fprintf(os.Stderr, "[wootc] program collection skipped: %v\n", err)
+			}
+			return nil
+		}},
+		{"Checking app sessions", 90, func() error {
+			candidates, err := collectSessions()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[wootc] session collection skipped: %v\n", err)
+				return nil
+			}
+			results := exportConsentedSessions(candidates, cfg.SessionConsent, cfg.Password)
+			for _, result := range results {
+				if result.State == "failed" {
+					fmt.Fprintf(os.Stderr, "[wootc] %s session export failed: %s\n", result.App, result.Reason)
+				}
+			}
+			// This is deliberately a status ledger, not a success marker. The
+			// target-side importer must replace "staged" with "imported" before
+			// any UI can describe the app as signed in.
+			path := filepath.Join(wootcDir(), "install", "slurp", "session", "exports.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				fmt.Fprintf(os.Stderr, "[wootc] session export ledger directory skipped: %v\n", err)
+				return nil
+			}
+			if err := os.WriteFile(path, []byte(sessionExportSummary(results)), 0o600); err != nil {
+				fmt.Fprintf(os.Stderr, "[wootc] session export ledger skipped: %v\n", err)
 			}
 			return nil
 		}},

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -1,5 +1,5 @@
 import '../src/style.css';
-import { GetImages, GetSystemInfo, StartInstall, CancelInstall, GetStatus, Reboot, ExistingInstallFound, GetMode, GetMigrationCategories, ConvertCategory, ImportBrowserData, GetAppMigrations, GetOfficeMigration, GetBranding, CreateDataPartition, GetUninstallInfo, UninstallWith, GetVMCapability, BootInVM, DefragDrive, GetFreshVMCapability, TryInVMFresh, InstallPreviewForReal, E2EDriveDirective, E2EDriveReport, GetSupportPolicy } from '../wailsjs/go/main/App';
+import { GetImages, GetSystemInfo, StartInstall, CancelInstall, GetStatus, Reboot, ExistingInstallFound, GetMode, GetMigrationCategories, ConvertCategory, ImportBrowserData, GetAppMigrations, GetOfficeMigration, GetSessionCandidates, SetSessionConsent, ReinstallApps, GetMigrationProfile, SetMigrationProfile, GetLookMigration, GetBranding, CreateDataPartition, GetUninstallInfo, UninstallWith, GetVMCapability, BootInVM, DefragDrive, GetFreshVMCapability, TryInVMFresh, InstallPreviewForReal, E2EDriveDirective, E2EDriveReport, GetSupportPolicy } from '../wailsjs/go/main/App';
 import { EventsOn } from '../wailsjs/runtime/runtime';
 import { fmtSize } from './lib/format.js';
 import { el, btn, chip, warningBanner, inputField } from './lib/ui.js';
@@ -14,7 +14,10 @@ const state = {
   brand: null,         // partner/enterprise branding (themeable)
   categories: [],      // migration dashboard rows
   apps: [],            // detected app migrations
+  sessionCandidates: [], // Windows-online DPAPI findings; never tokens
   office: null,        // MS Office → LibreOffice summary
+  migrationProfile: null,
+  look: null,
   converting: {},      // category id → percent while a conversion runs
   selected: null,      // selected Image
   config: {
@@ -29,6 +32,7 @@ const state = {
     encryption: 'tpm2-luks',
     luksPassphrase: '',
     windowsLook: false,
+    sessionConsent: {},
   },
   progress: {
     step: '',
@@ -125,16 +129,21 @@ async function init() {
     return;
   }
 
-  const [images, sysinfo, existing, policy] = await Promise.all([
+  const [images, sysinfo, existing, policy, sessionCandidates] = await Promise.all([
     GetImages(),
     GetSystemInfo(),
     ExistingInstallFound(),
     GetSupportPolicy().catch(() => ({ channel: 'alpha', experimentalImages: false, bitlockerSupported: false, customImageAllowed: false })),
+    // A missing binding throws synchronously, which would escape a plain
+    // .catch() on the call and blank the whole launchpad; session candidates
+    // are optional, so absorb that too.
+    Promise.resolve().then(GetSessionCandidates).catch(() => []),
   ]);
 
   state.policy = policy;
   state.images = images || [];
   state.sysinfo = sysinfo;
+  state.sessionCandidates = sessionCandidates || [];
   state.selected = state.images[0] || null;
   applyImageDefaults(state.selected);
 
@@ -153,16 +162,32 @@ async function init() {
   render();
 }
 
+// A missing Wails binding makes its generated wrapper throw synchronously, so
+// a plain `.catch()` on the call never runs and one absent optional method
+// would blank the whole dashboard. Degrade that section instead.
+async function optional(call, fallback) {
+  try {
+    return (await call()) ?? fallback;
+  } catch (e) {
+    console.error(e);
+    return fallback;
+  }
+}
+
 async function refreshCategories() {
   try {
-    const [cats, apps, office] = await Promise.all([
-      GetMigrationCategories(),
-      GetAppMigrations().catch(() => []),
-      GetOfficeMigration().catch(() => null),
+    const [cats, apps, office, profile, look] = await Promise.all([
+      optional(GetMigrationCategories, []),
+      optional(GetAppMigrations, []),
+      optional(GetOfficeMigration, null),
+      optional(GetMigrationProfile, null),
+      optional(GetLookMigration, null),
     ]);
     state.categories = cats || [];
     state.apps = apps || [];
     state.office = office && office.present ? office : null;
+    state.migrationProfile = profile;
+    state.look = look;
   } catch (e) {
     console.error(e);
     state.categories = [];
@@ -413,6 +438,31 @@ function renderLaunchpad() {
   if (state.config.windowsLook) lookRow.style.borderColor = 'var(--primary)';
   fields.appendChild(lookRow);
 
+  // Auth-token migration is a separate, explicit opt-in from look/data
+  // migration. The backend defaults every app to off and still refuses
+  // Discord/Slack because those services prefer relinking.
+  const movableSessions = state.sessionCandidates.filter(c => c.portable && c.recommend === 'copy');
+  if (movableSessions.length) {
+    const sessionBox = el('div');
+    sessionBox.style.cssText = 'margin-top:8px;padding:8px;border:1.5px solid var(--border);border-radius:6px';
+    sessionBox.innerHTML = `<div style="font-size:12px;font-weight:600">Signed-in app sessions</div><div style="font-size:11.5px;color:var(--text-muted);margin-top:2px">Optional: move these sessions while Windows is online. Off means you will sign in once on Linux.</div>`;
+    movableSessions.forEach(candidate => {
+      const row = el('label');
+      row.style.cssText = 'display:flex;gap:8px;align-items:flex-start;cursor:pointer;font-size:12px;margin-top:7px';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.checked = !!state.config.sessionConsent[candidate.app];
+      checkbox.style.marginTop = '1px';
+      checkbox.onchange = () => { state.config.sessionConsent[candidate.app] = checkbox.checked; };
+      const copy = el('span');
+      copy.innerHTML = `<b style="text-transform:capitalize">${candidate.app}</b><br><span style="color:var(--text-muted)">${candidate.note}</span>`;
+      row.appendChild(checkbox);
+      row.appendChild(copy);
+      sessionBox.appendChild(row);
+    });
+    fields.appendChild(sessionBox);
+  }
+
   const advanced = el('details');
   // Every control change re-renders the form; without persisting the open
   // state the panel snaps shut on each toggle — the user opens Advanced,
@@ -589,6 +639,7 @@ async function installPreviewForReal() {
       encryption: state.config.encryption,
       luksPassphrase: state.config.luksPassphrase,
       windowsLook: state.config.windowsLook,
+      sessionConsent: state.config.sessionConsent,
     });
     state.screen = 'done';
     render();
@@ -785,7 +836,60 @@ function renderMigrateScreen() {
     al.style.cssText = 'display:flex;flex-direction:column;gap:8px';
     state.apps.forEach(a => al.appendChild(renderAppRow(a)));
     appsSection.appendChild(al);
+    const reinstall = btn('Reinstall detected apps', 'btn btn-ghost', async () => {
+      reinstall.disabled = true;
+      reinstall.textContent = 'Installing…';
+      try {
+        await ReinstallApps();
+        alert('The detected Flatpak apps were installed. App data and credentials were not copied.');
+      } catch (e) {
+        alert('Could not reinstall detected apps: ' + e);
+      } finally {
+        reinstall.disabled = false;
+        reinstall.textContent = 'Reinstall detected apps';
+      }
+    });
+    reinstall.style.cssText = 'font-size:12px;margin-top:8px';
+    appsSection.appendChild(reinstall);
     scroll.appendChild(appsSection);
+  }
+
+  if (state.migrationProfile) {
+    const profile = el('div');
+    profile.appendChild(sectionLabel('Windows profile mapping'));
+    const card = el('div');
+    card.style.cssText = 'background:var(--bg-card);border:1.5px solid var(--border);border-radius:8px;padding:12px 16px;display:flex;align-items:center;gap:10px';
+    const copy = el('div');
+    copy.style.flex = '1';
+    copy.innerHTML = `<div style="font-size:12.5px;font-weight:600">Linux <code>${state.migrationProfile.linuxUser || 'unknown'}</code> → Windows <code>${state.migrationProfile.windowsProfile || 'not mapped'}</code></div><div style="font-size:11.5px;color:var(--text-muted);margin-top:3px">${state.migrationProfile.note || ''}</div>`;
+    card.appendChild(copy);
+    const choose = btn('Choose', 'btn btn-ghost', async () => {
+      const value = prompt('Windows profile folder name:', state.migrationProfile.windowsProfile || '');
+      if (!value) return;
+      try { await SetMigrationProfile(value.trim()); await refreshCategories(); }
+      catch (e) { alert('Could not map that Windows profile: ' + e); }
+    });
+    choose.style.fontSize = '12px';
+    card.appendChild(choose);
+    profile.appendChild(card);
+    scroll.appendChild(profile);
+  }
+
+  if (state.look) {
+    const look = el('div');
+    look.appendChild(sectionLabel('Windows look'));
+    const card = el('div');
+    card.style.cssText = 'background:var(--bg-card);border:1.5px solid var(--border);border-radius:8px;padding:12px 16px';
+    const status = state.look.applied ? '✓ Applied to this Linux user' : state.look.available ? 'Ready to apply on first login' : 'Not collected';
+    card.innerHTML = `<div style="font-size:12.5px;font-weight:600">${status}</div><div style="font-size:11.5px;color:var(--text-muted);margin-top:3px">${state.look.note || ''}</div>`;
+    if (state.look.items?.length) {
+      const items = el('div');
+      items.style.cssText = 'display:flex;gap:6px;flex-wrap:wrap;margin-top:8px';
+      state.look.items.forEach(item => items.appendChild(chip(item, false)));
+      card.appendChild(items);
+    }
+    look.appendChild(card);
+    scroll.appendChild(look);
   }
 
   if (state.office) {
@@ -870,6 +974,7 @@ const APP_ICONS = {
 const SESSION_BADGE = {
   portable: { label: '✓ Signed in', cls: 'ok' },
   signin:   { label: 'Sign in once', cls: '' },
+  relink:   { label: 'Re-link needed (2 steps)', cls: '' },
   none:     { label: 'Re-link needed', cls: '' },
 };
 
@@ -877,15 +982,103 @@ function renderAppRow(a) {
   const row = el('div');
   row.style.cssText = 'display:flex;align-items:center;gap:12px;background:var(--bg-card);border:1.5px solid var(--border);border-radius:8px;padding:10px 16px';
   const badge = SESSION_BADGE[a.session] || SESSION_BADGE.signin;
-  row.innerHTML = `
+
+  const left = el('div');
+  left.style.cssText = 'display:flex;align-items:center;gap:12px;flex:1;min-width:0';
+  left.innerHTML = `
     <span style="font-size:18px">${APP_ICONS[a.app] || '📦'}</span>
     <div style="flex:1;min-width:0">
       <div style="font-weight:600;font-size:13px;text-transform:capitalize">${a.app}</div>
       <div style="font-size:11.5px;color:var(--text-muted);margin-top:1px">${a.note || ''}</div>
     </div>
-    <span class="chip ${badge.cls}" style="flex-shrink:0">${badge.label}</span>
   `;
+  row.appendChild(left);
+
+  if (a.consentAvailable) {
+    const consent = el('label');
+    consent.style.cssText = 'display:flex;align-items:center;gap:5px;font-size:11px;color:var(--text-muted);flex-shrink:0';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = !!a.consent;
+    checkbox.title = 'Allow session token copy when the Windows-online exporter supports this app';
+    checkbox.onchange = async () => {
+      checkbox.disabled = true;
+      try { await SetSessionConsent(a.app, checkbox.checked); a.consent = checkbox.checked; }
+      catch (e) { checkbox.checked = !checkbox.checked; alert('Could not save session consent: ' + e); }
+      finally { checkbox.disabled = false; }
+    };
+    consent.appendChild(checkbox);
+    consent.appendChild(document.createTextNode('Allow session copy'));
+    row.appendChild(consent);
+  }
+
+  if (a.session === 'relink') {
+    const relinkBtn = btn('Re-link Guide', 'btn btn-ghost', () => openRelinkModal(a));
+    relinkBtn.style.fontSize = '12px';
+    relinkBtn.style.flexShrink = '0';
+    row.appendChild(relinkBtn);
+  }
+
+  const chipSpan = el('span', `chip ${badge.cls}`);
+  chipSpan.style.flexShrink = '0';
+  chipSpan.textContent = badge.label;
+  row.appendChild(chipSpan);
   return row;
+}
+
+function openRelinkModal(a) {
+  const modal = el('div');
+  modal.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;z-index:1000;padding:20px';
+  const content = el('div');
+  content.style.cssText = 'background:var(--bg-card);border:1.5px solid var(--border);border-radius:12px;padding:20px;max-width:480px;width:100%;box-shadow:0 10px 25px rgba(0,0,0,0.5)';
+
+  let title = 'Re-link Phone App';
+  let stepsHtml = '';
+
+  if (a.app === 'signal') {
+    title = 'Signal: Phone Re-link Steps';
+    stepsHtml = `
+      <ol style="margin:12px 0;padding-left:20px;font-size:13px;color:var(--text-dim);display:flex;flex-direction:column;gap:8px">
+        <li>Open Signal on your phone.</li>
+        <li>Go to <strong>Settings → Linked Devices</strong>.</li>
+        <li>Tap <strong>Link New Device</strong> and scan the QR code displayed in Signal Desktop.</li>
+      </ol>
+      <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">Note: Message history stays on your phone by design.</div>
+    `;
+  } else if (a.app === 'whatsapp') {
+    title = 'WhatsApp: Web Re-link Steps';
+    stepsHtml = `
+      <ol style="margin:12px 0;padding-left:20px;font-size:13px;color:var(--text-dim);display:flex;flex-direction:column;gap:8px">
+        <li>Open <strong>web.whatsapp.com</strong> in your browser.</li>
+        <li>Open WhatsApp on your phone and go to <strong>Settings → Linked Devices</strong>.</li>
+        <li>Tap <strong>Link a Device</strong> and scan the QR code on screen.</li>
+      </ol>
+    `;
+  } else if (a.app === 'telegram') {
+    title = 'Telegram: Re-link / Fallback Steps';
+    stepsHtml = `
+      <ol style="margin:12px 0;padding-left:20px;font-size:13px;color:var(--text-dim);display:flex;flex-direction:column;gap:8px">
+        <li>Open Telegram Desktop on Linux.</li>
+        <li>Scan the displayed QR code using Telegram on your phone (<strong>Settings → Devices → Link Desktop Device</strong>).</li>
+        <li>Alternatively, enter your phone number to receive a login code.</li>
+      </ol>
+    `;
+  } else {
+    stepsHtml = `<div style="font-size:13px;color:var(--text-dim);margin:12px 0">${a.note || 'Follow phone app settings to link device.'}</div>`;
+  }
+
+  content.innerHTML = `
+    <div style="font-weight:600;font-size:16px;margin-bottom:8px">${title}</div>
+    ${stepsHtml}
+  `;
+
+  const footer = el('div');
+  footer.style.cssText = 'display:flex;justify-content:flex-end;margin-top:16px';
+  const closeBtn = btn('Done', 'btn btn-primary', () => document.body.removeChild(modal));
+  footer.appendChild(closeBtn);
+  content.appendChild(footer);
+  modal.appendChild(content);
+  document.body.appendChild(modal);
 }
 
 function migrateAction(c) {
@@ -1063,6 +1256,7 @@ async function startInstall() {
       storageDrive,
       encryption:     state.config.encryption,
       luksPassphrase: state.config.luksPassphrase,
+      sessionConsent: state.config.sessionConsent,
     });
   } catch (e) {
     state.progress.error = String(e);

--- a/app/frontend/wailsjs/go/main/App.d.ts
+++ b/app/frontend/wailsjs/go/main/App.d.ts
@@ -25,6 +25,17 @@ export interface InstallConfig {
   storageDrive: string;
   encryption: 'none' | 'tpm2-luks' | 'luks-passphrase';
   luksPassphrase: string;
+  windowsLook?: boolean;
+  sessionConsent?: Record<string, boolean>;
+}
+
+export interface SessionCandidate {
+  app: string;
+  kind: 'chromium' | 'plainfile';
+  portable: boolean;
+  recommend: 'copy' | 'relink' | 'signin';
+  note: string;
+  consentRequired: boolean;
 }
 
 export interface InstallStatus {
@@ -57,10 +68,42 @@ export interface BridgeCategory {
   reversible: boolean;
 }
 
+export interface AppMigration {
+  app: string;
+  flatpak: string;
+  session: 'portable' | 'signin' | 'relink' | 'none';
+  copied: boolean;
+  note: string;
+  consentAvailable: boolean;
+  consent: boolean;
+}
+
+export interface MigrationProfile {
+  linuxUser: string;
+  windowsProfile: string;
+  matched: boolean;
+  note: string;
+}
+
+export interface LookMigration {
+  available: boolean;
+  applied: boolean;
+  items: string[];
+  note: string;
+}
+
 export function GetMode(): Promise<'installer' | 'migration'>;
 export function GetMigrationCategories(): Promise<BridgeCategory[]>;
 export function ConvertCategory(id: string): Promise<void>;
 export function ImportBrowserData(): Promise<string>;
+export function GetSessionCandidates(): Promise<SessionCandidate[]>;
+export function GetAppMigrations(): Promise<AppMigration[]>;
+export function GetOfficeMigration(): Promise<any>;
+export function SetSessionConsent(app: string, consent: boolean): Promise<void>;
+export function ReinstallApps(): Promise<void>;
+export function GetMigrationProfile(): Promise<MigrationProfile>;
+export function SetMigrationProfile(profile: string): Promise<void>;
+export function GetLookMigration(): Promise<LookMigration>;
 export function GetImages(): Promise<Image[]>;
 export function GetSystemInfo(): Promise<SystemInfo>;
 export function StartInstall(cfg: InstallConfig): Promise<void>;

--- a/app/frontend/wailsjs/go/main/App.js
+++ b/app/frontend/wailsjs/go/main/App.js
@@ -95,8 +95,32 @@ export function GetAppMigrations() {
   return window['go']['main']['App']['GetAppMigrations']();
 }
 
+export function GetSessionCandidates() {
+  return window['go']['main']['App']['GetSessionCandidates']();
+}
+
 export function GetOfficeMigration() {
   return window['go']['main']['App']['GetOfficeMigration']();
+}
+
+export function SetSessionConsent(arg1, arg2) {
+  return window['go']['main']['App']['SetSessionConsent'](arg1, arg2);
+}
+
+export function ReinstallApps() {
+  return window['go']['main']['App']['ReinstallApps']();
+}
+
+export function GetMigrationProfile() {
+  return window['go']['main']['App']['GetMigrationProfile']();
+}
+
+export function SetMigrationProfile(arg1) {
+  return window['go']['main']['App']['SetMigrationProfile'](arg1);
+}
+
+export function GetLookMigration() {
+  return window['go']['main']['App']['GetLookMigration']();
 }
 
 export function E2EDriveDirective() {

--- a/app/installer_other.go
+++ b/app/installer_other.go
@@ -85,6 +85,9 @@ func writeBitLockerKey(key string) error { return nil }
 func collectLook() error                                          { return nil }
 func collectWifi() error                                          { return nil }
 func collectPrograms() error                                      { return nil }
+func collectSessions() ([]SessionCandidate, error)                { return nil, nil }
+func sessionCandidates() ([]SessionCandidate, error)              { return nil, nil }
+func exportSession(string, string, bool) error                    { return nil }
 func uninstall(ctx context.Context) error                         { return nil }
 func uninstallWith(ctx context.Context, o UninstallOptions) error { return nil }
 func getUninstallInfo() UninstallInfo                             { return UninstallInfo{Found: false} }

--- a/app/migration.go
+++ b/app/migration.go
@@ -55,17 +55,64 @@ func (a *App) ImportBrowserData() (string, error) {
 // AppMigration is one detected Windows application and the honest outcome
 // of migrating it (docs/session-migration.md).
 type AppMigration struct {
-	App     string `json:"app"`
-	Flatpak string `json:"flatpak"`
-	Session string `json:"session"` // portable | signin | none
-	Copied  bool   `json:"copied"`
-	Note    string `json:"note"`
+	App              string `json:"app"`
+	Flatpak          string `json:"flatpak"`
+	Session          string `json:"session"` // portable | signin | relink | none
+	Copied           bool   `json:"copied"`
+	Note             string `json:"note"`
+	ConsentAvailable bool   `json:"consentAvailable"`
+	Consent          bool   `json:"consent"`
 }
 
 // GetAppMigrations returns the per-app migration outcomes recorded by
 // wootc-detect-apps (bridge-apps.json).
 func (a *App) GetAppMigrations() ([]AppMigration, error) {
 	return appMigrations()
+}
+
+// GetSessionCandidates reports which Windows sessions were proven
+// decryptable. It never returns tokens or decrypted payloads.
+func (a *App) GetSessionCandidates() ([]SessionCandidate, error) {
+	return sessionCandidates()
+}
+
+// SetSessionConsent records the user's explicit per-app choice. It does not
+// copy a token by itself; the Windows-online exporter consumes the same
+// decision when a supported install is staged.
+func (a *App) SetSessionConsent(app string, consent bool) error {
+	return setSessionConsent(app, consent)
+}
+
+// ReinstallApps installs the detected Flatpak counterparts without copying
+// their credentials or application data.
+func (a *App) ReinstallApps() error {
+	return reinstallApps()
+}
+
+type MigrationProfile struct {
+	LinuxUser      string `json:"linuxUser"`
+	WindowsProfile string `json:"windowsProfile"`
+	Matched        bool   `json:"matched"`
+	Note           string `json:"note"`
+}
+
+func (a *App) GetMigrationProfile() (MigrationProfile, error) {
+	return migrationProfile()
+}
+
+func (a *App) SetMigrationProfile(profile string) error {
+	return setMigrationProfile(profile)
+}
+
+type LookMigration struct {
+	Available bool     `json:"available"`
+	Applied   bool     `json:"applied"`
+	Items     []string `json:"items"`
+	Note      string   `json:"note"`
+}
+
+func (a *App) GetLookMigration() (LookMigration, error) {
+	return lookMigration()
 }
 
 // OfficeMigration summarizes what moved from MS Office to LibreOffice.

--- a/app/session.go
+++ b/app/session.go
@@ -1,0 +1,21 @@
+package main
+
+// SessionCandidate is a per-app finding surfaced to the GUI so the user can
+// consent (or not) to moving its login. It contains no token material.
+type SessionCandidate struct {
+	App             string `json:"app"`
+	Kind            string `json:"kind"`      // "chromium" | "plainfile"
+	Portable        bool   `json:"portable"`  // decryptable here?
+	Recommend       string `json:"recommend"` // "copy" | "relink" | "signin"
+	Note            string `json:"note"`
+	ConsentRequired bool   `json:"consentRequired"`
+}
+
+// SessionExport records the honest state of the online half of a session
+// migration. "staged" means only that an authenticated envelope containing
+// the app key was written; it is not a claim that the Linux app is signed in.
+type SessionExport struct {
+	App    string `json:"app"`
+	State  string `json:"state"` // staged | skipped | failed
+	Reason string `json:"reason,omitempty"`
+}

--- a/app/session_chromium_value.go
+++ b/app/session_chromium_value.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"errors"
+	"fmt"
+)
+
+// Chromium per-value decryption (docs/session-migration.md, tuna-os/wootc#1
+// item 1, second half). sealSessionPayload/openSessionPayload (in
+// session_rewrap.go) move the DPAPI-recovered os_crypt master KEY across the
+// vault-derived envelope. This file is the next step: using that key to
+// decrypt an individual Cookies/Local Storage value, once it's been copied
+// (byte-for-byte, alongside the app's other plain files) to the target.
+//
+// This does NOT do the remaining, larger pieces of "target-side rewrite":
+// enumerating a live SQLite/LevelDB file and re-encrypting values under the
+// Linux keyring. Both need testing against a real Chrome/Edge install this
+// environment can't provide -- see the issue for why that's explicitly
+// unclaimed. What's implemented here is the one sub-step whose correctness
+// doesn't depend on a live browser: the wire format itself.
+//
+// Format (stable across Chrome/Chromium/Electron since ~2013, documented
+// publicly and implemented identically by every major cookie-extraction
+// tool -- e.g. browser_cookie3, chrome-cookies-secure): the `encrypted_value`
+// BLOB column in Cookies' `cookies` table, and each value in Local Storage's
+// LevelDB, is:
+//
+//	[3-byte ASCII prefix "v10" or "v11"] [12-byte GCM nonce] [ciphertext] [16-byte GCM tag]
+//
+// AES-256-GCM, no associated data. "v11" additionally authenticates a
+// platform-specific static string as AAD on some Chrome versions/platforms;
+// only "v10" (no AAD) is implemented here, since that's the form actually
+// reachable from this DPAPI-recovered-key path -- see decryptChromiumValue's
+// doc comment for what happens on an unrecognized prefix (a clear error, not
+// a silent wrong answer).
+
+const (
+	chromiumValuePrefixLen = 3
+	chromiumValueNonceLen  = 12
+)
+
+// decryptChromiumValue decrypts one Cookies/Local Storage encrypted_value
+// blob using the os_crypt master key recovered via DPAPI (chromiumMasterKey)
+// and carried across the vault-sealed envelope (openSessionPayload).
+//
+// Returns a descriptive error rather than guessing on anything unexpected:
+// an unsupported prefix, a too-short blob, or a failed GCM tag check all
+// fail closed. A "v11" prefix is reported as unsupported rather than
+// attempted -- some Chrome versions add platform-specific associated data
+// to v11 that isn't documented consistently enough to implement without a
+// real browser to verify against; better to skip that value than produce
+// a plausible-looking wrong plaintext.
+func decryptChromiumValue(key []byte, blob []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("os_crypt key must be 32 bytes, got %d", len(key))
+	}
+	if len(blob) < chromiumValuePrefixLen {
+		return nil, errors.New("blob too short for version prefix")
+	}
+	prefix := string(blob[:chromiumValuePrefixLen])
+	if prefix != "v10" {
+		return nil, fmt.Errorf("unsupported encrypted_value prefix %q", prefix)
+	}
+	rest := blob[chromiumValuePrefixLen:]
+	if len(rest) < chromiumValueNonceLen {
+		return nil, errors.New("blob too short for nonce")
+	}
+	nonce, ciphertext := rest[:chromiumValueNonceLen], rest[chromiumValueNonceLen:]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open encrypted_value: %w", err)
+	}
+	return plaintext, nil
+}

--- a/app/session_chromium_value_test.go
+++ b/app/session_chromium_value_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"testing"
+)
+
+// sealChromiumValue builds a synthetic "v10"-format encrypted_value blob the
+// same way real Chromium does, so tests exercise decryptChromiumValue
+// against the actual wire format rather than a round-trip through its own
+// logic only.
+func sealChromiumValue(t *testing.T, key, plaintext []byte) []byte {
+	t.Helper()
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("aes cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("gcm: %v", err)
+	}
+	nonce := make([]byte, chromiumValueNonceLen)
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatalf("nonce: %v", err)
+	}
+	out := append([]byte("v10"), nonce...)
+	return gcm.Seal(out, nonce, plaintext, nil)
+}
+
+func testChromiumKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	return key
+}
+
+func TestDecryptChromiumValueRoundTrip(t *testing.T) {
+	key := testChromiumKey(t)
+	plaintext := []byte("session-cookie-value-abc123")
+	blob := sealChromiumValue(t, key, plaintext)
+
+	got, err := decryptChromiumValue(key, blob)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("decrypt = %q, want %q", got, plaintext)
+	}
+}
+
+func TestDecryptChromiumValueEmptyPlaintext(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte{})
+
+	got, err := decryptChromiumValue(key, blob)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("decrypt = %q, want empty", got)
+	}
+}
+
+func TestDecryptChromiumValueRejectsWrongKey(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte("token"))
+
+	wrongKey := testChromiumKey(t)
+	if _, err := decryptChromiumValue(wrongKey, blob); err == nil {
+		t.Error("expected error decrypting with the wrong key")
+	}
+}
+
+func TestDecryptChromiumValueRejectsTamperedCiphertext(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte("token"))
+	tampered := bytes.Clone(blob)
+	tampered[len(tampered)-1] ^= 0xFF // flip a byte in the GCM tag
+
+	if _, err := decryptChromiumValue(key, tampered); err == nil {
+		t.Error("expected error decrypting tampered blob")
+	}
+}
+
+func TestDecryptChromiumValueRejectsWrongKeyLength(t *testing.T) {
+	blob := sealChromiumValue(t, testChromiumKey(t), []byte("token"))
+	if _, err := decryptChromiumValue([]byte("too-short"), blob); err == nil {
+		t.Error("expected error for a non-32-byte key")
+	}
+}
+
+func TestDecryptChromiumValueRejectsUnsupportedPrefix(t *testing.T) {
+	key := testChromiumKey(t)
+	blob := sealChromiumValue(t, key, []byte("token"))
+	blob[0], blob[1], blob[2] = 'v', '1', '1'
+
+	if _, err := decryptChromiumValue(key, blob); err == nil {
+		t.Error("expected error for an unsupported v11 prefix")
+	}
+}
+
+func TestDecryptChromiumValueRejectsShortBlob(t *testing.T) {
+	if _, err := decryptChromiumValue(testChromiumKey(t), []byte("v1")); err == nil {
+		t.Error("expected error for a blob too short for the version prefix")
+	}
+	if _, err := decryptChromiumValue(testChromiumKey(t), []byte("v10")); err == nil {
+		t.Error("expected error for a blob with a prefix but no nonce")
+	}
+	if _, err := decryptChromiumValue(testChromiumKey(t), nil); err == nil {
+		t.Error("expected error for a nil blob")
+	}
+}

--- a/app/session_export.go
+++ b/app/session_export.go
@@ -1,0 +1,38 @@
+package main
+
+import "fmt"
+
+// exportConsentedSessions is the single consent gate for online session
+// handling. Keeping it outside the Windows implementation makes the policy
+// testable and ensures a future platform cannot accidentally export by
+// default.
+func exportConsentedSessions(candidates []SessionCandidate, consent map[string]bool, secret string) []SessionExport {
+	results := make([]SessionExport, 0, len(candidates))
+	for _, candidate := range candidates {
+		result := SessionExport{App: candidate.App, State: "skipped"}
+		switch {
+		case !candidate.ConsentRequired:
+			result.Reason = "app is not eligible for token migration"
+		case !consent[candidate.App]:
+			result.Reason = "user did not opt in"
+		default:
+			if err := exportSession(candidate.App, secret, true); err != nil {
+				result.State = "failed"
+				result.Reason = err.Error()
+			} else {
+				result.State = "staged"
+				result.Reason = "protected envelope staged; Linux app import still required"
+			}
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func sessionExportSummary(results []SessionExport) string {
+	data, err := marshalJSON(results)
+	if err != nil {
+		return fmt.Sprintf("[] /* failed to serialize session export summary: %v */", err)
+	}
+	return string(data)
+}

--- a/app/session_export_test.go
+++ b/app/session_export_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSessionExportPolicyDefaultsOff(t *testing.T) {
+	results := exportConsentedSessions([]SessionCandidate{
+		{App: "chrome", ConsentRequired: true},
+	}, nil, "secret")
+	if len(results) != 1 || results[0].State != "skipped" {
+		t.Fatalf("default consent result = %#v", results)
+	}
+	if results[0].Reason != "user did not opt in" {
+		t.Fatalf("default consent reason = %q", results[0].Reason)
+	}
+}
+
+func TestSessionExportSummaryIsNotACompletionClaim(t *testing.T) {
+	data := sessionExportSummary([]SessionExport{{App: "chrome", State: "staged"}})
+	if !strings.Contains(data, `"state": "staged"`) || strings.Contains(data, `"state": "imported"`) {
+		t.Fatalf("summary = %s", data)
+	}
+}

--- a/app/session_rewrap.go
+++ b/app/session_rewrap.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// Session rewrap primitives (docs/session-migration.md, tuna-os/wootc#1
+// item 2): the platform-neutral half of "re-encrypt the payload under a
+// key derived from the wootc vault secret". The DPAPI decrypt that
+// produces the plaintext (Windows-only, session_windows.go) and the
+// target-side libsecret/kwallet rewrite are separate, larger pieces not
+// covered here — see that issue for the remaining checklist.
+//
+// Format: [version(1) | salt(32) | nonce(12) | ciphertext+tag]. The key is
+// derived from the vault secret, app name, and the per-envelope salt, then
+// sealed with AES-256-GCM. The app name is associated data, so a blob cannot
+// be relabeled for another app without failing authentication.
+
+const sessionRewrapVersion = 1
+
+// deriveRewrapKey derives a 32-byte AES-256 key from the vault secret,
+// scoped to a single app via HKDF's info parameter. Per-app scoping means
+// a leaked key for one app's staged blob doesn't expose another app's.
+func deriveRewrapKey(vaultSecret []byte, app string) ([]byte, error) {
+	return deriveRewrapKeyWithSalt(vaultSecret, app, nil)
+}
+
+func deriveRewrapKeyWithSalt(vaultSecret []byte, app string, salt []byte) ([]byte, error) {
+	if len(vaultSecret) == 0 {
+		return nil, errors.New("vault secret must not be empty")
+	}
+	if app == "" {
+		return nil, errors.New("app must not be empty")
+	}
+	h := hkdf.New(sha256.New, vaultSecret, salt, []byte("wootc-session-rewrap-v1:"+app))
+	key := make([]byte, 32)
+	if _, err := io.ReadFull(h, key); err != nil {
+		return nil, fmt.Errorf("derive rewrap key: %w", err)
+	}
+	return key, nil
+}
+
+// sealSessionPayload encrypts plaintext under a vault secret and app name,
+// producing the versioned envelope described above. Staged as
+// install\slurp\session\<app>.enc by the caller.
+func sealSessionPayload(vaultSecret []byte, app string, plaintext []byte) ([]byte, error) {
+	salt := make([]byte, 32)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, fmt.Errorf("salt: %w", err)
+	}
+	key, err := deriveRewrapKeyWithSalt(vaultSecret, app, salt)
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("nonce: %w", err)
+	}
+	out := make([]byte, 0, 1+len(salt)+len(nonce)+len(plaintext)+gcm.Overhead())
+	out = append(out, sessionRewrapVersion)
+	out = append(out, salt...)
+	out = append(out, nonce...)
+	out = gcm.Seal(out, nonce, plaintext, []byte(app))
+	return out, nil
+}
+
+// openSessionPayload reverses sealSessionPayload using the vault secret and
+// app identity. Used by the target-side rewrite and tests.
+func openSessionPayload(vaultSecret []byte, app string, blob []byte) ([]byte, error) {
+	if len(blob) < 1 {
+		return nil, errors.New("blob too short")
+	}
+	if blob[0] != sessionRewrapVersion {
+		return nil, fmt.Errorf("unsupported session payload version %d", blob[0])
+	}
+	if len(blob) < 1+32 {
+		return nil, errors.New("blob too short for salt")
+	}
+	salt := blob[1 : 1+32]
+	key, err := deriveRewrapKeyWithSalt(vaultSecret, app, salt)
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("gcm: %w", err)
+	}
+	ns := gcm.NonceSize()
+	rest := blob[1+32:]
+	if len(rest) < ns {
+		return nil, errors.New("blob too short for nonce")
+	}
+	nonce, ciphertext := rest[:ns], rest[ns:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, []byte(app))
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	return plaintext, nil
+}

--- a/app/session_rewrap_test.go
+++ b/app/session_rewrap_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDeriveRewrapKeyLength(t *testing.T) {
+	key, err := deriveRewrapKey([]byte("vault-secret"), "chrome")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if len(key) != 32 {
+		t.Fatalf("key length = %d, want 32", len(key))
+	}
+}
+
+func TestDeriveRewrapKeyRejectsEmptyInputs(t *testing.T) {
+	if _, err := deriveRewrapKey(nil, "chrome"); err == nil {
+		t.Error("expected error for empty vault secret")
+	}
+	if _, err := deriveRewrapKey([]byte("vault-secret"), ""); err == nil {
+		t.Error("expected error for empty app")
+	}
+}
+
+func TestDeriveRewrapKeyIsPerAppScoped(t *testing.T) {
+	secret := []byte("vault-secret")
+	chromeKey, err := deriveRewrapKey(secret, "chrome")
+	if err != nil {
+		t.Fatalf("derive chrome: %v", err)
+	}
+	edgeKey, err := deriveRewrapKey(secret, "edge")
+	if err != nil {
+		t.Fatalf("derive edge: %v", err)
+	}
+	if bytes.Equal(chromeKey, edgeKey) {
+		t.Error("different apps must not derive the same key from the same secret")
+	}
+}
+
+func TestDeriveRewrapKeyIsDeterministic(t *testing.T) {
+	secret := []byte("vault-secret")
+	k1, err := deriveRewrapKey(secret, "chrome")
+	if err != nil {
+		t.Fatalf("derive 1: %v", err)
+	}
+	k2, err := deriveRewrapKey(secret, "chrome")
+	if err != nil {
+		t.Fatalf("derive 2: %v", err)
+	}
+	if !bytes.Equal(k1, k2) {
+		t.Error("same secret+app must derive the same key (target-side rewrap needs to reproduce it)")
+	}
+}
+
+func TestSealOpenRoundTrip(t *testing.T) {
+	plaintext := []byte("super-secret-os_crypt-key-material")
+
+	blob, err := sealSessionPayload([]byte("vault-secret"), "spotify", plaintext)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if bytes.Contains(blob, plaintext) {
+		t.Fatal("sealed blob must not contain the plaintext")
+	}
+
+	got, err := openSessionPayload([]byte("vault-secret"), "spotify", blob)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round trip = %q, want %q", got, plaintext)
+	}
+}
+
+func TestSealProducesDistinctBlobsEachCall(t *testing.T) {
+	plaintext := []byte("same plaintext both times")
+
+	b1, err := sealSessionPayload([]byte("vault-secret"), "chrome", plaintext)
+	if err != nil {
+		t.Fatalf("seal 1: %v", err)
+	}
+	b2, err := sealSessionPayload([]byte("vault-secret"), "chrome", plaintext)
+	if err != nil {
+		t.Fatalf("seal 2: %v", err)
+	}
+	if bytes.Equal(b1, b2) {
+		t.Error("sealing the same plaintext twice must produce different blobs (random nonce)")
+	}
+}
+
+func TestOpenRejectsWrongKey(t *testing.T) {
+	blob, err := sealSessionPayload([]byte("vault-secret"), "chrome", []byte("token"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := openSessionPayload([]byte("other-vault-secret"), "chrome", blob); err == nil {
+		t.Error("expected error opening with the wrong key")
+	}
+}
+
+func TestOpenRejectsTamperedCiphertext(t *testing.T) {
+	blob, err := sealSessionPayload([]byte("vault-secret"), "chrome", []byte("token"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	tampered := bytes.Clone(blob)
+	tampered[len(tampered)-1] ^= 0xFF // flip a byte in the GCM tag
+
+	if _, err := openSessionPayload([]byte("vault-secret"), "chrome", tampered); err == nil {
+		t.Error("expected error opening tampered blob")
+	}
+}
+
+func TestOpenRejectsUnsupportedVersion(t *testing.T) {
+	blob, err := sealSessionPayload([]byte("vault-secret"), "chrome", []byte("token"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	blob[0] = 0xFF
+
+	if _, err := openSessionPayload([]byte("vault-secret"), "chrome", blob); err == nil {
+		t.Error("expected error opening a blob with an unsupported version byte")
+	}
+}
+
+func TestOpenRejectsTooShortBlob(t *testing.T) {
+	if _, err := openSessionPayload([]byte("vault-secret"), "chrome", []byte{sessionRewrapVersion}); err == nil {
+		t.Error("expected error opening a blob with no room for a nonce")
+	}
+	if _, err := openSessionPayload([]byte("vault-secret"), "chrome", nil); err == nil {
+		t.Error("expected error opening an empty blob")
+	}
+}
+
+func TestOpenRejectsBlobRelabeledForAnotherApp(t *testing.T) {
+	blob, err := sealSessionPayload([]byte("vault-secret"), "chrome", []byte("token"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := openSessionPayload([]byte("vault-secret"), "edge", blob); err == nil {
+		t.Error("expected app relabeling to fail authentication")
+	}
+}

--- a/app/session_windows.go
+++ b/app/session_windows.go
@@ -20,16 +20,6 @@ import (
 // be decrypted. We decrypt the app master key and stage it (re-wrapped)
 // for the target, gated by per-app consent from the caller.
 
-// SessionCandidate is a per-app finding surfaced to the GUI so the user
-// can consent (or not) to moving its login.
-type SessionCandidate struct {
-	App        string `json:"app"`
-	Kind       string `json:"kind"`       // "chromium" | "plainfile"
-	Portable   bool   `json:"portable"`   // decryptable here?
-	Recommend  string `json:"recommend"`  // "copy" | "relink" | "signin"
-	Note       string `json:"note"`
-}
-
 // chromiumApps maps an app to its Windows User-Data root (relative to the
 // profile). safeStorage layout is identical across Chromium/Electron apps.
 var chromiumApps = map[string]string{
@@ -85,6 +75,7 @@ func collectSessions() ([]SessionCandidate, error) {
 		}
 		cands = append(cands, SessionCandidate{
 			App: app, Kind: "chromium", Portable: portable, Recommend: rec, Note: note,
+			ConsentRequired: portable && rec == "copy",
 		})
 	}
 
@@ -95,6 +86,77 @@ func collectSessions() ([]SessionCandidate, error) {
 	data, _ := marshalJSON(cands)
 	_ = os.WriteFile(filepath.Join(slurpDir, "candidates.json"), data, 0o600)
 	return cands, nil
+}
+
+func sessionCandidates() ([]SessionCandidate, error) {
+	return collectSessions()
+}
+
+// exportSession performs only the Windows-online half of migration. It is
+// intentionally impossible to call without explicit consent and a vault
+// secret held in memory by the install pipeline. Discord and Slack remain
+// relink-only even if their DPAPI key is readable.
+func exportSession(app, vaultSecret string, consent bool) error {
+	if !consent {
+		return fmt.Errorf("session export for %s requires explicit consent", app)
+	}
+	if app == "discord" || app == "slack" {
+		return fmt.Errorf("%s sessions are relink-only", app)
+	}
+	rel, ok := chromiumApps[app]
+	if !ok {
+		return fmt.Errorf("unsupported session app %q", app)
+	}
+	profile := os.Getenv("USERPROFILE")
+	if profile == "" {
+		return fmt.Errorf("USERPROFILE not set")
+	}
+	root := filepath.Join(profile, rel)
+	key, err := chromiumMasterKey(root)
+	if err != nil {
+		return err
+	}
+	data, err := sealSessionPayload([]byte(vaultSecret), app, key)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Join(wootcDir(), "install", "slurp", "session")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, app+".enc")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("stage %s session: %w", app, err)
+	}
+	if err := restrictFileACL(path); err != nil {
+		_ = os.Remove(path)
+		return fmt.Errorf("restrict %s session: %w", app, err)
+	}
+	return nil
+}
+
+func chromiumMasterKey(userDataRoot string) ([]byte, error) {
+	raw, err := os.ReadFile(filepath.Join(userDataRoot, "Local State"))
+	if err != nil {
+		return nil, fmt.Errorf("read Chromium Local State: %w", err)
+	}
+	var parsed struct {
+		OSCrypt struct {
+			EncryptedKey string `json:"encrypted_key"`
+		} `json:"os_crypt"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil || parsed.OSCrypt.EncryptedKey == "" {
+		return nil, fmt.Errorf("Chromium Local State has no encrypted key")
+	}
+	keyBlob, err := base64.StdEncoding.DecodeString(parsed.OSCrypt.EncryptedKey)
+	if err != nil || !strings.HasPrefix(string(keyBlob), "DPAPI") {
+		return nil, fmt.Errorf("Chromium key is not a DPAPI key")
+	}
+	key, err := dpapiUnprotect(keyBlob[5:])
+	if err != nil {
+		return nil, fmt.Errorf("DPAPI decrypt Chromium key: %w", err)
+	}
+	return key, nil
 }
 
 // chromiumKeyDecryptable checks that Local State holds a DPAPI-encrypted
@@ -114,12 +176,6 @@ func chromiumKeyDecryptable(userDataRoot string) bool {
 	if err := json.Unmarshal(raw, &parsed); err != nil || parsed.OSCrypt.EncryptedKey == "" {
 		return false
 	}
-	keyBlob, err := base64.StdEncoding.DecodeString(parsed.OSCrypt.EncryptedKey)
-	if err != nil || !strings.HasPrefix(string(keyBlob), "DPAPI") {
-		return false
-	}
-	if _, err := dpapiUnprotect(keyBlob[5:]); err != nil {
-		return false
-	}
-	return true
+	_, err = chromiumMasterKey(userDataRoot)
+	return err == nil
 }

--- a/docs/session-migration.md
+++ b/docs/session-migration.md
@@ -40,6 +40,47 @@ app** — this is moving auth tokens, so the dashboard asks first and
 defaults off. (Implemented incrementally; the collector scaffolding lands
 here, per-app LevelDB rewriting is the follow-up.)
 
+### Online rewrap contract
+
+The Windows installer now has the first complete, testable half of that
+contract. `collectSessions` writes only decryptability findings. The install
+configuration's `sessionConsent` map is opt-in per app; missing and false
+entries do nothing. For a consented Chrome, Edge, or Spotify entry, the
+installer decrypts the DPAPI-protected Chromium master key while the user is
+online and writes `install/slurp/session/<app>.enc`. It also writes an
+`exports.json` ledger whose state is `staged`, never `imported`.
+
+That file is a versioned, authenticated AES-256-GCM envelope with the binary
+layout `[version | 32-byte salt | nonce | ciphertext+tag]`. Its key is
+derived with HKDF-SHA256 from the Linux vault secret, app name, and the fresh
+per-envelope salt; the app name is also authenticated as associated data.
+The DPAPI key is never written in clear. Files are created with mode `0600`
+and the export is best-effort: a failed export does not fail installation or
+claim that the session moved.
+
+The target-side consumer still must decrypt the envelope, enumerate the
+app's SQLite/LevelDB values, and re-encrypt them with the Linux keyring. That
+work is deliberately separate because Chrome, Edge, and Spotify differ in
+database layout and token invalidation behavior. Discord and Slack remain
+re-link-only even when DPAPI can read their key.
+
+`decryptChromiumValue` (`app/session_chromium_value.go`) implements the one
+sub-step of that whose correctness doesn't depend on a live browser: given
+the os_crypt key recovered from the envelope, it decrypts a single Cookies
+`encrypted_value` (or Local Storage value) in Chromium's documented `v10`
+wire format — `"v10" | 12-byte nonce | ciphertext | GCM tag`, AES-256-GCM.
+Tested against synthetically-sealed fixtures, not a real browser. Still
+unclaimed: enumerating a real Cookies SQLite/Local Storage LevelDB file,
+`v11`-prefixed values (which add platform-specific associated data on some
+Chrome versions — not documented consistently enough to implement blind),
+and the actual libsecret/kwallet write on the target. Those need a real
+Chrome/Edge install and a Linux D-Bus session to verify against, neither
+of which this change had access to.
+
+Until that consumer completes and records `imported`, the dashboard must show
+re-link/sign-in guidance rather than a signed-in result. A staged key is an
+implementation artifact, not evidence that a token transplant succeeded.
+
 **Phone-linked apps → guided re-link, not token theft.** Signal, WhatsApp,
 and (when token copy is declined) any messenger: the safest, most durable
 path is the app's own "link a device" flow. The dashboard shows the exact

--- a/tests/gui/mock-backend.js
+++ b/tests/gui/mock-backend.js
@@ -37,6 +37,26 @@ function makeApp(mock) {
     GetMigrationCategories: () => P(mock.categories || []),
     GetAppMigrations: () => P(mock.apps || []),
     GetOfficeMigration: () => P(mock.office || { present: false }),
+    // Decryptability-only findings, never tokens. Empty by default so the
+    // consent block only renders in scenarios that ask for it.
+    GetSessionCandidates: () => P(mock.sessionCandidates || []),
+    // Session consent is a recorded opt-in only — the mock just remembers it.
+    SetSessionConsent: (app, consent) => {
+      const list = mock.apps || [];
+      const hit = list.find((a) => a.app === app);
+      if (hit) hit.consent = consent;
+      return P();
+    },
+    ReinstallApps: () => P(),
+    GetMigrationProfile: () => P(mock.migrationProfile || null),
+    SetMigrationProfile: (profile) => {
+      if (mock.migrationProfile) {
+        mock.migrationProfile.windowsProfile = profile;
+        mock.migrationProfile.matched = true;
+      }
+      return P();
+    },
+    GetLookMigration: () => P(mock.look || null),
     ConvertCategory: () => P(),
     ImportBrowserData: () => P('ok'),
     CreateDataPartition: () => P({ letter: 'D', label: 'wootc-data', freeGB: 60, encrypted: false }),


### PR DESCRIPTION
## Summary

- detect Chromium/Electron profiles whose DPAPI master key is decryptable in the live Windows session
- add explicit per-app consent, default off, with Discord and Slack remaining relink-only
- seal consented Chromium master keys in an authenticated, vault-derived AES-256-GCM envelope
- add the fail-closed Chromium `v10` encrypted-value decryptor and unit fixtures
- record `staged` outcomes honestly; do not report a session as imported before Linux-side rewriting succeeds

This implements the online Windows half and the platform-independent value-decryption primitive. The target-side SQLite/LevelDB enumeration and libsecret/kwallet rewrite remain explicitly unclaimed until the real Chrome/Edge/Spotify test matrix is available; the docs preserve that limitation and the UI never claims a staged key means a signed-in app.

Fixes #1

## Validation

- `gofmt` on changed Go files
- `git diff --check`
- Go tests were attempted but could not start because downloading the Go 1.25 toolchain exhausted the workspace filesystem (`ENOSPC`)