### PR TITLE
fix(deployer): stop the boot splash showing a false emergency shell

### DIFF
--- a/payload/deployer/Containerfile
+++ b/payload/deployer/Containerfile
@@ -61,6 +61,7 @@ RUN printf 'sysloglvl=0\n' > /etc/dracut.conf.d/99-wootc.conf && \
         --add-drivers "xfs btrfs" \
         --install "podman skopeo fisherman ostree cpio \
                    /usr/share/containers/policy.json /usr/share/containers/registries.conf \
+                   ntfs-3g lowntfs-3g mount.ntfs \
                    parted mkfs.ext4 mkfs.vfat mkfs.xfs mkfs.btrfs \
                    losetup qemu-nbd dmsetup cryptsetup systemd-cryptenroll \
                     /usr/lib/systemd/systemd-cryptsetup \
@@ -73,8 +74,18 @@ RUN printf 'sysloglvl=0\n' > /etc/dracut.conf.d/99-wootc.conf && \
 # inst_multiple fails SILENTLY when any one entry is missing (a missing
 # restorecon once dropped conmon/crun/podman and cost a full E2E debug
 # cycle), so the build must fail loudly here instead.
+# ntfs-3g is in this list deliberately. The image-injection path in deploy.sh
+# has a survivable fallback ("Phase 2 will carry the DEPLOYER's ntfs-3g
+# instead", deploy.sh:847) that is gated on `command -v ntfs-3g` INSIDE the
+# initramfs. ntfs-3g was installed into the builder above but never named in
+# dracut's --install list, so only libntfs-3g.so and the ntfs3 kernel module
+# ever landed — the binary did not, the guard was always false, and a target
+# image that could not be injected became a FATAL refusal instead of taking
+# the fallback. That is precisely the silent-drop failure this loop exists to
+# catch, so assert it here too.
 RUN for bin in conmon crun podman skopeo fisherman ostree cpio sfdisk mkfs.ext4 \
         mkfs.xfs qemu-ga qemu-img qemu-nbd cryptsetup systemd-cryptenroll \
+        ntfs-3g \
         df sync truncate journalctl jq tee which basename date head; do \
         lsinitrd /out/deployer-initramfs.img | grep -q "bin/${bin}$" || \
             { echo "FATAL: ${bin} missing from initramfs"; exit 1; }; \

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -476,7 +476,7 @@ if [[ -f "$DISK" ]]; then
         while [ "$_done_mb" -lt "$_total_mb" ]; do
             _n_mb=$(( _total_mb - _done_mb ))
             [ "$_n_mb" -gt "$_chunk_mb" ] && _n_mb=$_chunk_mb
-            tr '\0' '\377' < /dev/zero | \
+            tr '\0' '\377' 2>/dev/null < /dev/zero | \
                 dd of="$DISK" bs=1M count="$_n_mb" seek="$_done_mb" conv=notrunc status=none 2>/dev/null || true
             _done_mb=$(( _done_mb + _n_mb ))
             log "  VDL: ${_done_mb}/${_total_mb} MiB after $(( $(date +%s) - _vdl_t0 ))s"
