### PR TITLE
fix(deployer): hardcode '@ntfs-3g' — shebang handling discards the propagated argv[0]

### DIFF
--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -1383,22 +1383,32 @@ stage_ntfs3g_closure() {
         fi
         # The wrapper the attach hook's mount_host() will find as `ntfs-3g`.
         #
-        # `exec -a "\$0"` is load-bearing, not cosmetic. mount_host() launches
-        # the FUSE daemon with argv[0] prefixed '@' so systemd's initrd
-        # switch-root killing spree spares it (systemd's ROOT STORAGE DAEMONS
-        # contract). A plain `exec` here re-execs through the staged loader
-        # and resets argv[0] to the loader path — no '@' — so the daemon was
-        # SIGKILLed mid-switch-root and every loop I/O returned EIO, ending in
-        # "Failed to execute /sbin/init: Input/output error" (all three el10
-        # cells, run 32534827767). The native-binary path never re-execs,
-        # which is why this only bit when the target-image ntfs-3g install
-        # failed and Phase 2 fell back to this closure. Propagating "\$0"
-        # keeps whatever name the caller chose, '@' included. Needs bash for
-        # `exec -a`, which the attach hook (bash) already requires present.
+        # The hardcoded `exec -a "@ntfs-3g"` is load-bearing, not cosmetic:
+        # the FUSE daemon this wrapper becomes must carry an argv[0] whose
+        # first byte is '@' so systemd's initrd switch-root killing spree
+        # spares it (systemd's ROOT STORAGE DAEMONS contract). Without it the
+        # daemon is SIGKILLed mid-switch-root and every loop I/O returns EIO,
+        # ending in "Failed to execute /sbin/init: Input/output error" — all
+        # three el10 cells of run 32534827767. Only this fallback bites: a
+        # native ntfs-3g never re-execs, so the '@' mount_host() sets
+        # survives, which is why el10 was green while the target-image
+        # ntfs-3g install still succeeded.
+        #
+        # The '@' must be hardcoded HERE; propagating the caller's name via
+        # `exec -a "\$0"` does not work (run 32538672432 proved it): this is
+        # a shebang script, and Linux shebang handling REPLACES argv[0] with
+        # the script path when it builds the interpreter's argv — the
+        # caller's '@mount.ntfs-3g' is discarded before this script runs, so
+        # \$0 is always the plain script path. /proc/PID/cmdline — what the
+        # killing spree reads — is fixed at execve time, so the hardcoded '@'
+        # survives both ld.so's argv shift and ntfs-3g's daemonizing fork.
+        # Unconditional '@' is harmless in every other context (argv[0] only
+        # feeds ntfs-3g's usage messages). Needs bash for `exec -a`, which
+        # the attach hook (bash) already requires present.
         mkdir -p "$ovl/usr/bin" "$ovl/usr/sbin"
         cat > "$ovl/usr/bin/ntfs-3g" <<NTFSWRAP
 #!/bin/bash
-exec -a "\$0" /$pdir/$ldso --library-path /$pdir /$pdir/ntfs-3g "\$@"
+exec -a "@ntfs-3g" /$pdir/$ldso --library-path /$pdir /$pdir/ntfs-3g "\$@"
 NTFSWRAP
         chmod 0755 "$ovl/usr/bin/ntfs-3g"
         ln -sf /usr/bin/ntfs-3g "$ovl/usr/sbin/mount.ntfs"

--- a/tests/unit/phase2-early-cpio.bats
+++ b/tests/unit/phase2-early-cpio.bats
@@ -118,16 +118,22 @@ run_helpers() { # <bash-snippet> — with the extracted helpers + stubs loaded
     [ -L "$tmp/ovl/usr/sbin/mount.ntfs" ]
 }
 
-@test "behavioral: fallback wrapper preserves the caller's argv[0] (the '@' that survives switch-root)" {
-    # mount_host() launches the FUSE daemon as '@ntfs-3g' so systemd's initrd
-    # switch-root killing spree spares it. A wrapper that plain-execs the
-    # staged loader resets argv[0] to the loader path, the daemon is
-    # SIGKILLed mid-switch-root, and every loop I/O returns EIO — Phase 2
-    # died on "Failed to execute /sbin/init: Input/output error" on all
-    # three el10 cells of run 32534827767 (the only cells whose kernels lack
-    # ntfs3, and whose target ntfs-3g install failed, so ONLY they exercise
-    # this fallback). The wrapper must exec with `-a "\$0"` so the caller's
-    # chosen name — '@' included — reaches /proc/PID/cmdline.
+@test "behavioral: fallback wrapper hardcodes the '@' argv[0] that survives switch-root" {
+    # The FUSE daemon this wrapper becomes must carry argv[0] starting with
+    # '@' so systemd's initrd switch-root killing spree spares it; otherwise
+    # the daemon is SIGKILLed mid-switch-root and every loop I/O returns EIO
+    # — Phase 2 died on "Failed to execute /sbin/init: Input/output error"
+    # on all three el10 cells of run 32534827767 (the only cells whose
+    # kernels lack ntfs3 AND whose target ntfs-3g install failed, so only
+    # they exercise this fallback).
+    #
+    # The '@' must be HARDCODED, not propagated: `exec -a "\$0"` looked
+    # right and run 32538672432 proved it wrong — shebang handling replaces
+    # argv[0] with the script path before the wrapper runs, so \$0 never
+    # carries the caller's '@mount.ntfs-3g'. The assertion is textual
+    # because the honest end-to-end check needs a real binary loader: a
+    # script stand-in would itself go through shebang argv replacement and
+    # could not demonstrate the '@' reaching /proc/PID/cmdline.
     tmp="$BATS_TEST_TMPDIR/fallback"
     mkdir -p "$tmp/root" "$tmp/ovl" "$tmp/bin"
     printf '#!/bin/sh\necho fake\n' > "$tmp/bin/ntfs-3g"
@@ -146,7 +152,10 @@ run_helpers() { # <bash-snippet> — with the extracted helpers + stubs loaded
     [ -x "$wrapper" ]
     # bash, not sh: `exec -a` is a bashism, and /bin/sh may be dash.
     head -1 "$wrapper" | grep -q bash
-    grep -q 'exec -a "\$0" ' "$wrapper"
+    grep -q 'exec -a "@ntfs-3g" ' "$wrapper"
+    # The trap this test exists to block: never "propagate" \$0 again.
+    run grep 'exec -a "\$0"' "$wrapper"
+    [ "$status" -ne 0 ]
 }
 
 make_overlay() { # <dir> — a complete wootc overlay tree


### PR DESCRIPTION
Follow-up to #198, which was diagnostically right and mechanically wrong. The smoke matrix at its commit ([run 32538672432](https://github.com/tuna-os/wootc/actions/runs/32538672432)) reproduced the identical el10 Phase-2 failure: `Reached target Switch Root` at 6.8s on the serial, loop-EIO storm within 50ms, JBD2/EXT4 errors, unbootable root. The four non-el10 cells stayed green.

## Why #198 didn't work

The closure wrapper is a **shebang script**. When the attach hook launches it as `@mount.ntfs-3g`, Linux shebang handling builds the interpreter's argv as `[interpreter, script-path, args…]` — the caller's argv[0] is **discarded** and `$0` inside the script is always the plain script path. So `exec -a "$0"` faithfully propagated a name with no `@`, and systemd's switch-root killing spree still SIGKILLed the FUSE daemon backing the loop device.

## Fix

Hardcode the protected name in the wrapper:

```bash
exec -a "@ntfs-3g" /usr/lib/wootc/ntfs3g/ld-linux-… --library-path … /usr/lib/wootc/ntfs3g/ntfs-3g "$@"
```

`/proc/PID/cmdline` — what the killing spree reads — is fixed at the execve of the (binary) loader, so the `@` survives ld.so's internal argv shift and ntfs-3g's daemonizing fork. An unconditional `@` is harmless in every other context: argv[0] only feeds ntfs-3g's usage messages.

The regression test now pins the hardcoded name and **explicitly rejects** the `$0`-propagation variant it previously blessed — that assertion passed while the fix was wrong, which is exactly the trap the test needed to close.

## Verification

- `phase2-early-cpio.bats` 14/14 (behavioral fallback test drives `stage_ntfs3g_closure` and asserts the wrapper contract); `bash -n` clean.
- Smoke matrix will be dispatched from this branch; the two el10-win11pro cells (plain + BitLocker) are the deciders — they are the only smoke cells that mount the host NTFS via FUSE in Phase 2 *and* currently fall back to this closure (target-image ntfs-3g install fails 3/3 into yellowfin:gnome).
- The el10-win10pro cell's failure in the same run was unrelated: a QGA 60s timeout (exit 124) during the reset step, before deploy — a separate harness-robustness item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_