### PR TITLE
fix(windows): nil-pointer panic and a reclaim-check ambiguity (#191)

### DIFF
--- a/app/disk_windows.go
+++ b/app/disk_windows.go
@@ -57,8 +57,8 @@ func dedicatedVolumeInfo(d string) (bool, float64) {
 	// A wootc-created volume is labeled "wootc-data" and contains nothing
 	// but the wootc dir (ignoring system folders).
 	out, err := runPowerShellOutput(fmt.Sprintf(
-		`$items = Get-ChildItem '%s:\' -Force -ErrorAction SilentlyContinue | Where-Object { `+
-			`$_.Name -notin @('$RECYCLE.BIN','System Volume Information','wootc') }; `+
+		`$items = @(Get-ChildItem '%s:\' -Force -ErrorAction SilentlyContinue | Where-Object { `+
+			`$_.Name -notin @('$RECYCLE.BIN','System Volume Information','wootc') }); `+
 			`$v = Get-Volume -DriveLetter %s -ErrorAction SilentlyContinue; `+
 			`'{0}|{1}' -f $items.Count, [math]::Round($v.Size/1GB,1)`, d, d))
 	if err != nil {
@@ -116,7 +116,6 @@ func removePartitionAndExtendC(drive string) error {
 	script := fmt.Sprintf(`
 $ErrorActionPreference = 'Stop'
 $p = Get-Partition -DriveLetter %s
-$disk = $p.DiskNumber
 Remove-Partition -DriveLetter %s -Confirm:$false
 $supported = Get-PartitionSupportedSize -DriveLetter C
 Resize-Partition -DriveLetter C -Size $supported.SizeMax`, drive, drive)
@@ -170,8 +169,15 @@ func createRootDisk(sizeGB int) error {
 		return fmt.Errorf("fsutil setvaliddata (VDL extension): %w: %s", err, strings.TrimSpace(out))
 	}
 
+	// Two distinct failures, reported separately. Folding them into one branch
+	// dereferenced a nil st whenever Stat itself failed — so the path that runs
+	// ONLY when disk creation has already gone wrong panicked instead of saying
+	// what went wrong (#191).
 	st, err := os.Stat(path)
-	if err != nil || st.Size() != sizeBytes {
+	if err != nil {
+		return fmt.Errorf("root.disk verification failed: cannot stat %s: %w", path, err)
+	}
+	if st.Size() != sizeBytes {
 		return fmt.Errorf("root.disk verification failed: got %d bytes, want %d", st.Size(), sizeBytes)
 	}
 	return nil

--- a/app/installer_windows.go
+++ b/app/installer_windows.go
@@ -171,7 +171,15 @@ func getUninstallInfo() UninstallInfo {
 	return UninstallInfo{Found: false}
 }
 
+// ctx is accepted for signature symmetry with the install path but is
+// deliberately NOT honoured as a cancellation point (#191). Uninstall is an
+// ordered sequence of destructive cleanups — BCD entries, ESP files, then the
+// wootc directory — and abandoning it midway leaves a machine that is neither
+// migrated nor restored: a boot entry pointing at files that are gone is worse
+// than either end state. If cancellation is ever wanted here it needs an
+// explicit rollback story, not a ctx check dropped between steps.
 func uninstallWith(ctx context.Context, opts UninstallOptions) error {
+	_ = ctx
 	info := getUninstallInfo()
 
 	// 1. Remove all wootc BCD entries.

--- a/app/sysprobe_windows.go
+++ b/app/sysprobe_windows.go
@@ -31,11 +31,6 @@ func isUEFI() bool {
 	return r != 0 && ft == 2
 }
 
-func secureBootEnabled() bool {
-	on, _ := secureBootState()
-	return on
-}
-
 func secureBootState() (bool, bool) {
 	out, err := runCmd("powershell", "-NoProfile", "-NonInteractive",
 		"-Command", "try { if (Confirm-SecureBootUEFI -ErrorAction Stop) { 'on' } else { 'off' } } catch { 'unknown' }")


### PR DESCRIPTION
Fixes #191.

## The panic

`createRootDisk` folded two different failures into one branch:

```go
st, err := os.Stat(path)
if err != nil || st.Size() != sizeBytes {
    return fmt.Errorf("root.disk verification failed: got %d bytes, want %d", st.Size(), sizeBytes)
}
```

When `Stat` failed, `st` is **nil** and the error message immediately dereferences it. So the path that runs *only when disk creation has already gone wrong* panicked instead of reporting what went wrong. Now two branches, each saying its own thing.

## The reclaim-check ambiguity

`dedicatedVolumeInfo` decides whether a volume is **reclaimable**, and derived that from `$items.Count` where `$items` could be `$null` (nothing matched) or a scalar (exactly one match). PowerShell papers over both cases, so this was likely working — but the question feeding the decision is *"is this volume empty?"*, and a wrong **yes** means folding a volume that still holds the user's data back into C:.

Wrapped in `@()` so `.Count` is well-defined for 0, 1 and many. Not a known misfire; the point is that this particular question shouldn't rest on a language quirk.

## Tidying

- `secureBootEnabled` removed — dead code, `secureBootState` is used everywhere.
- Unused `$disk = $p.DiskNumber` in `removePartitionAndExtendC` removed.

## `uninstallWith`'s unused `ctx` — documented, not wired

Uninstall is an ordered sequence of destructive cleanups (BCD entries → ESP files → the wootc directory). Abandoning it midway leaves a machine **neither migrated nor restored** — a boot entry pointing at files that are gone is worse than either end state.

Cancellation here needs an explicit rollback story, not a `ctx` check dropped between steps. Said so in a comment rather than leaving the next reader to wonder.

## Verification

windows/amd64 build ✅ · `go vet` ✅ · `go build ./...` ✅ · `go test ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