@@ -796,7 +796,13 @@ ensure_ntfs_support() {
         # is EMPTY, which is exactly the case that kept being misread as a repo
         # problem. Print both.
         [ -s "$inj_err" ] && { err "  podman: $(tail -3 "$inj_err" | tr '\n' ' ')"; }
-        timeout 60 podman logs "$cname" 2>&1 | tail -10 >&2 || true
+        # 40, not 10. The install is a `||` chain (dnf -> epel -> microdnf ->
+        # rpm-ostree) and each rung is noisy, so a 10-line tail showed only
+        # rpm-ostree's "not booted via libostree" — the LAST and least
+        # informative failure — while the actual first error scrolled past.
+        # That truncation is what made a corrupt-rpmdb image look like a
+        # network problem for an entire investigation.
+        timeout 60 podman logs "$cname" 2>&1 | tail -40 >&2 || true
         [ "$attempt" -lt 3 ] && sleep $((attempt * 10))
     done
     if [ -z "$inj_ok" ]; then
@@ -858,8 +864,15 @@ if ! ensure_ntfs_support; then
         err "  [FAIL] ${IMAGE} has NO NTFS driver (no kernel ntfs3, no ntfs-3g) and injection failed."
         err "         Phase 2 could not mount the Windows volume that holds root.disk, so it would"
         err "         drop to an emergency shell. Refusing to write an unbootable deployment."
-        err "         Cause is almost always the ntfs-3g install above: network or repo reachability"
-        err "         from the deployer (EPEL/CRB for EL-family images)."
+        err "         Read the per-attempt 'podman:' lines above for the REAL cause — do not assume."
+        err "         Two distinct failure modes look alike here, and only one is a network problem:"
+        err "           * 'Could not resolve host' / 'Curl error' / mirror timeouts"
+        err "               -> genuine EPEL/CRB reachability from the deployer initramfs."
+        err "           * 'sqlite failure: ... database table is locked' / 'Transaction failed'"
+        err "               -> the image's rpmdb could not be written inside podman; NOT network."
+        err "         Note the last fallback (rpm-ostree) always ends in 'not booted via libostree'"
+        err "         because this runs in a container — that message is the tail of the chain, not"
+        err "         the cause, and it masks whichever of the above actually failed first."
         exit 1
     fi
 fi

--- a/payload/deployer/module-setup.sh
+++ b/payload/deployer/module-setup.sh
@@ -20,6 +20,39 @@ install() {
     inst "$moddir/deploy-hook.sh" /usr/lib/dracut/hooks/initqueue/online/99-wootc-deploy.sh
     inst /usr/bin/fisherman
 
+    # Drop systemd's GPT auto-discovery generator.
+    #
+    # This initramfs is a one-shot DEPLOYER: it runs entirely from the initrd
+    # and never switches root, so no boot path passes root= (see the deployer
+    # menuentries in installer_esp.go and setup-wootc.ps1 — all of them pass
+    # only wootc.* args). systemd does not know that, so gpt-auto-generator
+    # synthesises a dev-gpt-auto-root.device, initrd-root-fs.target waits on
+    # it, the device never appears, and at the 90s device timeout systemd
+    # prints the full failure cascade and "Entering emergency mode" over the
+    # friendly splash:
+    #
+    #   Timed out waiting for device dev-gpt-auto-root.device
+    #    -> Dependency failed for sysroot.mount - Root Partition
+    #    -> Dependency failed for initrd-root-fs.target
+    #    -> Entering emergency mode.
+    #
+    # It is cosmetic — dracut-initqueue keeps running our hook and the deploy
+    # completes — but it looks exactly like a fatal error to a user watching
+    # their machine migrate, which is the worst possible moment for it.
+    #
+    # rd.systemd.gpt_auto=0 is the documented switch, but systemd's generators
+    # read /proc/cmdline only; dracut's --kernel-cmdline lands in
+    # /etc/cmdline.d/, which just dracut's own shell helpers parse. Setting it
+    # for real would mean editing every menuentry template in both the Go and
+    # PowerShell installers and remembering to do so for every future one.
+    # Removing the generator here fixes all boot paths at the source. The
+    # deployer mounts everything it needs explicitly, so nothing else the
+    # generator provides (ESP/home/srv/swap auto-mount) is wanted either.
+    #
+    # 99wootc sorts after 00systemd, so the generator is already installed
+    # into $initdir by the time this runs.
+    rm -f "$initdir/usr/lib/systemd/system-generators/systemd-gpt-auto-generator"
+
     # Required binaries. fisherman's host-tool contract (checkRequiredTools in
     # cmd/fisherman/main.go plus its runner.Run call sites) needs sfdisk,
     # mkfs.fat, partprobe, blockdev, fsfreeze, fstrim, wipefs, lsblk, mkswap,

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -2868,6 +2868,9 @@ LAST_PROGRESS_MIN=-1
 DEPLOY_COMPLETE=false
 DEPLOYER_REBOOT_SEEN=false
 DEPLOYER_FATAL_SEEN=false
+# Deployer-stage emergency mode is NOT fatal (see the check below), so it is
+# tracked separately from DEPLOYER_FATAL_SEEN and only reported once.
+DEPLOYER_EMERGENCY_SEEN=false
 KERNEL_REBOOT_SEEN=false
 WINDOWS_BACK_STREAK=0
 LAST_GUEST_HEARTBEAT=""
@@ -3052,6 +3055,29 @@ while ! past_deadline "$DEPLOY_DEADLINE"; do
             fail "Deployer error:"
             echo "$NEW_OUTPUT" | grep -E "fatal|panic|kernel panic|\[FAIL\]"
             break
+        fi
+        # Emergency mode during the DEPLOYER boot. Deliberately a warning, not
+        # a failure: unlike Phase 2 (where emergency means the real root never
+        # appeared and the check below is rightly fatal), the deployer runs
+        # entirely from the initramfs, so systemd can trip emergency.target
+        # while dracut-initqueue carries on and the deploy completes normally.
+        #
+        # It was still worth surfacing: this scan only ever looked for
+        # fatal/panic/[FAIL], so a full "Entering emergency mode" cascade on
+        # the deployer console was STRUCTURALLY INVISIBLE to CI — it took a
+        # human watching a live noVNC console to notice systemd's
+        # gpt-auto-generator timing out on a synthesised dev-gpt-auto-root
+        # device and scaring the user mid-migration. A silent-but-scary
+        # console is a real defect even when the run goes green.
+        if [ "$DEPLOYER_EMERGENCY_SEEN" = false ] &&
+           echo "$NEW_OUTPUT" | grep -qE "Entering emergency mode|Dependency failed for sysroot"; then
+            DEPLOYER_EMERGENCY_SEEN=true
+            warn "deployer console entered EMERGENCY MODE (deploy may still succeed):"
+            echo "$NEW_OUTPUT" \
+                | grep -aE "Timed out waiting for device|Dependency failed for|Entering emergency mode" \
+                | head -8 | sed 's/^/    /' >&2
+            warn "  the deployer boots from the initramfs and never switches root, so"
+            warn "  anything waiting on a root device here is spurious — but the user SEES it."
         fi
         LAST_BYTE=$CURRENT_BYTE
     fi


### PR DESCRIPTION
## Symptom

Mid-migration, the deployer's splash screen showed this over the friendly progress UI:

```
Timed out waiting for device dev-gpt-auto-root.device
 → Dependency failed for sysroot.mount - Root Partition
 → Dependency failed for initrd-root-fs.target
 → Entering emergency mode.
[ 2.29] dracut-initqueue[502]: tr: write error: Broken pipe
[ 2.36] dracut-initqueue[507]: tr: write error: Broken pipe
...
```

The deploy kept running underneath and completed. Nothing was broken — but a nervous user watching their PC convert cannot tell that.

## Three defects

**1. systemd's gpt-auto-generator.** The deployer runs entirely from the initramfs and never switches root, so nothing passes `root=`. systemd invents a `dev-gpt-auto-root.device`, waits 90s, and trips `emergency.target`.

`rd.systemd.gpt_auto=0` is the documented switch, but systemd generators read `/proc/cmdline` only — dracut's `--kernel-cmdline` lands in `/etc/cmdline.d/`, which only dracut's *shell* helpers parse. Using it would mean editing all **nine** menuentry templates across `installer_esp.go` and `setup-wootc.ps1`, plus every future one. Removing the generator in the deployer's own dracut module fixes all boot paths at the source.

**2. `tr: write error: Broken pipe`** — `dd`'s stderr was redirected, `tr`'s was not.

**3. `ntfs-3g` missing from the initramfs.** This is the one that turned a survivable case fatal. `deploy.sh` has a fallback gated on `command -v ntfs-3g`; the Containerfile installed it into the *builder* but never named it in dracut's `--install` list, so only `libntfs-3g.so` and the `ntfs3` module landed. Confirmed against the built initramfs.

045a433 states the intended design outright:

> composefs → the early cpio copies `/usr/bin/ntfs-3g` plus libntfs-3g
> ostree → the NTFS_BINS fallback copies it into the deployment

So the deployer was always meant to carry it. This closes the gap between intent and reality.

## Diagnostics

The refusal message asserted *"network or repo reachability"*. The real observed failure was a **corrupt `rpmdb.sqlite` in the target image** (`SQLITE_CORRUPT` on ~20 btree pages) — nothing to do with the network, and that wrong hint cost an entire investigation. It now distinguishes the two signatures and warns that the trailing `rpm-ostree` error is the tail of the `||` chain, not the cause. `podman logs | tail -10` → `tail -40`, since 10 lines showed only that last rung.

## Why CI never caught it

`run-e2e.sh`'s deployer-stage scan matched only `fatal|panic|kernel panic|[FAIL]`, so an emergency cascade there was **structurally invisible**. It now warns with the relevant lines — a warning, not a failure, because the deploy genuinely survives. Phase 2's emergency check stays fatal.

## Verification

- Generator confirmed absent from the rebuilt initramfs; `systemd-cryptsetup-generator` and the rest intact.
- `usr/bin/ntfs-3g` + `lowntfs-3g` now present, and gated by the build's assertion loop.
- `Broken pipe` occurrences went from dozens to **0** in a real run.
- shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
