### PR TITLE
just brand args + the two GUI-cell fixes from the first main sweep

### DIFF
--- a/app/esp_ownership.go
+++ b/app/esp_ownership.go
@@ -243,17 +243,40 @@ func writeESPManifest(espPath, content string) error {
 	// being used by another process") — seen live on the E2E ESP the first
 	// time a GUI install crossed this path (run 32550338286). The hold is
 	// measured in milliseconds; a short bounded retry converts a hard
-	// install failure into a wait nobody notices. Every other error keeps
-	// failing fast on the first attempt's result.
+	// install failure into a wait nobody notices.
+	//
+	// Second Windows quirk, seen the first time the RETRY crossed this path
+	// (run 32556250889, bluefin-lts): the rename can REPORT failure after
+	// the move has in fact happened — the ESP dump taken seconds after the
+	// "failed" install showed the manifest complete, containing the very
+	// claim whose rename supposedly died with "The system cannot find the
+	// file specified" (the tmp was gone because it had been moved). So the
+	// return code is not the verdict: after every failed attempt, read the
+	// destination back — content equal to what we just wrote IS success,
+	// whoever's error code says otherwise.
 	var renameErr error
 	for attempt := 0; attempt < 20; attempt++ {
 		if renameErr = os.Rename(tmp, final); renameErr == nil {
 			return nil
 		}
+		if manifestLanded(final, content) {
+			os.Remove(tmp) //nolint:errcheck — may already be gone; that's fine
+			return nil
+		}
 		time.Sleep(250 * time.Millisecond)
 	}
 	os.Remove(tmp)
+	if manifestLanded(final, content) {
+		return nil
+	}
 	return renameErr
+}
+
+// manifestLanded reports whether final already holds exactly the content this
+// write intended — the ground truth a lying rename return code can't fake.
+func manifestLanded(final, content string) bool {
+	b, err := os.ReadFile(final)
+	return err == nil && string(b) == content
 }
 
 // stageESPFile claims rel and then writes it, in that order, so the ESP is

--- a/app/esp_ownership_test.go
+++ b/app/esp_ownership_test.go
@@ -339,3 +339,37 @@ func TestRealFedoraStillBlocksAfterTheNamespaceFix(t *testing.T) {
 		t.Fatal("a real Fedora ESP must still block the install")
 	}
 }
