### PR TITLE
fix: unbreak main's CI, and the defects a review of the merged feature wave confirmed

### DIFF
--- a/app/frontend/src/screens/launchpad.js
+++ b/app/frontend/src/screens/launchpad.js
@@ -173,10 +173,10 @@ export function renderLaunchpad() {
     row.style.cssText = 'display:flex;gap:8px;align-items:flex-start;cursor:pointer;font-size:12px;padding:6px 8px;border:1.5px solid var(--border);border-radius:6px';
     const checked = state.config.encryption === value;
     row.innerHTML = `<input type="radio" name="encryption" value="${value}" ${checked ? 'checked' : ''} style="margin-top:1px">
-      <span><b>${title}${recommended ? ' <span style="color:var(--primary);font-size:10px;font-weight:500">RECOMMENDED</span>' : ''}</b><br><span style="color:var(--text-muted)">${sub}</span></span>`;
+      <span><b>${title}${recommended ? ' <span style="color:var(--accent);font-size:10px;font-weight:500">RECOMMENDED</span>' : ''}</b><br><span style="color:var(--text-muted)">${sub}</span></span>`;
     row.querySelector('input').onchange = () => { state.config.encryption = value; refreshInstallValidity(); render(); };
     // Visual highlight for selected option
-    if (checked) row.style.borderColor = 'var(--primary)';
+    if (checked) row.style.borderColor = 'var(--accent)';
     return row;
   };
   encOpts.appendChild(encRadio('none', 'No encryption', 'Fastest. Anyone with physical access to the PC can read the Linux disk.', false));
@@ -202,7 +202,7 @@ export function renderLaunchpad() {
   lookRow.innerHTML = `<input type="checkbox" ${state.config.windowsLook ? 'checked' : ''} style="margin-top:1px">
     <span><b>Make it feel like Windows</b><br><span style="color:var(--text-muted)">Bring your wallpaper, accent color, keyboard layout, taskbar pins and desktop shortcuts over. Off keeps the desktop's own look.</span></span>`;
   lookRow.querySelector('input').onchange = (e) => { state.config.windowsLook = e.target.checked; };
-  if (state.config.windowsLook) lookRow.style.borderColor = 'var(--primary)';
+  if (state.config.windowsLook) lookRow.style.borderColor = 'var(--accent)';
   fields.appendChild(lookRow);
 
   // Auth-token migration is a separate, explicit opt-in from look/data

--- a/app/frontend/src/screens/vmpreview.js
+++ b/app/frontend/src/screens/vmpreview.js
@@ -69,7 +69,7 @@ export function renderVMPreviewScreen() {
       <h2>Building your preview…</h2>
       <div style="color:var(--text-muted);max-width:440px">${p.message || 'Working…'}</div>
       <div style="width:60%;max-width:360px;height:8px;background:var(--border);border-radius:4px;overflow:hidden;margin-top:8px">
-        <div style="width:${pct}%;height:100%;background:var(--primary);transition:width .3s"></div>
+        <div style="width:${pct}%;height:100%;background:var(--accent);transition:width .3s"></div>
       </div>
       <div style="font-size:12px;color:var(--text-muted)">${pct}%</div>`;
   }

--- a/app/profiles.go
+++ b/app/profiles.go
@@ -19,11 +19,15 @@ import (
 //     do NOT invent passwords for them. Their accounts are created locked, and
 //     the admin (or the user themselves) sets a password on first use.
 //
-// Creating the accounts is the whole job. wootc-mount-user-dirs already walks
-// every profile under /run/wootc/host/Users and bind-mounts each one into the
-// Linux account of the same name, skipping profiles with no matching account.
-// So the bridge needs no change: give the profiles accounts and their data
-// follows.
+// The account names are SANITIZED ("Alice Smith" → alice-smith), but the
+// first-boot bridge (wootc-mount-user-dirs) walks the raw profile directories
+// under /run/wootc/host/Users. Those two names only agree for profiles that
+// were already legal lowercase Linux names, so the vault also carries a
+// profile_map of directory name → account name — including the PRIMARY user's
+// own profile, whose chosen username need not resemble their directory at all.
+// The deployer persists that map into the installed system at
+// /etc/wootc/profile-map.tsv, and the bridge consults it before falling back
+// to an exact directory-name match.
 //
 // This file is deliberately NOT build-tagged. The logic is plain filesystem
 // walking, and tagging it //go:build windows would mean the tests never ran in
@@ -31,21 +35,37 @@ import (
 // user's files behind.
 
 // systemProfiles are the entries under C:\Users that are not people.
+// defaultuser0 is the OOBE setup account: Windows is supposed to delete it
+// after first boot but very often leaves the directory (with an NTUSER.DAT)
+// behind on OEM machines — exactly the empty stranger on the login screen
+// this list exists to prevent.
 var systemProfiles = map[string]bool{
 	"public": true, "default": true, "default user": true,
 	"all users": true, "defaultaccount": true, "wdagutilityaccount": true,
-	"administrator": true,
+	"administrator": true, "defaultuser0": true,
 }
 
-// listProfilesIn returns the sanitised Linux usernames for every real
-// Windows profile under usersDir, excluding `primary` (already created as the
-// admin account) and the built-in system profiles.
+// profileMapping ties a Windows profile directory (the basename under
+// C:\Users) to the Linux account name created for it.
+type profileMapping struct {
+	WindowsDir string
+	LinuxUser  string
+}
+
+// listProfilesIn returns a mapping for every real Windows profile under
+// usersDir, excluding the built-in system profiles and the primary user's own
+// profile: `primary` is the chosen Linux username (already created as the
+// admin account by fisherman) and `primaryDir` is the basename of their
+// Windows profile directory. Both exclusions matter — the chosen username can
+// be anything ("james"), while the directory keeps its Windows name
+// ("James Reilly"), and a locked doppelganger account for the person who ran
+// the installer would also break the bridge's single-user fallback (#73).
 //
 // Enumerating C:\Users rather than the registry ProfileList is deliberate: the
 // bridge matches on the DIRECTORY name under Users\, so anything the registry
 // reported that did not correspond to a directory would produce an account
 // with no data to bind — an empty stranger on the login screen.
-func listProfilesIn(usersDir, primary string) []string {
+func listProfilesIn(usersDir, primary, primaryDir string) []profileMapping {
 	entries, err := os.ReadDir(usersDir)
 	if err != nil {
 		return nil
@@ -55,7 +75,7 @@ func listProfilesIn(usersDir, primary string) []string {
 	if primary != "" {
 		seen[primary] = true
 	}
-	var out []string
+	var out []profileMapping
 
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -63,6 +83,9 @@ func listProfilesIn(usersDir, primary string) []string {
 		}
 		name := e.Name()
 		if systemProfiles[strings.ToLower(name)] {
+			continue
+		}
+		if primaryDir != "" && strings.EqualFold(name, primaryDir) {
 			continue
 		}
 		// A profile directory with no NTUSER.DAT was never a logged-in user
@@ -76,9 +99,10 @@ func listProfilesIn(usersDir, primary string) []string {
 			continue
 		}
 		seen[linux] = true
-		out = append(out, linux)
+		out = append(out, profileMapping{WindowsDir: name, LinuxUser: linux})
 	}
 
-	sort.Strings(out) // deterministic vault.json across runs
+	// Deterministic vault.json across runs.
+	sort.Slice(out, func(i, j int) bool { return out[i].LinuxUser < out[j].LinuxUser })
 	return out
 }

--- a/app/profiles_test.go
+++ b/app/profiles_test.go
@@ -10,6 +10,8 @@ import (
 // matter: missing a real person means their files are silently left behind
 // (the bridge skips profiles with no matching account), while inventing one
 // for a system or leftover directory puts a stranger on the login screen.
+// It also decides the directory→account map the first-boot bridge uses, so
+// the WindowsDir half must stay the RAW directory name.
 func TestListWindowsProfiles(t *testing.T) {
 	users := filepath.Join(t.TempDir(), "Users")
 
@@ -29,20 +31,27 @@ func TestListWindowsProfiles(t *testing.T) {
 		}
 	}
 
-	real("jreilly")          // the installer-runner (primary)
+	real("James Reilly")     // the installer-runner's own profile directory
 	real("Alice Smith")      // a real second user, needs sanitising
 	real("bob")              // a real third user
 	real("Public")           // system
-	real("defaultuser0")     // system-ish leftover from OOBE
+	real("defaultuser0")     // OOBE leftover — Windows often fails to delete it
 	bare("Default")          // system, and no NTUSER.DAT
 	bare("leftover-profile") // a directory that was never a logged-in user
 	if err := os.WriteFile(filepath.Join(users, "desktop.ini"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	got := listProfilesIn(users, "jreilly")
+	// The primary chose the username "james" — nothing like the directory
+	// name. Exclusion must work on the DIRECTORY, or the person who ran the
+	// installer gets a locked doppelganger account (and the bridge's #73
+	// single-user fallback breaks).
+	got := listProfilesIn(users, "james", "James Reilly")
 
-	want := []string{"alice-smith", "bob", "defaultuser0"}
+	want := []profileMapping{
+		{WindowsDir: "Alice Smith", LinuxUser: "alice-smith"},
+		{WindowsDir: "bob", LinuxUser: "bob"},
+	}
 	if len(got) != len(want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
@@ -51,17 +60,26 @@ func TestListWindowsProfiles(t *testing.T) {
 			t.Fatalf("got %v, want %v (sorted, deterministic)", got, want)
 		}
 	}
+}
 
-	// The primary must never be duplicated — fisherman already created it.
-	for _, g := range got {
-		if g == "jreilly" {
-			t.Error("primary user must be excluded")
-		}
+// A profile whose directory happens to match the primary username must not be
+// duplicated either — fisherman already created that account.
+func TestListWindowsProfilesPrimaryNameCollision(t *testing.T) {
+	users := filepath.Join(t.TempDir(), "Users")
+	d := filepath.Join(users, "jreilly")
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(d, "NTUSER.DAT"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := listProfilesIn(users, "jreilly", ""); len(got) != 0 {
+		t.Errorf("got %v, want none — primary user must be excluded", got)
 	}
 }
 
 func TestListWindowsProfilesNoUsersDir(t *testing.T) {
-	if got := listProfilesIn(filepath.Join(t.TempDir(), "Users"), "jreilly"); got != nil {
+	if got := listProfilesIn(filepath.Join(t.TempDir(), "Users"), "jreilly", "jreilly"); got != nil {
 		t.Errorf("got %v, want nil when there is no Users directory", got)
 	}
 }

--- a/app/profiles_windows.go
+++ b/app/profiles_windows.go
@@ -9,8 +9,18 @@ import (
 
 // listWindowsProfiles enumerates real Windows profiles on this machine. See
 // profiles.go for the rules and the reasoning.
-func listWindowsProfiles(primary string) []string {
-	return listProfilesIn(filepath.Join(systemDriveRoot(), "Users"), primary)
+func listWindowsProfiles(primary string) []profileMapping {
+	return listProfilesIn(filepath.Join(systemDriveRoot(), "Users"), primary, primaryProfileDir())
+}
+
+// primaryProfileDir is the basename of the running user's own Windows profile
+// directory ("James Reilly" for C:\Users\James Reilly). USERPROFILE is set for
+// every interactive session; empty just means no directory-based exclusion.
+func primaryProfileDir() string {
+	if p := os.Getenv("USERPROFILE"); p != "" {
+		return filepath.Base(p)
+	}
+	return ""
 }
 
 // systemDriveRoot is where Windows profiles live. Note this is NOT wootcDir()'s

--- a/app/vault_windows.go
+++ b/app/vault_windows.go
@@ -75,10 +75,26 @@ func writeVault(cfg InstallConfig) error {
 	// Every other Windows profile gets an account so its data has somewhere to
 	// land (#16). Deliberately NO password: we will not invent credentials for
 	// someone who never sat in front of the installer. The deployer creates
-	// these locked, and wootc-mount-user-dirs then bridges each profile into
-	// the account of the same name.
-	if others := listWindowsProfiles(cfg.Username); len(others) > 0 {
-		vault["secondary_users"] = others
+	// these locked from secondary_users, and persists profile_map (Windows
+	// profile directory → Linux account, sanitization applied) into the
+	// installed system so wootc-mount-user-dirs can bridge each directory to
+	// the right account even when the names differ ("Alice Smith" →
+	// alice-smith, and the primary's freely chosen username).
+	others := listWindowsProfiles(cfg.Username)
+	profileMap := map[string]string{}
+	if dir := primaryProfileDir(); dir != "" {
+		profileMap[dir] = cfg.Username
+	}
+	if len(others) > 0 {
+		names := make([]string, 0, len(others))
+		for _, m := range others {
+			names = append(names, m.LinuxUser)
+			profileMap[m.WindowsDir] = m.LinuxUser
+		}
+		vault["secondary_users"] = names
+	}
+	if len(profileMap) > 0 {
+		vault["profile_map"] = profileMap
 	}
 
 	data, err := marshalJSON(vault)

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -653,6 +653,7 @@ log "Attached raw image ${DISK} as ${LOOP_DEV}"
 VAULT_USER=""
 VAULT_PASSWORD_HASH=""
 VAULT_SECONDARY_USERS=""
+VAULT_PROFILE_MAP=""
 if [[ -n "$VAULT_PATH" ]]; then
     VAULT_FILE="/mnt/ntfs${VAULT_PATH}"
     if [[ -f "$VAULT_FILE" ]]; then
@@ -663,6 +664,11 @@ if [[ -n "$VAULT_PATH" ]]; then
         # Other Windows profiles (#16). Read HERE, before the shred below —
         # this is the only moment the vault exists.
         VAULT_SECONDARY_USERS=$(jq -r '.secondary_users[]? // empty' "$VAULT_FILE" 2>/dev/null || true)
+        # Windows profile directory → Linux account map, one "dir<TAB>user"
+        # line per profile (the primary included). Persisted into the target
+        # during verification so the first-boot bridge can match directories
+        # whose names sanitization changed ("Alice Smith" → alice-smith).
+        VAULT_PROFILE_MAP=$(jq -r '.profile_map // {} | to_entries[] | "\(.key)\t\(.value)"' "$VAULT_FILE" 2>/dev/null || true)
         if [[ -n "$VAULT_HOSTNAME" ]]; then
             HOSTNAME="$VAULT_HOSTNAME"
         fi
@@ -1128,11 +1134,16 @@ if [[ -d "$BUNDLE_STORE" ]]; then
     if [[ -f "/mnt/ntfs/wootc/bundle/bundle.json" ]]; then
         _bundle_img=$(jq -r '.image // empty' "/mnt/ntfs/wootc/bundle/bundle.json" 2>/dev/null || echo "")
     fi
-    if [[ -n "$_bundle_img" && "$_bundle_img" != "$IMAGE" ]]; then
+    # Compare against SOURCE_IMAGE, the registry ref the user actually chose.
+    # $IMAGE may have been rewritten by ntfs-3g injection to
+    # localhost/wootc-ntfs-injected:latest by this point, and a bundle that
+    # matched the selection exactly must not be rejected over the deployer's
+    # own transient tag.
+    if [[ -n "$_bundle_img" && "$_bundle_img" != "$SOURCE_IMAGE" ]]; then
         # A bundle for a DIFFERENT image is not an error — the user may have
         # changed their mind in the GUI — but silently pulling several GB when
         # they expected offline is worth saying out loud.
-        log "  Bundle holds ${_bundle_img}, not ${IMAGE}; ignoring it and pulling instead"
+        log "  Bundle holds ${_bundle_img}, not ${SOURCE_IMAGE}; ignoring it and pulling instead"
     else
         BUNDLE_JSON=",\"additionalImageStores\": [\"${BUNDLE_STORE}\"]"
         log "Offline image bundle found at ${BUNDLE_STORE} — skipping the image download"
@@ -1801,6 +1812,22 @@ if [[ -n "$VERIFY_ROOT" ]]; then
                 warn "  could not create an account for Windows profile '${_secuser}' — their files will not be bridged"
             fi
         done <<< "$VAULT_SECONDARY_USERS"
+    fi
+
+    # Persist the Windows-directory → Linux-account map for the first-boot
+    # bridge. Without it wootc-mount-user-dirs can only match a profile whose
+    # directory name IS a Linux account name — which excludes every name that
+    # sanitization changed ("Alice Smith" → alice-smith) and usually the
+    # primary user too (directory "James Reilly", chosen username "james").
+    # /etc is the per-deployment writable tree on every backend (the useradd
+    # above already depends on that).
+    if [[ -n "$VAULT_PROFILE_MAP" ]]; then
+        if install -d -m 0755 "$DEPLOY_ROOT/etc/wootc" &&
+           printf '%s\n' "$VAULT_PROFILE_MAP" > "$DEPLOY_ROOT/etc/wootc/profile-map.tsv"; then
+            log "  [PASS] persisted Windows→Linux profile map ($(printf '%s\n' "$VAULT_PROFILE_MAP" | wc -l) entr(y|ies)) to /etc/wootc/profile-map.tsv"
+        else
+            warn "  could not persist the profile map — the bridge will fall back to exact directory-name matches"
+        fi
     fi
 
     VERIFY_BOOT="${VERIFY_LOOP}p2"

--- a/payload/deployer/module-setup.sh
+++ b/payload/deployer/module-setup.sh
@@ -50,7 +50,9 @@ install() {
     # generator provides (ESP/home/srv/swap auto-mount) is wanted either.
     #
     # 99wootc sorts after 00systemd, so the generator is already installed
-    # into $initdir by the time this runs.
+    # into $initdir by the time this runs. dracut defines initdir, like
+    # moddir above, before invoking module install hooks.
+    # shellcheck disable=SC2154
     rm -f "$initdir/usr/lib/systemd/system-generators/systemd-gpt-auto-generator"
 
     # Required binaries. fisherman's host-tool contract (checkRequiredTools in

--- a/payload/migration/wootc-mount-user-dirs
+++ b/payload/migration/wootc-mount-user-dirs
@@ -242,23 +242,38 @@ for _root in "${_profile_roots[@]}"; do
     esac
     real_profiles+=("$winprofile")
 
+    # The installer records how each profile directory maps to the Linux
+    # account it created (sanitization changes most names: "Alice Smith" is
+    # account alice-smith, and the primary's chosen username need not resemble
+    # their directory at all). Consult the map first; the exact directory-name
+    # match stays as the fallback for deployments made before the map existed.
+    account="$name"
+    if [[ -r /etc/wootc/profile-map.tsv ]]; then
+        mapped=$(awk -F'\t' -v k="$name" '$1 == k { print $2; exit }' \
+            /etc/wootc/profile-map.tsv 2>/dev/null)
+        if [[ -n "$mapped" ]]; then
+            account="$mapped"
+            [[ "$account" != "$name" ]] && log "profile map: $name -> $account"
+        fi
+    fi
+
     # Only bind for a Linux account that actually exists (skip unrelated
     # Windows profiles) and has UID >= 1000 (a real user, not a system account).
-    uid=$(id -u "$name" 2>/dev/null) || continue
+    uid=$(id -u "$account" 2>/dev/null) || continue
     [[ "$uid" -ge 1000 ]] || continue
     matched=$((matched + 1))
 
-    home=$(getent passwd "$name" | cut -d: -f6)
+    home=$(getent passwd "$account" | cut -d: -f6)
     if [[ ! -d "$home" ]]; then
         # A matching account whose recorded home does not exist is a broken
         # deployment, not a skippable case — say so instead of exiting 0 in
         # silence (run 20260723T0423: fisherman's useradd left the home in
         # the deployment's masked var; this unit "succeeded" with 0 binds).
-        log "ERROR: user $name has no home directory ($home) — cannot bridge; deployment bug"
+        log "ERROR: user $account has no home directory ($home) — cannot bridge; deployment bug"
         continue
     fi
 
-    bind_profile "$winprofile" "$name" "$home"
+    bind_profile "$winprofile" "$account" "$home"
   done
 done
 


### PR DESCRIPTION
Main has been red on every push since 6e3bcd4 (#181), and ~99 commits of features merged since the last green matrix run had never been reviewed as a whole. This branch fixes the red and every defect that review confirmed; the design-level findings are filed as #196 and #197 rather than half-fixed here.

## The red: shellcheck on main

6e3bcd4 removed the gpt-auto generator from the deployer initramfs but referenced dracut's `$initdir` without the SC2154 directive the file already carries for `$moddir`. One directive (with the reasoning) takes lint — and with it every CI run on main and on PRs — back to green.

## Confirmed defects fixed

**All-profiles migration (#16 / #193) never bridged renamed profiles.** Accounts are created under *sanitized* names (`Alice Smith` → `alice-smith`) but the first-boot bridge matched profiles by their *raw* directory name, so any profile whose name sanitization changed got a locked account and no data — the exact failure #16 set out to fix. The installer's own profile could also spawn a locked doppelganger (username `james`, directory `James Reilly`), breaking the one-profile/one-user fallback (#73). Now: `vault.json` carries a `profile_map` (directory → account, primary included), the deployer persists it to `/etc/wootc/profile-map.tsv` before shredding the vault, the bridge consults it first (exact-name match stays as the pre-map fallback), the primary's own directory is excluded via `USERPROFILE`, and `defaultuser0` (the OOBE leftover) joins the system-profile exclusions. Unit tests updated to pin the mapping and the directory-based exclusion.

**Offline bundle rejected after ntfs injection.** The bundle-vs-selection check compared against `$IMAGE`, which `ensure_ntfs_support` may have rewritten to `localhost/wootc-ntfs-injected:latest`, so an exactly-matching bundle was "ignored" and gigabytes pulled anyway. It now compares against `SOURCE_IMAGE`, which exists precisely to keep the registry origin distinct from transient derivations. (The deeper offline-bundle problems are #196.)

**Invisible accent styling.** Four sites (launchpad's RECOMMENDED label and selected-row borders, vmpreview's build-progress fill) styled themselves with `var(--primary)`, which no stylesheet defines — the VM build progress bar rendered as an empty track. All four now use the real token, `--accent`.

## Reviewed and found sound

The main.js split (#189) was verified mechanically clean against its parent (no dropped listeners, state, or ids); the quit fix (#190), Windows light/dark (#183), window decoration (#186), the PowerShell e2e fixes (#182), the boot-splash fix (#181, functionally), the installer_windows split (#188, line-multiset-verified), the nil-panic/reclaim fixes (#192), release.yml mechanics, and the `WOOTC_TARGET_IMAGE` rename (#180) all check out.

## Verification

- Full CI lint target set, yamllint: pass locally; CI green on the branch.
- Fast tier: green apart from the known environment-only `apply-look` case (green in CI).
- `GOOS=windows` build + vet: pass. GUI suite: 20/20.
- E2E matrix smoke (7 cells) dispatched from this branch: run 32534827767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki