### PR TITLE
feat(app): follow the Windows light/dark setting (#173)

### DIFF
--- a/app/frontend/src/style.css
+++ b/app/frontend/src/style.css
@@ -24,6 +24,40 @@
   --transition:  0.18s ease;
 }
 
+/* Light theme (#173). WebView2 reports the Windows app-theme setting through
+   prefers-color-scheme, and the Wails window chrome already follows it via
+   windows.SystemDefault, so the content just has to keep up — previously it
+   was dark no matter what, which looks broken on a light-mode machine.
+
+   Only the tokens are redefined; every rule in this file already reads them
+   (verified: no hardcoded hex outside :root). The few rgba() accent tints
+   further down are low-alpha washes of the same hues and read correctly on
+   either background.
+
+   The greens/ambers/reds are NOT reused verbatim from the dark palette: at
+   full saturation they are designed against #0a0a0f and fail contrast on a
+   near-white card (#facc15 on white is essentially illegible), so the light
+   variants are darkened to stay readable as text. */
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg:          #f6f6fa;
+    --bg-card:     #ffffff;
+    --bg-input:    #f0f0f6;
+    --bg-hover:    #e9e9f2;
+    --border:      #d9d9e4;
+    --border-focus:#5b6ee1;
+    --text:        #16161f;
+    --text-muted:  #61617d;
+    --text-dim:    #4a4a63;
+    --accent:      #4553c4;
+    --accent-light:#5b6ee1;
+    --accent-glow: rgba(91,110,225,0.18);
+    --success:     #15803d;
+    --warning:     #a16207;
+    --danger:      #dc2626;
+  }
+}
+
 html, body {
   height: 100%;
   font-family: 'Inter', system-ui, sans-serif;

--- a/app/main.go
+++ b/app/main.go
@@ -22,6 +22,14 @@ func main() {
 
 	app := NewApp()
 
+	// Wails paints this before WebView2 renders, so it must agree with the
+	// theme the page is about to choose or the window flashes the wrong colour
+	// on launch (#173). Values mirror the --bg tokens in style.css.
+	background := &options.RGBA{R: 0x0a, G: 0x0a, B: 0x0f, A: 255} // dark  #0a0a0f
+	if !systemPrefersDark() {
+		background = &options.RGBA{R: 0xf6, G: 0xf6, B: 0xfa, A: 255} // light #f6f6fa
+	}
+
 	err := wails.Run(&options.App{
 		Title:            "wootc — Windows bootc Installer",
 		Width:            820,
@@ -32,7 +40,7 @@ func main() {
 		MaxHeight:        620,
 		DisableResize:    true,
 		Frameless:        false,
-		BackgroundColour: &options.RGBA{R: 10, G: 10, B: 15, A: 255},
+		BackgroundColour: background,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
@@ -43,9 +51,16 @@ func main() {
 		},
 		Windows: &windows.Options{
 			// Single-instance enforcement
-			WebviewIsTransparent:              false,
-			WindowIsTranslucent:               false,
-			DisablePinchZoom:                  true,
+			WebviewIsTransparent: false,
+			WindowIsTranslucent:  false,
+			DisablePinchZoom:     true,
+			// Follow the Windows app-theme setting for the window chrome, and
+			// let WebView2 report it to the page as prefers-color-scheme so the
+			// content can match (#173 — the UI used to be dark on a light-mode
+			// machine). This is windows.Theme's zero value, but state it: the
+			// whole point is that it tracks the OS, which is not obvious from
+			// an absent field.
+			Theme: windows.SystemDefault,
 		},
 	})
 

--- a/app/theme_other.go
+++ b/app/theme_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// systemPrefersDark is Windows-only in practice; see theme_windows.go. The
+// non-Windows build exists so main.go stays compilable on Linux for the
+// cross-platform `go test` tier, and returns the historical default.
+func systemPrefersDark() bool { return true }

--- a/app/theme_windows.go
+++ b/app/theme_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows/registry"
+
+// systemPrefersDark reports whether Windows is set to a DARK app theme.
+//
+// This exists only to pick the window's initial BackgroundColour. Wails paints
+// that colour before WebView2 has rendered anything, so with it hardcoded dark
+// a light-mode machine got a dark flash on every launch even after the page
+// itself learned to follow the theme (#173). The page keeps using CSS
+// prefers-color-scheme; this just stops the first frame from disagreeing.
+//
+// "AppsUseLightTheme" is the app-level setting (Settings > Personalisation >
+// Colours > "Choose your default app mode"), which is the one WebView2 maps to
+// prefers-color-scheme. Deliberately NOT SystemUsesLightTheme, which controls
+// the taskbar/Start chrome and can differ.
+//
+// Any failure falls back to dark, matching the historical appearance and the
+// :root defaults in style.css.
+func systemPrefersDark() bool {
+	k, err := registry.OpenKey(registry.CURRENT_USER,
+		`Software\Microsoft\Windows\CurrentVersion\Themes\Personalize`,
+		registry.QUERY_VALUE)
+	if err != nil {
+		return true
+	}
+	defer k.Close()
+
+	// 0 = dark app mode, 1 = light app mode. Absent on older builds.
+	v, _, err := k.GetIntegerValue("AppsUseLightTheme")
+	if err != nil {
+		return true
+	}
+	return v == 0
+}


### PR DESCRIPTION
Fixes #173.

The installer was dark regardless of the Windows setting. On a light-mode PC that reads as broken — expensive for an app whose job is convincing a nervous user to let it repartition their disk.

## Content

`style.css` gains a `@media (prefers-color-scheme: light)` block redefining the `:root` tokens.

This was clean because **every rule already reads a token** — verified there is no hardcoded hex outside `:root`; the only literals are low-alpha `rgba()` accent washes, which read correctly on either background.

The greens/ambers/reds are **not** the dark palette reused. At full saturation they're tuned against `#0a0a0f` and fail contrast on a near-white card — `#facc15` on white is effectively illegible — so the light variants are darkened to stay readable as text.

## Chrome

`main.go` sets `Theme: windows.SystemDefault` explicitly. It *is* the zero value, but the whole point of the field is that it tracks the OS, which an absent field doesn't convey.

## The launch flash

`BackgroundColour` was hardcoded dark. Wails paints it **before** WebView2 renders, so a light-mode machine flashed dark on every launch even once the page followed the theme.

`systemPrefersDark()` reads `AppsUseLightTheme` — the app-mode setting, which is what WebView2 maps to `prefers-color-scheme`. Deliberately **not** `SystemUsesLightTheme`, which controls taskbar/Start chrome and can differ. Fails safe to dark, matching the historical look and the `:root` defaults.

`theme_other.go` keeps `main.go` compiling on Linux for the cross-platform `go test` tier.

## Verification

Frontend builds; Windows and Linux both compile; `go test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
