### PR TITLE
fix(frontend): Cancel, Close and Reboot Later never actually quit

### DIFF
--- a/app/frontend/src/screens/control.js
+++ b/app/frontend/src/screens/control.js
@@ -1,4 +1,5 @@
 import { BootInVM, UninstallWith } from '../../wailsjs/go/main/App';
+import { Quit } from '../../wailsjs/runtime/runtime';
 import { state } from '../lib/state.js';
 import { render } from '../lib/render.js';
 import { el, btn } from '../lib/ui.js';
@@ -72,7 +73,7 @@ export function renderControlPanel() {
   const footer = el('div', 'footer');
   footer.appendChild(btn('Reinstall', 'btn btn-ghost', () => { state.screen = 'launchpad'; render(); }));
   footer.appendChild(btn('Uninstall TunaOS', 'btn btn-danger', () => confirmUninstall()));
-  footer.appendChild(btn('Close', 'btn btn-primary', () => window.wails?.Quit?.()));
+  footer.appendChild(btn('Close', 'btn btn-primary', () => Quit()));
   wrap.appendChild(footer);
   return wrap;
 }
@@ -87,7 +88,7 @@ async function confirmUninstall() {
   try {
     await UninstallWith({ deleteRootDisk: !!o.deleteRootDisk, removePartition: !!o.removePartition });
     alert('TunaOS has been removed. Windows is unchanged.');
-    window.wails?.Quit?.();
+    Quit();
   } catch (e) {
     alert('Uninstall hit a problem: ' + e);
   }

--- a/app/frontend/src/screens/done.js
+++ b/app/frontend/src/screens/done.js
@@ -1,4 +1,5 @@
 import { Reboot } from '../../wailsjs/go/main/App';
+import { Quit } from '../../wailsjs/runtime/runtime';
 import { state } from '../lib/state.js';
 import { el, btn } from '../lib/ui.js';
 
@@ -28,7 +29,7 @@ export function renderDoneScreen() {
   wrap.appendChild(screen);
 
   const footer = el('div', 'footer');
-  footer.appendChild(btn('Reboot Later', 'btn btn-ghost', () => window.wails?.Quit?.()));
+  footer.appendChild(btn('Reboot Later', 'btn btn-ghost', () => Quit()));
   footer.appendChild(btn('Reboot Now →', 'btn btn-primary', () => Reboot()));
   wrap.appendChild(footer);
   return wrap;

--- a/app/frontend/src/screens/launchpad.js
+++ b/app/frontend/src/screens/launchpad.js
@@ -1,4 +1,5 @@
 import { StartInstall, CreateDataPartition, DefragDrive } from '../../wailsjs/go/main/App';
+import { Quit } from '../../wailsjs/runtime/runtime';
 import { state } from '../lib/state.js';
 import { render } from '../lib/render.js';
 import { installVerb } from '../lib/branding.js';
@@ -277,7 +278,7 @@ export function renderLaunchpad() {
   const footer = el('div', 'footer');
   const installBtn = btn(`${installVerb()} →`, 'btn btn-primary', () => startInstall());
   installBtn.id = 'install-btn';
-  footer.appendChild(btn('Cancel', 'btn btn-ghost', () => window.wails?.Quit?.()));
+  footer.appendChild(btn('Cancel', 'btn btn-ghost', () => Quit()));
   // Try-in-VM (§6.1): only when a fresh-build VM is possible on this host.
   if (state.freshVmCapability?.available && state.selected) {
     footer.appendChild(btn('Try in VM', 'btn btn-ghost', () => tryInVM()));

--- a/app/frontend/src/screens/migrate.js
+++ b/app/frontend/src/screens/migrate.js
@@ -3,6 +3,7 @@ import {
   GetLookMigration, SetMigrationProfile, SetSessionConsent, ReinstallApps,
   ConvertCategory, ImportBrowserData,
 } from '../../wailsjs/go/main/App';
+import { Quit } from '../../wailsjs/runtime/runtime';
 import { state } from '../lib/state.js';
 import { render } from '../lib/render.js';
 import { fmtSize } from '../lib/format.js';
@@ -164,7 +165,7 @@ export function renderMigrateScreen() {
 
   const footer = el('div', 'footer');
   footer.appendChild(btn('Refresh', 'btn btn-ghost', () => refreshCategories()));
-  footer.appendChild(btn('Close', 'btn btn-primary', () => window.wails?.Quit?.()));
+  footer.appendChild(btn('Close', 'btn btn-primary', () => Quit()));
   wrap.appendChild(footer);
   return wrap;
 }

--- a/tests/gui/gui.spec.js
+++ b/tests/gui/gui.spec.js
@@ -308,3 +308,19 @@ test('titlebar — closing during an install asks for confirmation', async ({ pa
   await page.locator('#win-close').click();
   expect(await page.evaluate(() => window.__wootcWindowCalls)).toContain('Quit');
 });
+
+// Every "get me out of here" button must actually quit. These reach the
+// runtime via the Quit import; an earlier version called window.wails?.Quit?.()
+// — a global Wails does not define — so they optional-chained into silent
+// no-ops and no test noticed, because the mock had invented window.wails.
+test('every exit button reaches the runtime', async ({ page }) => {
+  // Launchpad "Cancel"
+  await boot(page, { mode: 'installer', images: IMAGES, sysinfo: SYSINFO });
+  await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+  expect(await page.evaluate(() => window.__wootcWindowCalls)).toContain('Quit');
+
+  // Migration dashboard "Close"
+  await boot(page, { mode: 'migration', categories: MIGRATION_CATEGORIES, apps: APPS, office: OFFICE });
+  await page.locator('.footer').getByRole('button', { name: 'Close', exact: true }).click();
+  expect(await page.evaluate(() => window.__wootcWindowCalls)).toContain('Quit');
+});

--- a/tests/gui/mock-backend.js
+++ b/tests/gui/mock-backend.js
@@ -94,4 +94,9 @@ window.runtime = {
   Quit: () => { window.__wootcWindowCalls.push('Quit'); },
   Environment: () => Promise.resolve({ buildType: 'test' }),
 };
-window.wails = { Quit: () => {} };
+// NO window.wails stub. Wails v2 exposes window.runtime.Quit; window.wails
+// does not exist. Stubbing it here made five real buttons (Cancel, Reboot
+// Later, and three Closes) look functional in tests while silently doing
+// nothing in the shipped app, because they optional-chained off a global the
+// mock invented. If something reaches for window.wails again, it should break
+// loudly here rather than pass.


### PR DESCRIPTION
Five buttons called `window.wails?.Quit?.()`. **Wails v2 exposes `window.runtime.Quit` — there is no `window.wails` at all**, so the optional chaining swallowed the miss and every one of them silently did nothing:

| Screen | Button |
|---|---|
| launchpad | **Cancel** |
| done | **Reboot Later** |
| control | **Close** (×2) |
| migrate | **Close** |

The runtime's own `runtime.js` is unambiguous:

```js
export function Quit() {
    window.runtime.Quit();
}
```

The titlebar controls added in #175 use the real `Quit` import and do work — which makes this survivable rather than trapping. But a user who reaches for **Cancel** and gets no response has every reason to think the app has hung, at exactly the moment they're most nervous about what it's doing to their disk.

## Why no test caught it

`tests/gui/mock-backend.js` defined a stub:

```js
window.wails = { Quit: () => {} };
```

So the invented global **existed under test** and the buttons looked functional. That stub is now removed — if anything reaches for `window.wails` again it should break loudly rather than pass — and the runtime mock records `Quit` so a test can assert the call actually lands.

## Verification

New test `every exit button reaches the runtime` covers the launchpad and migration exits. Confirmed it genuinely catches the bug: reverting a single call site to `window.wails?.Quit?.()` fails the test, restoring it passes.

20/20 GUI tests pass.

Found while splitting `main.js` for #118; deliberately kept out of that PR to hold it to a pure refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
