### PR TITLE
fix(ci): stop handing the bootc target image to podman-compose (#166)

### DIFF
--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -205,7 +205,18 @@ jobs:
           # Passed as a $-var, not interpolated into the run: block, so a
           # value containing "/`/$() in this attacker-influenceable
           # workflow_dispatch input cannot execute shell on the runner. See #154.
-          WOOTC_E2E_IMAGE: ${{ inputs.image }}
+          #
+          # DO NOT name this WOOTC_E2E_IMAGE. That name is already taken by the
+          # harness for the *Windows container* image (compose.yml's `image:`
+          # and run-e2e.sh's dockur preflight both read it, defaulting to
+          # localhost/wootc-e2e-windows-ssh:latest). Because `env:` exports to
+          # the whole step, setting it here handed podman-compose the *bootc
+          # target* image instead, so the "Windows VM" was really a bootc OS
+          # container: it booted systemd, never ran QEMU, and every run died on
+          # "QEMU did not start within 15 minutes" with an empty container.log
+          # and a guest process list full of gdm/NetworkManager. That is #166,
+          # introduced here by 2617aed (#159) on 2026-08-14.
+          WOOTC_TARGET_IMAGE: ${{ inputs.image }}
         run: |
           cd tests/e2e
           FLAGS=""
@@ -215,7 +226,7 @@ jobs:
           # ENTIRE matrix finishes, so without this a failing cell cannot be
           # diagnosed for hours — the evidence artifact is the only way in.
           set -o pipefail
-          bash run-e2e.sh "$WOOTC_E2E_IMAGE" $FLAGS 2>&1 | tee /tmp/run-e2e-console.log
+          bash run-e2e.sh "$WOOTC_TARGET_IMAGE" $FLAGS 2>&1 | tee /tmp/run-e2e-console.log
 
       - name: Collect evidence
         if: always()


### PR DESCRIPTION
Fixes #166.

## The bug

`WOOTC_E2E_IMAGE` already names the **Windows container** image — both `tests/e2e/compose.yml` (`image:`) and `run-e2e.sh`'s dockur preflight read it, defaulting to `localhost/wootc-e2e-windows-ssh:latest`.

`e2e-hosted.yml` set that same variable to the **bootc target** image. Since `env:` exports to the whole step, `podman-compose` launched `ghcr.io/projectbluefin/bluefin:lts` *as the VM container*. That is a valid OS image, so it started happily, ran systemd, and never ran QEMU.

Every hosted E2E has failed this way since 2026-08-15:

```
[FAIL] QEMU did not start within 15 minutes
```

with an empty `container.log` and a guest process list of `gdm` / `NetworkManager` / `tailscaled` — a Fedora boot, not a Windows VM.

## Origin

Introduced by 2617aed (#159), which moved the image into an `env:` block so an attacker-influenceable `workflow_dispatch` input could not execute shell on the runner. **That fix was correct** — only the variable name was wrong.

## The fix

Renamed the pass-through to `WOOTC_TARGET_IMAGE` (read by nothing else) and documented the collision inline so it cannot silently return.

## Note on #166's history

The issue actually covers **two** sequential causes. The earlier failures (08-07 → 08-14, fast 6-10 min) were `Deployer build failed` from the fedora:46 keyring mismatch (#135), already fixed in main by the `fedora:45` pin. This PR addresses the current one.

## Verification

- No stale references remain in any workflow.
- All four E2E workflows still parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)