### PR TITLE
release: dispatch winget-publish explicitly (GITHUB_TOKEN releases never trigger it)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ on:
 permissions:
   contents: write
   packages: read                 # granted through to the reusable e2e-hosted (base-image pull)
+  actions: write                 # publish job dispatches winget-publish.yml for full releases
 
 concurrency:
   group: release-${{ github.event_name == 'workflow_run' && 'auto' || github.ref }}
@@ -241,3 +242,16 @@ jobs:
           files: release-assets/*
           body_path: NOTES.md
           draft: false
+
+      - name: Dispatch winget submission (full releases only)
+        # winget-publish.yml listens on release:published, but releases cut
+        # here are created with GITHUB_TOKEN, and GitHub never triggers
+        # workflows from events its own token caused (recursion guard) — the
+        # v0.1.0-alpha.1 publish proved it: 0 winget runs. An explicit
+        # workflow_dispatch through the API DOES fire, so hand it the tag.
+        if: ${{ steps.chan.outputs.prerelease == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run winget-publish.yml --repo "${{ github.repository }}" \
+            -f tag="${{ steps.chan.outputs.tag }}"

--- a/tests/unit/release-pipeline.bats
+++ b/tests/unit/release-pipeline.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# Release pipeline contracts that no other suite owns.
+
+RELEASE=.github/workflows/release.yml
+WINGET=.github/workflows/winget-publish.yml
+
+@test "full releases hand the tag to winget-publish themselves" {
+    # winget-publish.yml listens on release:published, but every release this
+    # pipeline cuts is created with GITHUB_TOKEN — and GitHub never triggers
+    # workflows from events its own token caused (recursion guard). The
+    # v0.1.0-alpha.1 publish proved the failure mode: release live, zero
+    # winget runs. The publish job must therefore dispatch winget-publish
+    # explicitly, and only for full releases (prerelease channels stay out
+    # of winget by design).
+    grep -q 'gh workflow run winget-publish.yml' "$RELEASE"
+    grep -q "prerelease == 'false'" "$RELEASE"
+    grep -q 'actions: write' "$RELEASE"
+    # The receiving side must accept a tag over workflow_dispatch, or the
+    # hand-off dispatches into a workflow that cannot use it.
+    grep -q 'workflow_dispatch' "$WINGET"
+    grep -q "inputs.tag" "$WINGET"
+}


### PR DESCRIPTION
## What broke

`v0.1.0-alpha.1` published successfully — full asset set, `releases/latest` resolving — but **winget-publish.yml has zero runs**. Its `on: release: [published]` trigger is dead code for our own releases: they're created by `softprops/action-gh-release` with the workflow's `GITHUB_TOKEN`, and GitHub's recursion guard never fires workflows from events its own token caused.

## The fix

An explicit `workflow_dispatch` through the API **does** fire. The publish job now hands the tag to `winget-publish.yml` itself (`gh workflow run … -f tag=<tag>`), guarded on `prerelease == 'false'` — full releases only, the auto/manual pre-release channels stay out of winget by design. `permissions: actions: write` added for the dispatch.

`winget-publish.yml` already accepts a tag via `workflow_dispatch`, so the receiving side needed no changes; it still renders manifests from the actual published bytes and exits green with a notice when `WINGET_TOKEN` is unset.

## Test

New `tests/unit/release-pipeline.bats` pins the whole chain: the dispatch line, the full-release guard, the `actions: write` grant, and the receiving workflow's `workflow_dispatch` + `inputs.tag` contract.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_