### PR TITLE
Production-ready distribution: winget, hardened release publish, manual-testing guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,16 @@ jobs:
         with: { node-version: '24' }
       - uses: ./.github/actions/podman-runtime
 
+      - name: Reclaim disk (the deployer image build needs the room)
+        run: |
+          df -h / || true
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" \
+                      /usr/local/lib/node_modules /usr/share/swift || true
+          sudo apt-get clean
+          docker image prune -af 2>/dev/null || true
+          echo "--- after cleanup ---"; df -h /
+
       - name: Resolve channel + tag
         id: chan
         run: |
@@ -105,10 +115,16 @@ jobs:
             echo "tag=auto-v$(date -u +%Y%m%d)-${sha::7}" >> "$GITHUB_OUTPUT"
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
             echo "channel=auto" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "${GITHUB_REF_TYPE}" = "tag" ]; then
             echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
             echo "channel=tagged" >> "$GITHUB_OUTPUT"
+          else
+            # workflow_dispatch from a branch: synthesize a tag rather than
+            # publishing a release literally named "main".
+            echo "tag=manual-v$(date -u +%Y%m%d)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "channel=manual" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build brand installers (one exe per brand)
@@ -199,7 +215,7 @@ jobs:
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.chan.outputs.tag }}
-          target_commitish: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
+          target_commitish: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || (github.ref_type != 'tag' && github.sha || '') }}
           prerelease: ${{ steps.chan.outputs.prerelease }}
           files: release-assets/*
           body_path: NOTES.md

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,78 @@
+name: winget publish
+
+# Submits (or updates) TunaOS.wootc in microsoft/winget-pkgs whenever a FULL
+# release is published — pre-releases (the auto-v* nightly channel) are
+# skipped, because winget users should land on E2E-gated, human-blessed
+# builds only. See packaging/winget/README.md for the one-time setup
+# (WINGET_TOKEN secret) and why branded installers are not auto-submitted.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to (re)submit, e.g. v0.1.0'
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    runs-on: windows-latest
+    steps:
+      - name: Skip pre-releases
+        if: ${{ github.event_name == 'release' && github.event.release.prerelease }}
+        run: |
+          echo "Pre-release — winget submission skipped by design."
+          echo "skip=true" >> $env:GITHUB_ENV
+
+      - uses: actions/checkout@v7
+        if: ${{ env.skip != 'true' }}
+
+      - name: Render manifests from the release
+        if: ${{ env.skip != 'true' }}
+        shell: pwsh
+        run: |
+          $tag = if ('${{ github.event_name }}' -eq 'release') { '${{ github.event.release.tag_name }}' } else { '${{ inputs.tag }}' }
+          $version = $tag -replace '^v',''
+          $url = "https://github.com/${{ github.repository }}/releases/download/$tag/wootc.exe"
+          Write-Host "tag=$tag version=$version"
+          Write-Host "url=$url"
+          # Hash the ACTUAL published bytes — never trust a locally rebuilt exe.
+          Invoke-WebRequest -Uri $url -OutFile wootc.exe
+          $sha = (Get-FileHash wootc.exe -Algorithm SHA256).Hash
+          Write-Host "sha256=$sha"
+          $out = "rendered/manifests/t/TunaOS/wootc/$version"
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          Get-ChildItem packaging/winget/*.yaml.in | ForEach-Object {
+            $dest = Join-Path $out ($_.Name -replace '\.in$','')
+            (Get-Content $_ -Raw) `
+              -replace '\{\{VERSION\}\}', $version `
+              -replace '\{\{TAG\}\}', $tag `
+              -replace '\{\{URL\}\}', $url `
+              -replace '\{\{SHA256\}\}', $sha `
+              | Set-Content -NoNewline $dest
+            Write-Host "rendered $dest"
+          }
+          Get-ChildItem $out | ForEach-Object { Write-Host "--- $($_.Name)"; Get-Content $_.FullName }
+          echo "MANIFEST_DIR=$out" >> $env:GITHUB_ENV
+
+      - name: Submit to winget-pkgs
+        if: ${{ env.skip != 'true' }}
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "::notice::WINGET_TOKEN secret is not set — manifests were rendered and printed above, but not submitted."
+            Write-Host "::notice::Add a classic PAT with public_repo scope as the WINGET_TOKEN secret to enable automatic submission (packaging/winget/README.md)."
+            exit 0
+          }
+          # wingetcreate validates the manifests, forks microsoft/winget-pkgs,
+          # and opens the PR. Works for both the first submission (creates the
+          # package) and later version updates.
+          Invoke-WebRequest -Uri https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe submit --token $env:WINGET_TOKEN --prtitle "TunaOS.wootc: update" $env:MANIFEST_DIR

--- a/README.md
+++ b/README.md
@@ -28,14 +28,34 @@ have never touched a partition editor.
 
 ## Get wootc
 
-Download `wootc.exe` from the
+**Download** (simplest): grab `wootc.exe` from the
 [latest release](https://github.com/tuna-os/wootc/releases/latest) and run
-it as Administrator. Because the binary is not yet code-signed, Windows
-shows a SmartScreen warning and an "unknown publisher" prompt on the way —
+it as Administrator. That is the whole install — one file, no setup wizard;
+the app downloads and verifies its boot pieces itself (every artifact is
+checked against the release's `SHA256SUMS` before it is trusted).
+
+**winget** (once the first submission clears Microsoft's review):
+
+```
+winget install TunaOS.wootc
+```
+
+**Branded installers**: every release also ships the same engine wearing
+each distribution's own identity — `Bazzite-Installer.exe`,
+`Bluefin-Installer.exe`, `Aurora-Installer.exe`, `TunaOS-Installer.exe` —
+which pre-select that distribution's images and pre-download the OS while
+still on Windows (no network needed after the reboot). Pick the one for the
+Linux you want; they are otherwise identical.
+
+Because the binaries are not yet code-signed, Windows shows a SmartScreen
+warning and an "unknown publisher" prompt on the way —
 **[Getting started](docs/getting-started.md)** walks through both screens
 and explains why they appear. The
 [user guide](docs/user-guide.md) covers everything after that, including
 [how to put everything back](docs/user-guide.md#9-uninstall--put-everything-back).
+Testing on your own machine? Read
+**[Manual testing](docs/manual-testing.md)** first — a five-minute
+pre-flight that makes the try safe and the feedback useful.
 
 ## Why
 

--- a/app/deployer_windows.go
+++ b/app/deployer_windows.go
@@ -52,6 +52,17 @@ func downloadDeployer(ctx context.Context, progress func(float64)) error {
 		dest := filepath.Join(installDir, name)
 		want, inManifest := sums[name]
 		if !inManifest {
+			// wubildr.efi is the one genuinely optional artifact: the release
+			// pipeline builds it best-effort (the signed shim+grub chain is
+			// the real boot path), so a release may legitimately ship
+			// without it. Absent from the manifest → skip it; PRESENT in the
+			// manifest, it is verified exactly like everything else. Every
+			// other artifact stays fail-closed (#53): no manifest entry, no
+			// install.
+			if isOptionalArtifact(name) {
+				progress(float64(i+1) / float64(len(files)))
+				continue
+			}
 			return fmt.Errorf("checksum not found in manifest for %s: refusing to install an unverified boot artifact", name)
 		}
 
@@ -89,6 +100,12 @@ func downloadDeployer(ctx context.Context, progress func(float64)) error {
 	}
 	return nil
 }
+
+// isOptionalArtifact names the boot artifacts an install can proceed
+// without. Only wubildr.efi qualifies — it serves the legacy NTFS fallback
+// path; the Secure Boot chain (shim+grub) and the deployer pair are the
+// install.
+func isOptionalArtifact(name string) bool { return name == "wubildr.efi" }
 
 // fetchChecksums returns the SHA256SUMS manifest as a filename→hash map.
 // Fail-closed (#53): every error aborts the install rather than silently

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,19 @@ Grab the latest `wootc.exe` from the
 anywhere — Downloads is fine. There is nothing to "install"; wootc is a
 single program you run.
 
+Prefer a specific distribution? The same release page carries branded
+builds of the identical engine — `Bazzite-Installer.exe`,
+`Bluefin-Installer.exe`, `Aurora-Installer.exe`, `TunaOS-Installer.exe`.
+They pre-select their own images and download the whole OS while still on
+Windows, which is the right choice on a Wi-Fi-only laptop.
+
+Command-line folks can use winget once the package clears Microsoft's
+one-time review: `winget install TunaOS.wootc`.
+
+Want to check your download? Every release ships a `SHA256SUMS` file;
+compare with PowerShell's `Get-FileHash .\wootc.exe` — the app performs the
+same verification on every boot artifact it downloads for itself.
+
 Your browser may say something like *"wootc.exe isn't commonly downloaded"*
 and hide the file behind a menu. That message means exactly what it says —
 not many people have downloaded this exact file yet — and nothing more.

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -1,0 +1,80 @@
+# Manual testing on a real machine
+
+wootc is exercised nightly by an automated matrix of real Windows VMs, but
+a VM is not a laptop: virtual ethernet, virtual firmware, no vendor OEM
+partitions, no years of accumulated Windows. This is the pre-flight for
+trying wootc **interactively on real hardware** — five minutes that make
+the attempt safe and the feedback actionable.
+
+wootc's whole design is reversibility (everything lives in `C:\wootc`, no
+repartitioning, Windows stays the default boot), so the blast radius is
+deliberately small. Treat it as alpha software anyway.
+
+## Before you start
+
+1. **Have a backup of anything you can't lose.** wootc doesn't touch your
+   files — and you should never test alpha boot software without one.
+2. **Know your BitLocker recovery key** (Settings ▸ Privacy & security ▸
+   Device encryption, or `manage-bde -protectors C: -get`). The alpha
+   refuses encrypted drives up front, but if your firmware boot order is
+   ever touched on a BitLocker machine, Windows may ask for the key once on
+   the way back. Have it *before* rebooting, not after.
+3. **Plug in the power adapter.** The app refuses to start on battery; the
+   deploy boot can take 30–60 minutes on a slow connection.
+4. **Check free disk**: 35 GB+ free on `C:` (20 GB minimum for Linux plus
+   the 15 GB headroom the app reserves for Windows). The slider won't offer
+   more than fits.
+5. **Wired network beats Wi-Fi** for the *generic* `wootc.exe`: the deploy
+   boot has no Wi-Fi. On a Wi-Fi-only laptop use a **branded installer**
+   (or set `WOOTC_PRELOAD=1` before launching) — it downloads the whole OS
+   while still on Windows, and the deploy boot then needs no network at
+   all.
+6. **Let it manage Fast Startup and hibernation.** The app turns them off
+   during install (and the uninstaller restores your original setting) —
+   don't re-enable them mid-test.
+
+## What a good run looks like
+
+1. **Windows, in the app**: pick an image, set a password, Install. The
+   progress list narrates every step; the shield strip tells you what has
+   actually changed at any moment. Reboot when asked (save other work
+   first — the restart is forced).
+2. **The deploy boot**: a calm splash screen ("Your Windows and all of your
+   files are safe"), progress bar, 5–15 minutes on a fast line (the splash
+   says so honestly if it will be longer). No scrolling text — that only
+   appears in debug/E2E runs. It ends with "All set!" and reboots.
+3. **First Linux boot**: the boot menu shows your distribution *and*
+   Windows. Linux starts, you log in with the password you set, a welcome
+   opens the "Bring over from Windows" dashboard, and your Windows folders
+   are bridged (look for the "Windows drive" bookmark in the file manager).
+4. **The way back**: reboot → Windows starts by default. In Windows, the
+   app's Manage screen offers "Restart into <your distro>" whenever you
+   want Linux again — and Uninstall puts everything back.
+
+## If something goes wrong
+
+Nothing before the reboot leaves more than the `C:\wootc` folder and (late
+in the pipeline) one one-time boot entry — and a failure or cancel removes
+the boot entry again. A failed deploy boot returns to Windows by itself
+after 30 seconds.
+
+Collect, in this order, and attach to a GitHub issue:
+
+| What | Where |
+|---|---|
+| Installer log + state | `C:\wootc\logs\`, `C:\wootc\install\state.json` |
+| Deployer log (the deploy boot writes it back) | `C:\wootc\logs\deployer.log` |
+| Deployer journal snapshot | `C:\wootc\logs\deployer-last-journal.log` |
+| What the screen said | a phone photo beats a memory |
+
+Then run the uninstaller (Windows ▸ Settings ▸ Apps ▸ "TunaOS (wootc)", or
+`wootc.exe uninstall`): it removes the boot entry and ESP files, restores
+your Fast Startup/hibernation settings, and keeps `root.disk` unless you
+tick otherwise — so a fixed build can retry without re-downloading.
+
+## Debug mode
+
+Add `wootc.debug` to the deployer's GRUB entry (press `e` in the boot menu)
+to keep verbose consoles and get a shell instead of the auto-return on
+failure. This is the observed/E2E behavior; normal runs stay calm on
+purpose.

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,27 @@
+# winget packaging
+
+`*.yaml.in` are templates for the [winget-pkgs](https://github.com/microsoft/winget-pkgs)
+manifests of the generic installer, published as **`TunaOS.wootc`** (a
+portable package: winget places `wootc.exe` on PATH; running it elevates
+via UAC as usual).
+
+`.github/workflows/winget-publish.yml` renders them on every **full**
+release (pre-releases are skipped): it fills `{{VERSION}}` / `{{TAG}}` from
+the release tag, `{{URL}}` with the release's `wootc.exe` asset, computes
+`{{SHA256}}` from the actual bytes, and submits a PR to winget-pkgs with
+[wingetcreate](https://github.com/microsoft/winget-create).
+
+Requirements, both one-time:
+
+- **`WINGET_TOKEN` repository secret** — a classic PAT with `public_repo`
+  scope, used by wingetcreate to fork winget-pkgs and open the PR. Without
+  it the workflow prints what it *would* submit and exits green.
+- The **first** submission creates the package (same rendered manifests);
+  Microsoft's moderation review of a new package can take a few days.
+  Updates after that are routine.
+
+Branded installers (Bazzite-Installer, Aurora-Installer, …) are deliberately
+NOT auto-submitted: their winget identities belong to their projects
+(`Bazzite.Installer` would sit in Bazzite's namespace), so each needs that
+project's sign-off first. The same templates work — swap the identifier,
+name, and asset.

--- a/packaging/winget/TunaOS.wootc.installer.yaml.in
+++ b/packaging/winget/TunaOS.wootc.installer.yaml.in
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+# Template — {{VERSION}}, {{URL}}, {{SHA256}} are filled by
+# .github/workflows/winget-publish.yml from the GitHub release being published.
+PackageIdentifier: TunaOS.wootc
+PackageVersion: "{{VERSION}}"
+InstallerType: portable
+Commands:
+  - wootc
+Installers:
+  - Architecture: x64
+    InstallerUrl: "{{URL}}"
+    InstallerSha256: "{{SHA256}}"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/TunaOS.wootc.locale.en-US.yaml.in
+++ b/packaging/winget/TunaOS.wootc.locale.en-US.yaml.in
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: TunaOS.wootc
+PackageVersion: "{{VERSION}}"
+PackageLocale: en-US
+Publisher: TunaOS
+PublisherUrl: https://github.com/tuna-os
+PublisherSupportUrl: https://github.com/tuna-os/wootc/issues
+PackageName: wootc
+PackageUrl: https://github.com/tuna-os/wootc
+License: GPL-2.0 OR MIT
+LicenseUrl: https://github.com/tuna-os/wootc/blob/main/LICENSE-GPL-2.0
+ShortDescription: Try Linux alongside Windows — no USB, no repartitioning, fully undoable.
+Description: |-
+  wootc installs a bootc-based Linux (TunaOS, Bluefin, and friends) from
+  inside Windows. Everything lives in one folder on your Windows drive —
+  no partitions are touched, Windows stays the default boot, your files are
+  bridged into Linux, and one uninstall puts everything back.
+Moniker: wootc
+Tags:
+  - linux
+  - dual-boot
+  - migration
+  - bootc
+  - installer
+ReleaseNotesUrl: "https://github.com/tuna-os/wootc/releases/tag/{{TAG}}"
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/TunaOS.wootc.yaml.in
+++ b/packaging/winget/TunaOS.wootc.yaml.in
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: TunaOS.wootc
+PackageVersion: "{{VERSION}}"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/tests/unit/north-star-boot.bats
+++ b/tests/unit/north-star-boot.bats
@@ -100,6 +100,11 @@ MODSETUP="payload/deployer/module-setup.sh"
     grep -q 'sha256sum "$f" >> SHA256SUMS' tests/e2e/run-e2e.sh
     grep -q '"SHA256SUMS") { if (Test-Path' tests/e2e/run-e2e.sh
     grep -q 'install", "SHA256SUMS"' app/deployer_windows.go
+    # wubildr.efi is best-effort in the release pipeline, so the app must
+    # treat it as the ONE optional artifact — a release without it must not
+    # brick every online install — while everything else stays fail-closed.
+    grep -q 'func isOptionalArtifact(name string) bool { return name == "wubildr.efi" }' app/deployer_windows.go
+    grep -q 'wubildr.efi || rm -f release-assets/wubildr.efi' .github/workflows/release.yml
 }
 
 @test "something is on screen before the network is up" {


### PR DESCRIPTION
Follow-up to #200, finishing the "automated + production-ready" story before the first tagged release.

## Release pipeline hardening (its first real run is imminent)
- **Disk reclaim** in the publish job before the multi-GB deployer image build — the same sweep the E2E jobs already do; without it the hosted runner can run out of space mid-publish.
- A branch-ref `workflow_dispatch` now synthesizes `manual-vYYYYMMDD-<sha>` (pre-release) instead of publishing a release literally named `main`.
- **Landmine defused**: `wubildr.efi` is built best-effort by the pipeline but was *required* by `downloadDeployer`'s fail-closed verification — a release without it would have bricked every online install with "checksum not found in manifest". It is now the one artifact that may be absent from the manifest (when present it verifies like everything else); every other artifact stays fail-closed (#53). Pinned in `north-star-boot.bats`.

## winget
- `packaging/winget/` — `TunaOS.wootc` portable manifests as templates (version / installer / defaultLocale, schema 1.6.0).
- `.github/workflows/winget-publish.yml` — on every **full** release (pre-releases skipped by design): renders the manifests with the release's version and the **sha256 of the actual published `wootc.exe` bytes**, then submits a PR to microsoft/winget-pkgs via wingetcreate. Needs a one-time `WINGET_TOKEN` secret (classic PAT, `public_repo`); without it the workflow prints the rendered manifests and exits green, so nothing blocks releasing.
- Branded installers are deliberately **not** auto-submitted — `Bazzite.*`/`Aurora.*` winget identities belong to those projects and need their sign-off (documented in `packaging/winget/README.md`).

## Docs: easy installation + interactive testing
- README **Get wootc**: download-one-file, `winget install TunaOS.wootc`, the branded-installer table, checksum verification, and a pointer to the new testing guide.
- `docs/getting-started.md`: branded builds + winget + `Get-FileHash` verification added to the download step.
- **`docs/manual-testing.md`** (new): the real-hardware pre-flight — backup, BitLocker recovery key *in hand before rebooting*, AC power, disk headroom, why Wi-Fi-only laptops should use a branded build (or `WOOTC_PRELOAD=1`), what a good run looks like phase by phase, exactly which logs to collect when it isn't, and how debug mode differs from the calm product boot.

## Verification
`go build` (linux + windows/amd64), `go test` green, both new/edited workflows YAML-validated, `north-star-boot.bats` 10/10 including the new wubildr contract, `shellcheck -S error` clean.

After merge: tagging `v0.1.0-alpha.1` runs the E2E-gated tagged channel and publishes the first complete release (all five brand exes + boot artifacts + SHA256SUMS) — the point where a laptop test needs nothing but a download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_