### PR TITLE
fix(e2e): two PowerShell bugs that could only fail inside a VM, plus a gate

### DIFF
--- a/tests/e2e/build-ssh-image.sh
+++ b/tests/e2e/build-ssh-image.sh
@@ -158,7 +158,7 @@ SMOKE_OK=true
 # Uses a one-shot swtpm that starts, binds, and terminates immediately —
 # catches missing libraries or broken TPM emulation before a test run.
 if podman run --rm --entrypoint "" "$TARGET_IMAGE" sh -c \
-    'd=/tmp/swtpm-smoke-$$; mkdir -p "$d"; swtpm socket --tpm2 --tpmstate dir="$d" --server type=unix,path="$d.sock" --ctrl type=unix,path="$d-ctrl.sock" --terminate 2>/dev/null & sleep 2; test -S "$d.sock"; rc=$?; kill %1 2>/dev/null; rm -rf "$d" "$d.sock" "$d-ctrl.sock" 2>/dev/null; exit $rc' >/dev/null 2>&1; then
+    'd=/tmp/swtpm-smoke-$$; mkdir -p "$d"; swtpm socket --tpm2 --tpmstate dir="$d" --server type=unixio,path="$d.sock" --ctrl type=unixio,path="$d-ctrl.sock" --terminate 2>/dev/null & sleep 2; test -S "$d.sock"; rc=$?; kill %1 2>/dev/null; rm -rf "$d" "$d.sock" "$d-ctrl.sock" 2>/dev/null; exit $rc' >/dev/null 2>&1; then
     echo "+   swtpm (start + bind socket): OK"
 else
     echo "[FAIL] swtpm cannot start and bind a socket in the derived image — TPM emulation will fail" >&2

--- a/tests/e2e/setup-wootc.ps1
+++ b/tests/e2e/setup-wootc.ps1
@@ -536,7 +536,7 @@ Write-Host "[wootc] Configuring BCD..."
 # Create a new BCD entry by cloning the Windows Boot Manager.
 $bcdCreateOutput = (& bcdedit /copy "{bootmgr}" /d "wootc Deployer" 2>&1) | Out-String
 if ($LASTEXITCODE -ne 0) {
-    throw "bcdedit /copy exited with code $LASTEXITCODE: $bcdCreateOutput"
+    throw "bcdedit /copy exited with code ${LASTEXITCODE}: $bcdCreateOutput"
 }
 Write-Host "[wootc] bcdedit copy: $bcdCreateOutput"
 
@@ -554,32 +554,32 @@ Set-Content -Force -Path "$installDir\bcd-guid.txt" -Value $newGuid -Encoding AS
 # grubx64.efi (Fedora-signed), which loads grub.cfg from EFI/fedora/.
 $setPathOutput = & bcdedit /set $newGuid path "\EFI\fedora\shimx64.efi" 2>&1
 if ($LASTEXITCODE -ne 0) {
-    throw "bcdedit /set path exited with code $LASTEXITCODE: $setPathOutput"
+    throw "bcdedit /set path exited with code ${LASTEXITCODE}: $setPathOutput"
 }
 Write-Host "[wootc] BCD path set to \EFI\fedora\shimx64.efi"
 
 # One-time boot: boot the deployer on the very next restart only.
 $setBootSeqOutput = & bcdedit /set "{fwbootmgr}" bootsequence $newGuid /addfirst 2>&1
 if ($LASTEXITCODE -ne 0) {
-    throw "bcdedit /set bootsequence exited with code $LASTEXITCODE: $setBootSeqOutput"
+    throw "bcdedit /set bootsequence exited with code ${LASTEXITCODE}: $setBootSeqOutput"
 }
 Write-Host "[wootc] Set one-time bootsequence to $newGuid"
 
 # ── Observable verification (#50): prove the BCD state is correct ──────
 # Query the new entry and {fwbootmgr} to confirm the EFI path and that
 # bootsequence contains the new GUID.
-$verifyGuidOut = & bcdedit /enum $newGuid 2>&1
+$verifyGuidOut = (& bcdedit /enum $newGuid 2>&1) | Out-String
 if ($LASTEXITCODE -ne 0) {
-    throw "bcdedit /enum $newGuid exited with code $LASTEXITCODE: $verifyGuidOut"
+    throw "bcdedit /enum $newGuid exited with code ${LASTEXITCODE}: $verifyGuidOut"
 }
 if ($verifyGuidOut -notmatch 'path.*shimx64\.efi') {
     throw "Verification failed: new BCD entry does not point to shimx64.efi`n$verifyGuidOut"
 }
 Write-Host "[wootc] Verified: BCD entry path points to shimx64.efi"
 