+
+// The rename can report failure after the move has in fact happened (run
+// 32556250889, bluefin-lts: the ESP dump showed the manifest complete —
+// containing the very claim whose rename "failed" with file-not-found).
+// The verdict must therefore be the destination's CONTENT, not the return
+// code. manifestLanded is that verdict.
+func TestManifestLandedIsTheVerdict(t *testing.T) {
+	esp := t.TempDir()
+	final := espManifestPath(esp)
+	if err := os.MkdirAll(filepath.Dir(final), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "# Files on this EFI partition written by wootc.\nefi/fedora/shimx64.efi\n"
+	if manifestLanded(final, content) {
+		t.Fatal("no file yet — nothing can have landed")
+	}
+	writeFile(t, final, content)
+	if !manifestLanded(final, content) {
+		t.Fatal("the exact intended content is on disk; that IS success")
+	}
+	if manifestLanded(final, content+"efi/fedora/grubx64.efi\n") {
+		t.Fatal("different intended content must not be mistaken for success")
+	}
+	// And the writer itself: a normal write must still land and verify.
+	if err := writeESPManifest(esp, content); err != nil {
+		t.Fatalf("writeESPManifest: %v", err)
+	}
+	if !manifestLanded(final, content) {
+		t.Fatal("written manifest should verify against its own content")
+	}
+	if _, err := os.Stat(final + ".tmp"); err == nil {
+		t.Fatal("tmp file left behind after a successful write")
+	}
+}

--- a/justfile
+++ b/justfile
@@ -146,15 +146,44 @@ build-icon:
 # Build the real wootc.exe (frontend + windows/amd64) into wootc-files/, where
 # it's shared into the VM as \\host.lan\Data\wootc.exe (see compose.yml).
 # native_webview2loader is required for the CDP endpoint (see tests/gui/run-cdp.sh).
-build-wootc-exe:
+#
+# brand picks which embedded identity the binary wears (app/branding/<brand>/,
+# docs/branding-and-distribution.md) — the file is still named wootc.exe
+# because that is the E2E/VM share contract; the brand is baked inside:
+#   just build-wootc-exe bazzite && just vm-wootc bazzite
+build-wootc-exe brand="wootc":
     #!/usr/bin/env bash
     set -euo pipefail
+    test -f "app/branding/{{ brand }}/brand.json" || {
+        echo "unknown brand '{{ brand }}' — pick one of:" >&2
+        ls app/branding >&2; exit 1; }
     mkdir -p "{{ FILES }}"
     (cd app/frontend && npm install --silent && npm run build >/dev/null)
     (cd app && GOOS=windows GOARCH=amd64 \
-        go build -tags desktop,production,native_webview2loader -ldflags "-w -s" \
+        go build -tags desktop,production,native_webview2loader \
+        -ldflags "-w -s -X main.brandID={{ brand }}" \
         -o "{{ FILES }}/wootc.exe" .)
+    echo "brand: {{ brand }} ($(jq -r '.productName // "wootc"' "app/branding/{{ brand }}/brand.json"))"
     ls -lh "{{ FILES }}/wootc.exe"
+
+# Build EVERY brand's installer under its release name (Bazzite-Installer.exe,
+# …) — the same loop the release pipeline runs, for local side-by-side testing.
+build-brands out="dist":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    (cd app/frontend && npm install --silent && npm run build >/dev/null)
+    mkdir -p "{{ out }}"
+    for dir in app/branding/*/; do
+        brand=$(basename "$dir")
+        exe=$(jq -r '.exeName // empty' "$dir/brand.json")
+        [ -n "$exe" ] || { echo "$dir/brand.json has no exeName" >&2; exit 1; }
+        (cd app && GOOS=windows GOARCH=amd64 \
+            go build -tags desktop,production,native_webview2loader \
+            -ldflags "-w -s -X main.brandID=$brand" \
+            -o "../{{ out }}/$exe.exe" .)
+        echo "built {{ out }}/$exe.exe (brand: $brand)"
+    done
+    ls -lh "{{ out }}"
 
 # ── Remote E2E ────────────────────────────────────────────────────────────────
 #
@@ -434,7 +463,8 @@ vm-start:
 # Windows disk/answer file is already staged in tests/e2e/storage (run `just
 # e2e` once first if storage/ is empty). Once inside Windows, run
 # \\host.lan\Data\wootc.exe by hand to click through the real GUI.
-vm-wootc: build-wootc-exe build vm-start
+# Pass a brand to click through a branded build: `just vm-wootc bazzite`.
+vm-wootc brand="wootc": (build-wootc-exe brand) build vm-start
     #!/usr/bin/env bash
     set -euo pipefail
     port=$(cat "{{ STORAGE }}/.rdp-port" 2>/dev/null || echo "{{ RDP_PORT }}")

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -2303,6 +2303,20 @@ reset_oem_attempt
 # If a restart does not clear it, say so and leave the app's own refusal as
 # the verdict rather than pretending the machine is ready.
 gui_settle_pending_servicing() {
+    # Stop the update machinery FIRST, or "cleared" does not stay cleared:
+    # el10-gnome-win10pro (run 32556250889) restarted, probed clean
+    # ("Pending servicing cleared by a restart"), launched the GUI — and two
+    # minutes later the app refused with "(servicing)" because Windows
+    # Update had resumed post-reboot and staged fresh work between our probe
+    # and the app's. An E2E VM has no business updating mid-test; disabling
+    # wuauserv/UsoSvc makes the settle below stick. Best-effort per service
+    # (WaaSMedicSvc actively resists), logged, never fatal.
+    qga_powershell 'foreach ($svc in "wuauserv","UsoSvc","WaaSMedicSvc") {
+  try { Stop-Service -Name $svc -Force -ErrorAction SilentlyContinue } catch {}
+  try { Set-Service -Name $svc -StartupType Disabled -ErrorAction SilentlyContinue } catch {}
+}
+Write-Output "update services stopped"' >/dev/null 2>&1 || true
+    info "    Windows Update services stopped+disabled for the test run (servicing state can no longer re-stage mid-run)"
     # shellcheck disable=SC2016 # PowerShell variables must remain literal.
     local probe='$r = @()
 if (Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending") { $r += "servicing" }


### PR DESCRIPTION
Two commits: the branded-build tooling, plus the fixes for both GUI-cell failures in the first main smoke sweep ([run 32556250889](https://github.com/tuna-os/wootc/actions/runs/32556250889)).

## just: brand argument for local builds and manual VM testing
- `just build-wootc-exe bazzite` — bakes any `app/branding/<brand>` identity into the E2E-shared `wootc.exe` (filename is the VM share contract; the brand lives inside via `-X main.brandID`). Unknown brands fail early with the available list.
- `just vm-wootc bazzite` — one command to an interactive Windows desktop running that branded build.
- `just build-brands [dist]` — every brand under its release exe name, the same loop `release.yml` runs.

Verified: parse + dry-runs + a real branded build ("brand: bazzite (Bazzite Installer)").

## fix(app): trust the ESP manifest's content, not the rename's word
**bluefin-lts** failed with `recording that EFI\fedora\shimx64.efi belongs to wootc: rename …tmp → wootc-owned.txt: The system cannot find the file specified` — yet the ESP dump seconds later showed the manifest **complete, containing that very claim**. On this Windows the rename can report failure after the move has in fact happened; the retry from 7d45616 trusted the return code, spun against a vanished tmp, and surfaced ENOENT for a write that had landed. `writeESPManifest` now verifies the outcome **by content** after every failed attempt (`manifestLanded`): the destination holding exactly the intended bytes is success, whatever the error code says. Regression-tested (`TestManifestLandedIsTheVerdict`).

This cell type (bluefin-lts + GUI) is the release gate's exact configuration, so this also unblocks the in-flight `v0.1.0-alpha.1` release if its gate trips on the same race.

## fix(e2e): stop Windows Update re-staging servicing mid-run
**el10-gnome-win10pro**: the harness settled pending servicing correctly ("cleared by a restart"), launched the GUI — and the app refused with "(servicing)" two minutes later, because Windows Update resumed after the settle reboot and staged fresh work between the harness's probe and the app's. The product is right to refuse; the VM had no business updating mid-test. The settle now stops+disables `wuauserv`/`UsoSvc`/`WaaSMedicSvc` first (best-effort, logged), so cleared stays cleared.

## Verification
`go test` green incl. the new regression test, `go vet` + windows build clean, `shellcheck -S error` clean on run-e2e.sh, justfile parse/dry-run verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki