### PR TITLE
fix(deployer): keep the '@' argv[0] through the ntfs-3g closure wrapper

### DIFF
--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -1382,11 +1382,23 @@ stage_ntfs3g_closure() {
             return 1
         fi
         # The wrapper the attach hook's mount_host() will find as `ntfs-3g`.
-        # Needs only a POSIX sh, which the hook (bash) already requires.
+        #
+        # `exec -a "\$0"` is load-bearing, not cosmetic. mount_host() launches
+        # the FUSE daemon with argv[0] prefixed '@' so systemd's initrd
+        # switch-root killing spree spares it (systemd's ROOT STORAGE DAEMONS
+        # contract). A plain `exec` here re-execs through the staged loader
+        # and resets argv[0] to the loader path — no '@' — so the daemon was
+        # SIGKILLed mid-switch-root and every loop I/O returned EIO, ending in
+        # "Failed to execute /sbin/init: Input/output error" (all three el10
+        # cells, run 32534827767). The native-binary path never re-execs,
+        # which is why this only bit when the target-image ntfs-3g install
+        # failed and Phase 2 fell back to this closure. Propagating "\$0"
+        # keeps whatever name the caller chose, '@' included. Needs bash for
+        # `exec -a`, which the attach hook (bash) already requires present.
         mkdir -p "$ovl/usr/bin" "$ovl/usr/sbin"
         cat > "$ovl/usr/bin/ntfs-3g" <<NTFSWRAP
-#!/bin/sh
-exec /$pdir/$ldso --library-path /$pdir /$pdir/ntfs-3g "\$@"
+#!/bin/bash
+exec -a "\$0" /$pdir/$ldso --library-path /$pdir /$pdir/ntfs-3g "\$@"
 NTFSWRAP
         chmod 0755 "$ovl/usr/bin/ntfs-3g"
         ln -sf /usr/bin/ntfs-3g "$ovl/usr/sbin/mount.ntfs"

--- a/tests/unit/phase2-early-cpio.bats
+++ b/tests/unit/phase2-early-cpio.bats
@@ -118,6 +118,37 @@ run_helpers() { # <bash-snippet> — with the extracted helpers + stubs loaded
     [ -L "$tmp/ovl/usr/sbin/mount.ntfs" ]
 }
 
+@test "behavioral: fallback wrapper preserves the caller's argv[0] (the '@' that survives switch-root)" {
+    # mount_host() launches the FUSE daemon as '@ntfs-3g' so systemd's initrd
+    # switch-root killing spree spares it. A wrapper that plain-execs the
+    # staged loader resets argv[0] to the loader path, the daemon is
+    # SIGKILLed mid-switch-root, and every loop I/O returns EIO — Phase 2
+    # died on "Failed to execute /sbin/init: Input/output error" on all
+    # three el10 cells of run 32534827767 (the only cells whose kernels lack
+    # ntfs3, and whose target ntfs-3g install failed, so ONLY they exercise
+    # this fallback). The wrapper must exec with `-a "\$0"` so the caller's
+    # chosen name — '@' included — reaches /proc/PID/cmdline.
+    tmp="$BATS_TEST_TMPDIR/fallback"
+    mkdir -p "$tmp/root" "$tmp/ovl" "$tmp/bin"
+    printf '#!/bin/sh\necho fake\n' > "$tmp/bin/ntfs-3g"
+    chmod +x "$tmp/bin/ntfs-3g"
+    # A fake loader good enough for the closure's exec-verification call.
+    printf '#!/bin/sh\nexit 0\n' > "$tmp/bin/ld-linux-fake.so.2"
+    chmod +x "$tmp/bin/ld-linux-fake.so.2"
+    run run_helpers "
+        DEPLOY_ROOT='$tmp/root'
+        PATH='$tmp/bin':\$PATH
+        dso_closure() { printf '%s\n' '$tmp/bin/ld-linux-fake.so.2'; }
+        stage_ntfs3g_closure '$tmp/ovl'
+    "
+    [ "$status" -eq 0 ]
+    wrapper="$tmp/ovl/usr/bin/ntfs-3g"
+    [ -x "$wrapper" ]
+    # bash, not sh: `exec -a` is a bashism, and /bin/sh may be dash.
+    head -1 "$wrapper" | grep -q bash
+    grep -q 'exec -a "\$0" ' "$wrapper"
+}
+
 make_overlay() { # <dir> — a complete wootc overlay tree
     mkdir -p "$1/usr/lib/systemd/system/initrd-root-device.target.wants" \
              "$1/usr/lib/wootc" \


### PR DESCRIPTION
All three el10 cells of the post-#195 smoke matrix ([run 32534827767](https://github.com/tuna-os/wootc/actions/runs/32534827767)) failed identically: Phase 2 attached root.disk, mounted the ext4 root, then drowned in loop-device I/O errors ~7s in — `Failed to execute /sbin/init, giving up: Input/output error`. The other four cells (fedora ×2, bluefin-lts, bluefin-dakota) were green.

## Root cause

`mount_host()` in the attach hook launches the FUSE daemon with `exec -a "@$drv"` — the `@` argv[0] prefix that tells systemd's initrd switch-root killing spree to spare the process (systemd's ROOT STORAGE DAEMONS contract). But when Phase 2 falls back to the deployer's private ntfs-3g closure, the binary the hook finds is a **wrapper** that plain-`exec`s the staged loader:

```sh
exec /usr/lib/wootc/ntfs3g/ld-linux-… --library-path … /usr/lib/wootc/ntfs3g/ntfs-3g "$@"
```

That re-exec resets argv[0] to the loader path — no `@` — so systemd SIGKILLed the FUSE daemon mid-switch-root, and every subsequent I/O on the loop device backed by that (now-dead) FUSE mount returned EIO, before `/sbin/init` could even be paged in.

Two gates explain why only el10 fails, and only now:
- el10/yellowfin kernels are the only smoke cells **without ntfs3** (`unknown filesystem type 'ntfs3'` on the serial), so only they mount the host NTFS via FUSE in Phase 2 at all — Fedora-family cells use the kernel driver, which has no daemon to kill.
- The wrapper is only used when the target-image ntfs-3g install fails — which it now does 3/3 into `yellowfin:gnome` (`[WARN] ntfs-3g install attempt 3/3 failed`). A native ntfs-3g binary doesn't re-exec, so its `@` survives — which is why el10 was green while the in-image install still worked.

## Fix

The wrapper now propagates the caller's chosen name — `@` included — and moves to bash for `exec -a` (the attach hook already requires bash in the same initramfs):

```bash
exec -a "$0" /usr/lib/wootc/ntfs3g/ld-linux-… --library-path … /usr/lib/wootc/ntfs3g/ntfs-3g "$@"
```

`/proc/PID/cmdline` — what the killing spree reads — is fixed at `execve` time, so the `@` survives both ld.so's internal argv shift and ntfs-3g's daemonizing fork.

## Verification

- New behavioral bats test drives `stage_ntfs3g_closure` down the fallback path and pins the `exec -a "$0"` + bash-shebang contract (`phase2-early-cpio.bats`); full suite 14/14, `deployer-dso-closure` + `qga-real-root` suites green.
- `bash -n` and shellcheck finding-count parity on deploy.sh (30 → 30, all pre-existing).
- E2E smoke matrix dispatched from this branch to prove the el10 cells green.

The separate question of *why* the dnf install of ntfs-3g into yellowfin now fails 3/3 (repo/EPEL drift?) is worth its own look — but the closure fallback exists precisely to survive that, and now it actually does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_