-$verifyFwbmOut = & bcdedit /enum "{fwbootmgr}" 2>&1
+$verifyFwbmOut = (& bcdedit /enum "{fwbootmgr}" 2>&1) | Out-String
 if ($LASTEXITCODE -ne 0) {
-    throw "bcdedit /enum {fwbootmgr} exited with code $LASTEXITCODE: $verifyFwbmOut"
+    throw "bcdedit /enum {fwbootmgr} exited with code ${LASTEXITCODE}: $verifyFwbmOut"
 }
 if ($verifyFwbmOut -notmatch [regex]::Escape($newGuid)) {
     throw "Verification failed: {fwbootmgr} bootsequence does not contain $newGuid`n$verifyFwbmOut"

--- a/tests/lint-ps1.ps1
+++ b/tests/lint-ps1.ps1
@@ -1,0 +1,142 @@
+#!/usr/bin/env pwsh
+# lint-ps1.ps1 — static gate for the repo's PowerShell.
+#
+# WHY THIS EXISTS
+# Nothing in this repo ever parsed its .ps1 files, so two real bugs shipped in
+# tests/e2e/setup-wootc.ps1 and only surfaced deep inside a Windows VM, minutes
+# into an E2E run, as a confusing mid-deploy failure:
+#
+#   1. "... exited with code $LASTEXITCODE: $out"
+#      PowerShell parses the colon after a variable name as a SCOPE qualifier
+#      ($env:X, $script:Y), so "$LASTEXITCODE:" is a syntax error. Five throw
+#      statements could therefore never report their message — every one of
+#      them died with a ParserError instead, hiding the actual bcdedit error.
+#      Fix: ${LASTEXITCODE}:
+#
+#   2. $out = & bcdedit /enum $guid 2>&1      # <- no | Out-String
+#      if ($out -notmatch 'path.*shimx64\.efi') { throw ... }
+#      A native command's output is an ARRAY OF LINES. -match/-notmatch against
+#      an array is a FILTER, not a boolean: it returns the matching (or
+#      non-matching) elements. A multi-line output therefore returns a
+#      non-empty array — which is truthy — so the check fired even when the
+#      text was plainly present, and BCD verification failed 100% of the time.
+#      Fix: pipe the capture through Out-String so it is one string.
+#
+# Bug 1 is a parse error and is caught definitively below. Bug 2 parses fine, so
+# it gets a targeted AST check instead. Both are cheap; the whole thing runs in
+# well under a second and needs only pwsh (GitHub's ubuntu images ship it).
+#
+# Usage: pwsh -NoProfile -File tests/lint-ps1.ps1 [files...]
+#        With no arguments, lints every tracked *.ps1.
+
+param([string[]]$Files)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+
+if (-not $Files -or $Files.Count -eq 0) {
+    Push-Location $repoRoot
+    try { $Files = @(& git ls-files '*.ps1') } finally { Pop-Location }
+}
+if (-not $Files -or $Files.Count -eq 0) {
+    Write-Host 'no .ps1 files found — nothing to lint'
+    exit 0
+}
+
+$failed = 0
+
+foreach ($rel in $Files) {
+    $path = if ([System.IO.Path]::IsPathRooted($rel)) { $rel } else { Join-Path $repoRoot $rel }
+    if (-not (Test-Path -LiteralPath $path)) {
+        Write-Host "  ! skipping missing $rel"
+        continue
+    }
+
+    # ── 1. Parse ────────────────────────────────────────────────────────────
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $path, [ref]$tokens, [ref]$errors)
+
+    if ($errors -and $errors.Count -gt 0) {
+        foreach ($e in $errors) {
+            Write-Host "FAIL ${rel}:$($e.Extent.StartLineNumber): $($e.Message)"
+        }
+        $failed = 1
+        # A file that does not parse cannot be walked for check 2.
+        continue
+    }
+
+    # ── 2. -notmatch against un-stringified command output ──────────────────
+    # Scope this tightly, because the naive version is almost all noise:
+    #
+    #   * -match on an array is FINE and idiomatic — it means "does any line
+    #     match", which is exactly what callers want. Only -notmatch is broken,
+    #     because it returns the non-matching lines (nearly always a non-empty,
+    #     i.e. truthy, array) instead of a boolean.
+    #   * Get-Content -Raw already returns ONE string.
+    #   * A pipeline ending in Select-Object -First 1 yields a single item.
+    #   * $x = "interpolated $(thing)" is a string, not command output — so
+    #     only the TOP-LEVEL right-hand side counts, never a nested subexpression.
+    $arrayVars = @{}
+    $assignments = $ast.FindAll({
+        param($n) $n -is [System.Management.Automation.Language.AssignmentStatementAst]
+    }, $true)
+
+    foreach ($a in $assignments) {
+        $left = $a.Left -as [System.Management.Automation.Language.VariableExpressionAst]
+        if (-not $left) { continue }
+
+        # TOP-LEVEL pipeline only — do not descend into subexpressions.
+        $pipeline = $a.Right -as [System.Management.Automation.Language.PipelineAst]
+        if (-not $pipeline) { continue }
+
+        # Must actually invoke a command (rules out plain string/number RHS).
+        $invokes = $pipeline.PipelineElements | Where-Object {
+            $_ -is [System.Management.Automation.Language.CommandAst]
+        }
+        if (-not $invokes) { continue }
+
+        # Constructs that already collapse the result to a single value.
+        $text = $pipeline.Extent.Text
+        if ($text -match 'Out-String|-Raw\b|Select-Object\s+-First\s+1') { continue }
+
+        $arrayVars[$left.VariablePath.UserPath] = $a.Extent.StartLineNumber
+    }
+
+    if ($arrayVars.Count -gt 0) {
+        $binaries = $ast.FindAll({
+            param($n) $n -is [System.Management.Automation.Language.BinaryExpressionAst]
+        }, $true)
+
+        foreach ($b in $binaries) {
+            $op = $b.Operator.ToString()
+            # -notmatch only; see the note above on why -match is legitimate.
+            if ($op -ne 'Inotmatch' -and $op -ne 'Cnotmatch') { continue }
+
+            $v = $b.Left -as [System.Management.Automation.Language.VariableExpressionAst]
+            if (-not $v) { continue }
+
+            $name = $v.VariablePath.UserPath
+            if (-not $arrayVars.ContainsKey($name)) { continue }
+
+            Write-Host ("FAIL ${rel}:$($b.Extent.StartLineNumber): " +
+                "`$$name holds command output (assigned line $($arrayVars[$name])) " +
+                'and is used with -match/-notmatch. Native command output is an ' +
+                'ARRAY OF LINES, so -match filters instead of returning a bool — ' +
+                'a multi-line value is always truthy. Pipe the assignment through ' +
+                '| Out-String.')
+            $failed = 1
+        }
+    }
+
+    if ($failed -eq 0) { Write-Host "  ok $rel" }
+}
+
+if ($failed -ne 0) {
+    Write-Host ''
+    Write-Host 'PowerShell lint FAILED'
+    exit 1
+}
+Write-Host 'PowerShell lint passed'
+exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -56,6 +56,19 @@ run_fast() {
         echo "!! python3 not installed — skipping python unit tests" >&2
     fi
 
+    # PowerShell static gate. The .ps1 payloads only ever execute inside a
+    # Windows guest, minutes into an E2E run, so a syntax error there costs a
+    # whole VM cycle to discover — which is exactly how two bugs shipped in
+    # setup-wootc.ps1 (an invalid `$LASTEXITCODE:` scope reference, and a
+    # `-notmatch` against un-stringified command output). Both are caught
+    # statically in well under a second. See tests/lint-ps1.ps1.
+    if command -v pwsh >/dev/null; then
+        echo "── powershell lint (tests/lint-ps1.ps1) ──"
+        pwsh -NoProfile -File tests/lint-ps1.ps1 || rc=1
+    else
+        echo "!! pwsh not installed — skipping PowerShell lint" >&2
+    fi
+
     if command -v go >/dev/null; then
         echo "── go test (fisherman TUI, cross-platform app) ──"
         # app/main.go has //go:embed all:frontend/dist, so the package will not


### PR DESCRIPTION
`setup-wootc.ps1` only executes inside the Windows guest, minutes into an E2E run — so a defect there costs a full VM cycle to discover. **Nothing in this repo ever parsed it.** Two bugs had shipped.

## Bug 1 — invalid scope reference

```powershell
throw "bcdedit /copy exited with code $LASTEXITCODE: $bcdCreateOutput"
```

PowerShell reads the colon after a variable name as a **scope qualifier** (`$env:X`, `$script:Y`), so `$LASTEXITCODE:` is a syntax error. Five `throw` statements could never emit their message — every one died with a `ParserError` instead, hiding the actual `bcdedit` failure. Fixed with `${LASTEXITCODE}:`.

## Bug 2 — `-notmatch` against an array

```powershell
$verifyGuidOut = & bcdedit /enum $newGuid 2>&1        # ← no | Out-String
if ($verifyGuidOut -notmatch 'path.*shimx64\.efi') { throw ... }
```

A native command's output is an **array of lines**. `-notmatch` against an array is a *filter*, not a boolean — it returns the non-matching elements. A multi-line value is therefore always a non-empty, truthy array, so **BCD verification failed 100% of the time**.

The run that exposed it reported `new BCD entry does not point to shimx64.efi` while printing a dump that plainly read `path  \EFI\fedora\shimx64.efi`. Reproduced in `pwsh` before and after. Both `/enum` captures now pipe through `Out-String`, matching the `/copy` capture directly above them.

## The gate

`tests/lint-ps1.ps1` (AST-based) catches both classes, wired into `tests/run.sh` fast tier and skipped gracefully when `pwsh` is absent — GitHub's ubuntu runners ship it. Self-tested against synthetic reproductions of both bugs.

**Check 2 is deliberately narrow.** A first pass flagged 10 sites; hand review confirmed **all 10 were correct code**:

- `-match` on an array is legitimate and idiomatic ("does any line match") — so only `-notmatch` is flagged
- `Get-Content -Raw` returns a single string
- a pipeline ending in `Select-Object -First 1` yields a single item
- only the top-level RHS counts, so `$x = "text $(sub)"` isn't mistaken for command output

It now reports **0** findings on the real tree while still failing on both original bugs.

## Bonus

`build-ssh-image.sh`'s swtpm smoke test passed `--server`/`--ctrl type=unix`, but swtpm requires `type=unixio`. It declared every freshly built image broken (*"swtpm cannot start and bind a socket"*) and advised deleting a perfectly good image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
