### PR TITLE
docs: refactor the README — impressive and clean, story moved to docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 ## Start here
 
-- **`README.md#buildtest-matrix`** — the one current status/roadmap source.
+- **`docs/status.md#buildtest-matrix`** — the one current status source
+  (the roadmap itself is `ROADMAP.md`).
   Green/red per image family × phase and per axis, from the E2E rig and the
   hosted matrix; a cell is only green once the hosted E2E passed it
   end-to-end (see `docs/RELEASING.md`). Open work is tracked on the org
@@ -174,7 +175,7 @@ quirks are documented in the `wootc-e2e` skill and the e2e-runner agent:
 **Green** since 2026-07-23 (rung 2 of `docs/milestones.md`): the full cycle
 passes repeatably via `run-e2e.sh` on the E2E runner, including the BitLocker
 cell (`el10-gnome-win11pro-bitlocker`, full cycle green 2026-07-28), and
-the same chain is green GUI-driven on `bluefin:lts` (README matrix,
+the same chain is green GUI-driven on `bluefin:lts` (docs/status.md matrix,
 `pages/e2e/latest`). The acceptance criteria below are the definition of
 that target:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@
    QGA control plane, deployer initramfs, E2E test runner) and the docs to
    read before touching each one, plus `docs/agent-lessons.md`, which
    documents traps that have each cost a 60–90 minute VM run.
-3. Check `README.md`'s build/test matrix for current known-good vs. known-red
-   status before assuming a symptom is your change's fault.
+3. Check the build/test matrix in `docs/status.md` for current known-good vs.
+   known-red status before assuming a symptom is your change's fault.
 
 ## Building and testing
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# wootc — Windows-hosted bootc Linux
+<h1 align="center">wootc</h1>
+
+<p align="center"><strong>Try Linux from inside Windows — no repartitioning, nothing deleted, fully reversible.</strong></p>
+
+<p align="center">
+  <a href="https://github.com/tuna-os/wootc/releases/latest"><img src="https://img.shields.io/github/v/release/tuna-os/wootc?label=release&color=2eb9df" alt="Latest release"></a>
+  <a href="https://github.com/tuna-os/wootc/actions/workflows/e2e-gui.yml"><img src="https://github.com/tuna-os/wootc/actions/workflows/e2e-gui.yml/badge.svg" alt="Nightly E2E"></a>
+  <a href="https://github.com/tuna-os/wootc/actions/workflows/ci.yml"><img src="https://github.com/tuna-os/wootc/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="#license"><img src="https://img.shields.io/badge/license-GPL--2.0%20%2B%20MIT-blue" alt="License"></a>
+</p>
 
 <p align="center">
   <a href="https://tuna-os.github.io/wootc/e2e/latest/">
@@ -7,69 +16,47 @@
          width="760">
   </a>
   <br>
-  <em>▶ Latest <strong>green</strong> end-to-end run (sped-up): Windows 11 → wootc deployer → native Linux from <code>root.disk</code> → Windows 11. <a href="https://tuna-os.github.io/wootc/e2e/latest/">Click to play the full timelapse.</a> Only passing runs are ever published here.</em>
-</p>
-
-<p align="center">
-  <strong>Install a real, image-based Linux desktop from inside Windows — no repartitioning, no data loss, fully reversible.</strong>
+  <em>▶ The latest <strong>green</strong> end-to-end run, sped up: Windows 11 → wootc → native Linux booting from a file → back to Windows. <a href="https://tuna-os.github.io/wootc/e2e/latest/">Play the full timelapse.</a> Only passing runs are ever published here.</em>
 </p>
 
 ---
 
-wootc is a Windows-hosted installer for [bootc](https://github.com/containers/bootc)
-Linux images. It writes a complete Linux system into `root.disk`, a single
-sparse file on your existing Windows NTFS volume, and adds a one-shot Windows
-Boot Manager entry that boots into it. There is **no repartitioning of the
-Windows disk**, and uninstalling is deleting a folder and a boot entry.
+wootc installs a real, image-based [bootc](https://github.com/containers/bootc)
+Linux desktop into `root.disk` — a single file beside your Windows files — and
+adds a boot menu entry for it. **No repartitioning. No backup ceremony. No
+point of no return.** Windows stays your default boot until you decide
+otherwise, and uninstalling is deleting a folder and a boot entry.
 
-It's a modern, Secure-Boot-friendly take on the classic [Wubi](https://en.wikipedia.org/wiki/Wubi_(software))
-idea, built for container-native (OCI/ostree) Linux images and for people who
-have never touched a partition editor.
+Setup asks for as much as a Mac's first-run assistant would: **a password.**
+Your username and computer name are mirrored from your PC, the disk is sized
+from your free space, encryption is TPM-backed by default — and your files,
+Wi-Fi networks, wallpaper, and taskbar carry over, so the first login already
+feels like your machine.
 
-## Get wootc
+## Get it
 
-**Download** (simplest): grab `wootc.exe` from the
-[latest release](https://github.com/tuna-os/wootc/releases/latest) and run
-it as Administrator. That is the whole install — one file, no setup wizard;
-the app downloads and verifies its boot pieces itself (every artifact is
-checked against the release's `SHA256SUMS` before it is trusted).
-
-**winget** (once the first submission clears Microsoft's review):
+**[⬇ Download the latest release](https://github.com/tuna-os/wootc/releases/latest)**
+— one exe, no setup wizard. Run it as Administrator; it fetches and verifies
+its own boot pieces against the release's `SHA256SUMS`.
 
 ```
 winget install TunaOS.wootc
 ```
+*(winget availability lands with the first accepted submission.)*
 
-**Branded installers**: every release also ships the same engine wearing
-each distribution's own identity — `Bazzite-Installer.exe`,
-`Bluefin-Installer.exe`, `Aurora-Installer.exe`, `TunaOS-Installer.exe` —
-which pre-select that distribution's images and pre-download the OS while
-still on Windows (no network needed after the reboot). Pick the one for the
-Linux you want; they are otherwise identical.
+Every release also ships **branded installers** — `Bazzite-Installer.exe`,
+`Bluefin-Installer.exe`, `Aurora-Installer.exe`, `TunaOS-Installer.exe` — the
+same engine wearing each distribution's identity, pre-selected to its images
+and pre-downloading the OS while still on Windows (no network needed after
+the reboot).
 
-Because the binaries are not yet code-signed, Windows shows a SmartScreen
-warning and an "unknown publisher" prompt on the way —
-**[Getting started](docs/getting-started.md)** walks through both screens
-and explains why they appear. The
-[user guide](docs/user-guide.md) covers everything after that, including
-[how to put everything back](docs/user-guide.md#9-uninstall--put-everything-back).
-Testing on your own machine? Read
-**[Manual testing](docs/manual-testing.md)** first — a five-minute
-pre-flight that makes the try safe and the feedback useful.
-
-## Why
-
-> **North Star** — make it as easy as possible for *non-technical Windows
-> users* to migrate to Linux **without losing any of their data**. Every
-> decision is weighed against: *would a nervous Windows user get through this
-> without fear or data loss?* Reversibility and data safety beat feature count;
-> friendly language beats technical precision; **nothing permanent changes on
-> the machine until Linux is proven working.**
-
-Switching OS is scary because it usually means repartitioning, backups, and a
-point of no return. wootc removes all three: Linux lives in a file next to
-Windows, both boot from the same disk, and you decide if and when to make it
-permanent.
+> The binaries are not yet code-signed, so Windows shows SmartScreen and an
+> "unknown publisher" prompt on the way in.
+> **[Getting started](docs/getting-started.md)** walks through both screens;
+> the **[user guide](docs/user-guide.md)** covers everything after, including
+> [putting everything back](docs/user-guide.md#9-uninstall--put-everything-back).
+> Trying it on your own hardware? Read
+> **[manual testing](docs/manual-testing.md)** first.
 
 ## How it works
 
@@ -78,232 +65,90 @@ Windows 11  →  wootc.exe (arms the system)  →  reboot
             →  signed shim → GRUB → deployer initramfs
             →  fisherman: bootc install into root.disk
             →  reboot → native Linux, loop-mounted from root.disk
-            →  (optional) reclaim the disk and remove Windows
+            →  (optional, later) graduate to a real partition
 ```
 
-1. **Arm (in Windows).** The GUI creates `C:\wootc\disks\root.disk`, stages a
-   Microsoft/Fedora-signed `shim → GRUB → deployer` chain on the ESP, writes a
-   credential vault, optionally slurps your Windows look, and sets a **one-shot**
+1. **Arm.** The app creates `C:\wootc\disks\root.disk`, stages a
+   Microsoft/Fedora-signed boot chain on the ESP, and sets a **one-shot**
    boot entry. Nothing else on the machine is touched.
-2. **Deploy (one reboot).** Under Secure Boot, the signed chain launches the
-   deployer initramfs, which mounts the NTFS volume, attaches `root.disk`, and
-   uses [fisherman](https://github.com/projectbluefin/fisherman) to run
-   `bootc install` — partitioning and populating the disk from the chosen OCI
-   image, with optional LUKS/TPM2 encryption.
-3. **Boot Linux.** A dracut hook (`99wootc-boot`) attaches `root.disk` on every
-   boot and pivots into the native system. The OS itself is unmodified — the
-   same image boots whether it lives in a file on NTFS or on a real partition.
-4. **Commit (optional, later).** When you're ready to go Linux-only, graduate
-   the system onto a native partition and reclaim the Windows space.
+2. **Deploy.** One reboot: under Secure Boot, the signed chain launches a
+   small installer environment that writes the chosen OS image into
+   `root.disk` — with optional LUKS/TPM2 encryption.
+3. **Live in both.** A boot hook attaches `root.disk` on every boot and
+   pivots into an unmodified, native Linux system. Windows stays on the boot
+   menu, and your Windows drive is right there in the file manager.
+4. **Commit — or don't.** Graduate Linux onto a real partition when you're
+   sure, keep dual-booting forever, or uninstall and leave no trace.
 
-The Windows installer is a [Wails](https://wails.io) app (Go + web UI); the
-deployer and migration tooling are POSIX shell and run inside the initramfs and
-the target system.
+## What you get
 
-## Features
+- **A password is the whole form.** Solid defaults for everything else,
+  stated on screen and adjustable under Advanced.
+- **Your stuff comes along** — files, Wi-Fi networks, wallpaper, accent
+  color, keyboard layout, taskbar pins, browser profiles (Firefox, Chrome,
+  Edge), Steam libraries, MS Office → LibreOffice settings, WSL dotfiles and
+  packages. Secrets never move silently: passwords, keys, and tokens stay
+  put, and you sign in again where it matters.
+- **BitLocker-safe.** C: is never decrypted — Linux gets its own unencrypted
+  space while your Windows drive stays protected.
+- **A real image catalog** — GNOME, KDE Plasma, Niri, and XFCE desktops on
+  Enterprise Linux, Fedora, Arch, and Debian bases, or any supported custom
+  OCI image.
+- **Try before you reboot** — boot the result in a VM window from inside
+  Windows first.
+- **An honest way back.** Uninstall lives in Windows' own Apps list, removes
+  the boot entry and installer, restores changed settings, and only ever
+  reclaims a partition wootc itself created.
 
-| Area | What it does |
-|---|---|
-| **Guided installer** | Fixed-size GUI: pick an image, set user/hostname/disk, choose encryption. Live preflight (BitLocker, Fast Startup, UEFI, Secure Boot, free space). |
-| **Image catalog** | GNOME / KDE / Niri / XFCE variants across Enterprise Linux, Fedora, Arch, and Debian bases. Override with a custom OCI ref or `C:\wootc\images.json`. |
-| **Data safety first** | `root.disk` sits beside Windows; a one-shot boot entry means a failed deploy falls back to Windows. Reversible, partition-aware **uninstall**. |
-| **BitLocker-safe (§3.5)** | Never forces decryption. Offers an unencrypted partition for Linux (create new or reuse) while C: stays encrypted. |
-| **Disk encryption (§2.6)** | LUKS for the Linux root: TPM2 auto-unlock (default) or passphrase. |
-| **User Data Bridge (§4)** | Brings your files, browser profiles (Firefox/Chrome/Edge), Steam libraries, and MS Office → LibreOffice settings across — honestly, with a consent tier that never copies secrets silently. |
-| **Windows-Style Mode (§4.4)** | *Opt-in.* Wallpaper, accent color, keyboard layout, taskbar pins, and desktop shortcuts brought over on first login. Off by default — the image maker's look wins. |
-| **WSL migration (§4.6)** | Copies a WSL user's dotfiles (public SSH keys only) and turns their installed packages into a Homebrew `Brewfile`. |
-| **Bring your Windows over** | A Linux-side GUI to import data from a Windows install on **another disk** — second drive, external/USB, or a backup — unlocking **BitLocker** read-only (`cryptsetup bitlk`). |
-| **Try in VM (§6)** | Boot `root.disk` in a QEMU window without rebooting, or build a fresh preview from an image and promote it to the real install if you like it. |
-| **Themeable / lockable** | Partners can re-skin the installer and lock it to a single image family for a branded on-ramp. |
+## Trust, engineered
 
-See [docs/SPEC.md](docs/SPEC.md) for the full specification and section numbers.
+Every release is **gated on a full end-to-end run**: a real Windows 11 VM
+(Secure Boot + TPM 2.0) installs that exact build through the real GUI, boots
+natively into Linux from `root.disk`, and returns to Windows cleanly — no
+green run, no release. Nightly green runs cut automatic pre-releases from the
+exact commit they proved, and every failed check in the harness is
+release-blocking by construction.
 
-## Project status
-
-**This is active, boot-path-focused development — not yet a released installer.**
-
-Verified end-to-end on the KVM E2E rig (Windows 11 + TPM 2.0 + Secure Boot):
-
-- ✅ **Arm (rung 1):** the real `wootc.exe` arms a virgin Windows VM over QGA —
-  root disk, signed chain, one-shot BCD, `state.json = armed` (24/24).
-- ✅ **Deploy:** the Secure Boot chain launches the deployer and fisherman lays
-  down a full bootc image into `root.disk` — every post-deploy check passes
-  (dracut hook, services, loop-root BLS args, ESP kernel-sync, `host-esp.conf`).
-- ✅ **Native Phase-2 boot (rung 2):** the signed Windows BCD → shim → GRUB
-  chain boots the installed Bluefin system from the NTFS-hosted `root.disk`.
-  The initramfs mounts NTFS with the kernel driver, attaches the raw disk with
-  `losetup`, resolves the root UUID, runs OSTree prepare-root, switches to the
-  real deployment, reaches the graphical system, and exposes Linux QGA.
-- ✅ **GUI + migration:** installer GUI (Playwright-tested), User Data Bridge
-  and WSL/Office/Steam/browser bridges (unit-tested), external-disk import
-  engine, Try-in-VM orchestration, Phase-3 planner.
-- ✅ **Graduate to native disk (Phase 3 / rung 3):** the VM boots Phase 2,
-  independently verifies a blank `/dev/sdb`, runs the native `bootc install`,
-  reboots into the graduated system, and confirms the file seeded in Windows
-  survived onto the native disk — Windows and `root.disk` untouched (29/29).
-- ✅ **GUI-driven full run:** the entire Phase-1 → 2 → 3 chain armed by the
-  **real `wootc.exe` GUI** (drive mode — the app drives its own live form),
-  green end-to-end on `bluefin:lts`. The timelapse at the top of this README
-  is that run.
-
-Follow the verification ladder in [docs/milestones.md](docs/milestones.md).
-
-### Build/test matrix
-
-Red/green status per combination, from the KVM E2E rig (laptop runners) and the
-hosted-runner matrix (`.github/workflows/e2e-matrix.yml`). Legend:
-✅ proven green · 🟡 in progress / partially proven · 🔴 known-red (tracked
-issue) · ⚪ not yet run.
-
-**Last full matrix sweep: 2026-07-25 — 12 of 22 cases green.** A case is only
-marked ✅ once the whole chain passes (Windows seed → deploy → Phase-2 boot →
-seeded file readable from Linux).
-
-> ⚠️ **The ✅s below predating 2026-07-27 are currently UNVERIFIED** (per-row
-> exceptions are called out — e.g. the `dakota` composefs cell was re-proven on
-> the failure-ledger harness on 2026-08-02). Until commit
-> `3d7f9e2`, `fail()` only printed — a failed check that did not itself
-> abort could not stop the run reaching "ALL TESTS PASSED". A real BitLocker run
-> was recorded PASS with `[FAIL] User data NOT visible in Phase 2 $HOME` in its
-> own log, which is the North Star assertion itself. The harness now records
-> every failure to a ledger and gates the banner on it, so this class of false
-> green cannot recur — but the counts above were produced by the old harness and
-> are being re-run. Treat them as claims awaiting evidence, not as status.
-
-> ℹ️ **Resolved (2026-07-27):** the hosted-runner TPM blocker
-> ([#59](https://github.com/tuna-os/wootc/issues/59)) was ours, not GitHub's —
-> our sshd wrapper took PID 1 from `tini`, so `swtpm`'s `-d` daemonization never
-> wrote its pid file and dockur silently disabled TPM. Fixed in `4a087eb`;
-> GitHub-hosted runners are back in scope.
-
-**Image family × phase** (Windows 11 Pro, Secure Boot + TPM 2.0):
-
-| Image family | Backend / rootfs | Arm (P1) | Deploy | Phase-2 boot | Phase-3 graduate | GUI-driven full run |
-|---|---|:--:|:--:|:--:|:--:|:--:|
-| `bluefin:lts` | ostree · ext4-sealed | ✅ | ✅ | ✅ | ✅ (29/29) | ✅ |
-| `yellowfin:gnome` (EL10) | ostree · ext4-sealed | ✅ | ✅ | ✅ | ✅ | ⚪ |
-| `yellowfin:kde` / `:xfce` (EL10) | ostree · ext4-sealed | ✅ | ✅ | ✅ | ⚪ | ⚪ |
-| `bonito:gnome` / `:kde` / `:niri` (Fedora) | ostree · **xfs** (unsealed) | ✅ | ✅ | ✅ | ⚪ | ⚪ |
-| `dakota` | composefs-native | ✅ | ✅ | ✅ | ⚪ | ⚪ |
-| `marlin` (Arch) / `flounder` (Debian) | ostree · xfs (unsealed) | ✅ | 🔴 | ⚪ | ⚪ | ⚪ |
-
-`dakota` (composefs-native) went green on the failure-ledger harness —
-composefs full chain, run `30710282014` (2026-08-02);
-[#28](https://github.com/tuna-os/wootc/issues/28) is closed. Phase-3
-graduation for composefs is a follow-on rung. `marlin`/`flounder` fail in
-`bootc install` with *"bootupd is required for ostree-based installs"*: they are
-ostree images that ship no `bootupd`.
-
-**Axes** (against the EL10 / `bluefin:lts` baseline):
-
-| Axis | Status | Notes |
-|---|:--:|---|
-| Windows 11 Pro | ✅ | primary proven path |
-| Windows 11 Home / Enterprise / LTSC | ✅ | all three green on EL10 |
-| Windows 10 Pro | ✅ | green in 37 min via the restored Windows base image |
-| Windows 10 Home / Enterprise / LTSC | 🔴 | Setup stops on its edition picker — the answer file's product key matches no image in the ISO for those editions — [#58](https://github.com/tuna-os/wootc/issues/58) |
-| Root filesystem: `xfs` (unsealed) | ✅ | mounted with explicit `-t` (a typeless mount tried ext4 on xfs) |
-| Root filesystem: `ext4` (sealed, fs-verity) | ✅ | proven sealed default |
-| Root filesystem: `btrfs` (sealed) | 🟡 | works on Fedora-kernel images (bonito) via `wootc.filesystem=btrfs`; [#35](https://github.com/tuna-os/wootc/issues/35) fixed — blocked on EL10 kernels whose out-of-tree btrfs kmod is rejected under Secure Boot |
-| Encryption: none | ✅ | |
-| Encryption: `tpm2-luks` | 🟡 | [#33](https://github.com/tuna-os/wootc/issues/33) fixed (`bffd284`, 2026-08-10) — Phase-2 dracut regen works; green cell re-verification pending under the failure-ledger harness |
-| BitLocker FDE (unencrypted-volume path) | ✅ | proven green — [#34](https://github.com/tuna-os/wootc/issues/34). Setup carves unencrypted volume E: for `root.disk` while C: stays encrypted; drive letter resolver dynamically discovers tree location. |
-
-The full three-phase chain (Windows seed → deploy → Phase-2 bridge →
-Phase-3 native disk → seeded file on the native disk) is **green end-to-end
-on `bluefin:lts`** — both via the script path (29/29) and driven entirely
-through the real `wootc.exe` GUI (drive mode). The timelapse above is that
-GUI-driven green run.
-
-## Safety model
-
-- **Nothing permanent until proven.** The first boot into the deployer is a
-  one-shot entry; the default boot order stays Windows until Linux is verified.
-- **The source is never mutated.** External-disk and BitLocker imports mount
-  **read-only**; BitLocker volumes are never decrypted in place.
-- **Secrets stay put.** Passwords, private keys, tokens, and credential stores
-  are never copied silently — you sign in again where it matters.
-- **Reversible uninstall.** Removes the boot entry, bootloader files and
-  installer, keeps `root.disk` unless asked to delete it, can reclaim a
-  dedicated Linux partition, and restores the power settings setup changed.
-  Listed in Windows' own Apps list as "TunaOS (wootc)".
-
-## Architecture
-
-wootc keeps a deliberate boundary between **generic Windows→Linux migration
-machinery** and the **bootc-specific provisioner**, so the design can be adapted
-to other distributions and deployment methods. The seam is documented in
-[docs/architecture-boundary.md](docs/architecture-boundary.md); `deploy.sh`
-marks its provisioner region explicitly.
-
-```
-app/                     Wails Windows installer (Go backend + web UI)
-payload/deployer/        one-shot deployer initramfs + deploy.sh
-payload/migration/       User Data Bridge, WSL, external-disk import, Phase-3
-payload/builder/         Try-in-VM Alpine builder (headless OCI→disk)
-payload/wubildr/         reproducible custom GRUB EFI build
-platform/dracut/99wootc-boot/   Phase-2 loop-root attach hook
-platform/grub/           external GRUB configuration
-fisherman/               bootc install / partitioning (submodule, tuna-os fork)
-tests/                   e2e (KVM Windows 11), gui (Playwright), migration
-docs/                    SPEC, boundary, milestones, walkthroughs
-```
-
-## Build and test
-
-```bash
-just build                     # deployer initramfs + custom GRUB
-
-# GUI unit tests (Playwright over the real frontend bundle, mocked backend)
-cd tests/gui && npx playwright test
-
-# Migration bridge tests (containerized, no Windows needed)
-bash tests/migration/test-bridge.sh
-```
-
-### End-to-end (KVM)
-
-The E2E harness drives a Windows 11 VM (via [dockur/windows](https://github.com/dockur/windows))
-over the QEMU Guest Agent — no guest networking required. It needs a host with
-KVM, UEFI Secure Boot, and TPM 2.0.
-
-```bash
-just remote-sync               # push + reset a runner to origin/main
-just remote-e2e                # fresh install + deploy (~30 min)
-just remote-e2e-quick          # reuse the installed disk (~5 min)
-
-just remote-logs               # tail the run
-just remote-serial             # watch the deployer serial console
-just remote-status             # grep PASS/FAIL markers
-```
-
-Every E2E run records a sped-up timelapse to `tests/e2e/storage/artifacts/<run>/video/`.
-To refresh the [walkthrough](https://tuna-os.github.io/wootc/e2e/latest/) at the top
-of this README, publish a passing run's clip:
-
-```bash
-tests/e2e/publish-visual.sh --from-host <host>   # or a local artifact dir
-git add pages && git commit -m 'docs: refresh E2E walkthrough' && git push origin main
-```
-
-A GitHub-hosted workflow (`.github/workflows/pages.yml`) then deploys it to Pages —
-no self-hosted runner required. The README hero is a committed relative path, so it
-renders inline on GitHub even before Pages redeploys.
+The current proven matrix — image families, Windows editions, filesystems,
+encryption modes — lives in **[docs/status.md](docs/status.md)**. The project
+is in **alpha** on the road to a checkable 1.0: see the
+**[ROADMAP](ROADMAP.md)** for the version ladder and its evidence gates, and
+**[docs/philosophy.md](docs/philosophy.md)** for the thinking behind it all.
 
 ## Documentation
 
-- [docs/SPEC.md](docs/SPEC.md) — the full specification
-- [docs/architecture-boundary.md](docs/architecture-boundary.md) — the bootc / generic seam
-- [docs/milestones.md](docs/milestones.md) — the verification ladder
-- [docs/gui-walkthrough.md](docs/gui-walkthrough.md) — installer screenshots
-- [docs/non-bootc-adoption.md](docs/non-bootc-adoption.md) — "what if I don't want bootc?"
-- [CONTEXT.md](CONTEXT.md) — project vocabulary
+| | |
+|---|---|
+| [Getting started](docs/getting-started.md) | download → first boot, screen by screen |
+| [User guide](docs/user-guide.md) | living in the migrated system, and the way back |
+| [Philosophy](docs/philosophy.md) | the North Star, the Wubi heritage, why a file |
+| [Status](docs/status.md) | the proven matrix and its evidence |
+| [SPEC](docs/SPEC.md) | the full specification |
+| [Architecture boundary](docs/architecture-boundary.md) | the generic-migration / bootc seam |
+| [Branding & distribution](docs/branding-and-distribution.md) | one engine, five installers |
+| [Manual testing](docs/manual-testing.md) | pre-flight for real-hardware runs |
+
+## Contributing
+
+The stack: a [Wails](https://wails.io) (Go + web) Windows app, a dracut-based
+deployer initramfs, POSIX-shell migration tooling, and a KVM E2E harness that
+drives real Windows VMs through the real GUI.
+
+```bash
+just test                              # fast tier: bats + go, no containers
+just build                             # deployer initramfs + custom GRUB
+cd tests/gui && npx playwright test    # GUI suite over the built frontend
+```
+
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** — the best first contributions
+turn a claim green: a red or unproven matrix cell, or an open milestone task
+on the [tracking boards](https://github.com/tuna-os/wootc/issues/210).
 
 ## License
 
-The Windows installer components derived from [WubiUEFI](https://github.com/hakuna-m/wubiuefi)
-are **GPL-2.0** ([LICENSE-GPL-2.0](LICENSE-GPL-2.0)); the deployer initramfs
-and GRUB configuration are **MIT** ([LICENSE-MIT](LICENSE-MIT)).
-fisherman, bootc, bootupd, podman, and skopeo are separate binaries under their
-own (Apache-2.0) licenses, invoked over a process boundary. See
-[docs/SPEC.md](docs/SPEC.md#7-license) for details.
+Windows installer components derived from
+[WubiUEFI](https://github.com/hakuna-m/wubiuefi) are **GPL-2.0**
+([LICENSE-GPL-2.0](LICENSE-GPL-2.0)); the deployer initramfs and GRUB
+configuration are **MIT** ([LICENSE-MIT](LICENSE-MIT)). fisherman, bootc,
+bootupd, podman, and skopeo are separate binaries under their own
+(Apache-2.0) licenses, invoked over a process boundary.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,7 +8,7 @@ matrix greens; the channel graduates when whole tiers are green.
 
 ## The single source of truth
 
-The [build/test matrix](https://github.com/tuna-os/wootc/blob/main/README.md#buildtest-matrix) is authoritative. A
+The [build/test matrix](status.md#buildtest-matrix) is authoritative. A
 combination is *green* only when the hosted E2E (`e2e-matrix.yml` /
 `e2e-gui.yml`) has passed it end-to-end — Windows seed → deploy → Phase-2
 bridge → Phase-3 native disk → seeded file on the native disk.

--- a/docs/finish-plan.md
+++ b/docs/finish-plan.md
@@ -10,8 +10,8 @@ deprioritized ("pretty rare").*
 > and #28/#35/#33 are closed with their fixes in `main` (`7d99c45`,
 > `8d964f4`, `2166d09`, `6b7c412`, `bffd284`). Remaining: one non-dakota
 > composefs family (marlin/flounder), `tpm2-luks` cell re-verification, and
-> the full matrix re-sweep — tracked in the README build/test matrix and
-> open issues. Read the README matrix for current status.
+> the full matrix re-sweep — tracked in the docs/status.md build/test matrix and
+> open issues. Read the docs/status.md matrix for current status.
 
 The project's green core is done: `bluefin:lts` (ostree/grub2/ext4-sealed)
 passes the full Phase 1 → 2 → 3 chain, GUI-driven, 29/29. What separates

--- a/docs/gui-phase1-architecture.md
+++ b/docs/gui-phase1-architecture.md
@@ -2,7 +2,7 @@
 
 Status: proposal, 2026-07-17 — **historical (2026-08-11):** the GUI now
 compiles, drives the E2E install in drive mode (`WOOTC_E2E_DRIVE=1`), and
-green GUI-driven runs are published in the README build/test matrix.
+green GUI-driven runs are published in the docs/status.md build/test matrix.
 Companion to `docs/SPEC.md` §3 and the E2E
 learnings accumulated on runner-a. Scope: everything that runs on Windows —
 the Wails GUI (`app/`), the install pipeline it drives, and the contract

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,90 @@
+# Philosophy — why wootc exists and how it decides
+
+## The North Star
+
+> Make it as easy as possible for **non-technical Windows users** to migrate
+> to Linux **without losing any of their data**. Every decision is weighed
+> against one question: *would a nervous Windows user get through this
+> without fear or data loss?*
+
+Three consequences follow, and they outrank everything else:
+
+- **Reversibility and data safety beat feature count.** A feature that adds
+  risk to the user's existing machine does not ship, however impressive.
+- **Friendly language beats technical precision.** The UI says "your Windows
+  files come along", not "NTFS is loop-mounted read-write via the kernel
+  driver". The precise version lives in the docs, where it belongs.
+- **Nothing permanent changes until Linux is proven working.** The first
+  boot into the installer is a one-shot entry; the default boot order stays
+  Windows until the installed system has actually come up.
+
+## Ask nothing macOS wouldn't ask
+
+The setup bar is a Mac's first-run assistant: the default install form asks
+for **a password, nothing else**. Everything else is a solid default the
+user can trust — identity mirrored from the PC they're sitting at, disk
+sized from their free space, TPM-backed encryption, their files, Wi-Fi and
+look brought along — each stated plainly on the form and adjustable under
+Advanced. A control earns a place on the main form only when it is a
+question wootc genuinely cannot answer for the user (where Linux should
+live on a BitLocker machine, an identity that could not be derived).
+
+The same principle governs migration: **everything safe to migrate,
+migrates by default** — files, Wi-Fi networks, wallpaper, keyboard layout,
+taskbar pins, browser profiles, Steam libraries. wootc asks only for what
+it needs to do that job. What never moves silently is spelled out in the
+consent tiers of [SPEC §4.6](SPEC.md#46-device-and-connectivity-migration):
+passwords, private keys, tokens, and credential stores stay put — you sign
+in again where it matters.
+
+## Why a file, not a partition
+
+Switching OS is scary because it traditionally means repartitioning,
+backups, and a point of no return. wootc removes all three: Linux lives in
+`root.disk`, a single sparse file beside your Windows files, both systems
+boot from the same disk, and you decide if and when to make it permanent.
+Uninstalling is deleting a folder and a boot entry.
+
+This is the classic [Wubi](https://en.wikipedia.org/wiki/Wubi_(software))
+idea, rebuilt for the modern stack: UEFI + Secure Boot (a Microsoft/Fedora
+signed shim → GRUB chain instead of unsigned bootloaders), and
+container-native [bootc](https://github.com/containers/bootc) images
+(the OS is an OCI image; the same image boots from a file on NTFS or a
+native partition, so "graduating" to a real disk later is a deployment,
+not a reinstall).
+
+Within the tuna-os / Universal Blue family, wootc is the **conversion
+front door**: the Windows-hosted complement to the bootc-installer family,
+driving [fisherman](https://github.com/projectbluefin/fisherman) under the
+hood. One engine ships as five installers — generic wootc plus branded
+TunaOS, Bluefin, Aurora, and Bazzite builds
+([branding-and-distribution.md](branding-and-distribution.md)).
+
+## Evidence, not claims
+
+Nobody should trust "it works on my machine" from a tool that writes to a
+stranger's only computer. So the project holds itself to evidence:
+
+- **Releases are E2E-gated.** A release is published only after a real
+  Windows VM installs that exact build through the real GUI, boots natively
+  into Linux from `root.disk`, and returns to Windows cleanly. No green
+  run, no release.
+- **Failures are load-bearing.** The E2E harness records every failed check
+  to a ledger and gates the pass banner on it — a lesson learned the hard
+  way when an early harness recorded a PASS with a North-Star failure in
+  its own log ([status.md](status.md) tells that story).
+- **The support policy is honest.** The GUI's claims (`GetSupportPolicy`)
+  flip only for scenarios the matrix has proven; anything else is refused
+  with plain words rather than allowed to fail mysteriously.
+
+What "1.0" means under this philosophy — the North Star made checkable —
+is defined in the [ROADMAP](../ROADMAP.md).
+
+## The uninstall promise
+
+Leaving must be as safe as arriving: uninstall removes the boot entry,
+bootloader files and the installer, keeps `root.disk` unless you ask it
+deleted, can reclaim a dedicated Linux partition (only one wootc created —
+verified by volume label), and restores the power settings setup changed.
+It is listed in Windows' own Apps list, because that is where a Windows
+user would look.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,136 @@
+# Verification status — what is proven, on what evidence
+
+This page carries the detailed red/green state that used to live in the
+README: what has been proven end-to-end, on which rigs, with which caveats.
+The [ROADMAP](../ROADMAP.md) says where the project is going; this page says
+what the evidence supports today. The verification ladder itself is defined
+in [milestones.md](milestones.md).
+
+A case is only marked ✅ once the whole chain passes: Windows seed → deploy →
+Phase-2 boot → seeded file readable from Linux.
+
+## Proven end-to-end (KVM E2E rig: Windows 11 + TPM 2.0 + Secure Boot)
+
+- ✅ **Arm (rung 1):** the real `wootc.exe` arms a virgin Windows VM over QGA —
+  root disk, signed chain, one-shot BCD, `state.json = armed` (24/24).
+- ✅ **Deploy:** the Secure Boot chain launches the deployer and fisherman lays
+  down a full bootc image into `root.disk` — every post-deploy check passes
+  (dracut hook, services, loop-root BLS args, ESP kernel-sync, `host-esp.conf`).
+- ✅ **Native Phase-2 boot (rung 2):** the signed Windows BCD → shim → GRUB
+  chain boots the installed Bluefin system from the NTFS-hosted `root.disk`.
+  The initramfs mounts NTFS with the kernel driver, attaches the raw disk with
+  `losetup`, resolves the root UUID, runs OSTree prepare-root, switches to the
+  real deployment, reaches the graphical system, and exposes Linux QGA.
+- ✅ **GUI + migration:** installer GUI (Playwright-tested), User Data Bridge
+  and WSL/Office/Steam/browser bridges (unit-tested), external-disk import
+  engine, Try-in-VM orchestration, Phase-3 planner.
+- ✅ **Graduate to native disk (Phase 3 / rung 3):** the VM boots Phase 2,
+  independently verifies a blank `/dev/sdb`, runs the native `bootc install`,
+  reboots into the graduated system, and confirms the file seeded in Windows
+  survived onto the native disk — Windows and `root.disk` untouched (29/29).
+- ✅ **GUI-driven full run:** the entire Phase-1 → 2 → 3 chain armed by the
+  **real `wootc.exe` GUI** (drive mode — the app drives its own live form),
+  green end-to-end on `bluefin:lts`. The timelapse on the
+  [walkthrough page](https://tuna-os.github.io/wootc/e2e/latest/) is that run.
+- ✅ **E2E-gated releases:** `v0.1.0-alpha.1` was published only after a fresh
+  full GUI-driven run passed on the exact tagged commit; nightly green runs cut
+  automatic pre-releases from the SHA they proved.
+
+## Build/test matrix
+
+Red/green status per combination, from the KVM E2E rig (laptop runners) and
+the hosted-runner matrix (`.github/workflows/e2e-matrix.yml`). Legend:
+✅ proven green · 🟡 in progress / partially proven · 🔴 known-red (tracked
+issue) · ⚪ not yet run.
+
+**Last full matrix sweep: 2026-07-25 — 12 of 22 cases green**, with targeted
+re-runs since (dates on the affected rows).
+
+> ⚠️ **The ✅s below predating 2026-07-27 are currently UNVERIFIED** (per-row
+> exceptions are called out — e.g. the `dakota` composefs cell was re-proven on
+> the failure-ledger harness on 2026-08-02). Until commit
+> `3d7f9e2`, `fail()` only printed — a failed check that did not itself
+> abort could not stop the run reaching "ALL TESTS PASSED". A real BitLocker run
+> was recorded PASS with `[FAIL] User data NOT visible in Phase 2 $HOME` in its
+> own log, which is the North Star assertion itself. The harness now records
+> every failure to a ledger and gates the banner on it, so this class of false
+> green cannot recur — but the counts above were produced by the old harness and
+> are being re-run. Treat them as claims awaiting evidence, not as status.
+
+> ℹ️ **Resolved (2026-07-27):** the hosted-runner TPM blocker
+> ([#59](https://github.com/tuna-os/wootc/issues/59)) was ours, not GitHub's —
+> our sshd wrapper took PID 1 from `tini`, so `swtpm`'s `-d` daemonization never
+> wrote its pid file and dockur silently disabled TPM. Fixed in `4a087eb`;
+> GitHub-hosted runners are back in scope.
+
+**Image family × phase** (Windows 11 Pro, Secure Boot + TPM 2.0):
+
+| Image family | Backend / rootfs | Arm (P1) | Deploy | Phase-2 boot | Phase-3 graduate | GUI-driven full run |
+|---|---|:--:|:--:|:--:|:--:|:--:|
+| `bluefin:lts` | ostree · ext4-sealed | ✅ | ✅ | ✅ | ✅ (29/29) | ✅ |
+| `yellowfin:gnome` (EL10) | ostree · ext4-sealed | ✅ | ✅ | ✅ | ✅ | ⚪ |
+| `yellowfin:kde` / `:xfce` (EL10) | ostree · ext4-sealed | ✅ | ✅ | ✅ | ⚪ | ⚪ |
+| `bonito:gnome` / `:kde` / `:niri` (Fedora) | ostree · **xfs** (unsealed) | ✅ | ✅ | ✅ | ⚪ | ⚪ |
+| `dakota` | composefs-native | ✅ | ✅ | 🔴 [#209](https://github.com/tuna-os/wootc/issues/209) | ⚪ | ⚪ |
+| `marlin` (Arch) / `flounder` (Debian) | ostree · xfs (unsealed) | ✅ | 🔴 | ⚪ | ⚪ | ⚪ |
+
+`dakota` (composefs-native) went green on the failure-ledger harness —
+composefs full chain, run `30710282014` (2026-08-02);
+[#28](https://github.com/tuna-os/wootc/issues/28) is closed. Its Phase-2
+**first boot after a clean GUI deploy** currently hangs CPU-bound
+([#209](https://github.com/tuna-os/wootc/issues/209), 2026-08-22) — being
+root-caused for v0.2.0-alpha. `marlin`/`flounder` fail in
+`bootc install` with *"bootupd is required for ostree-based installs"*: they are
+ostree images that ship no `bootupd`.
+
+**Axes** (against the EL10 / `bluefin:lts` baseline):
+
+| Axis | Status | Notes |
+|---|:--:|---|
+| Windows 11 Pro | ✅ | primary proven path |
+| Windows 11 Home / Enterprise / LTSC | ✅ | all three green on EL10 |
+| Windows 10 Pro | ✅ | green in 37 min via the restored Windows base image |
+| Windows 10 Home / Enterprise / LTSC | 🔴 | Setup stops on its edition picker — the answer file's product key matches no image in the ISO for those editions — [#58](https://github.com/tuna-os/wootc/issues/58) |
+| Root filesystem: `xfs` (unsealed) | ✅ | mounted with explicit `-t` (a typeless mount tried ext4 on xfs) |
+| Root filesystem: `ext4` (sealed, fs-verity) | ✅ | proven sealed default |
+| Root filesystem: `btrfs` (sealed) | ✅ | green cell on bonito via `wootc.filesystem=btrfs` (2026-08-22); blocked on EL10 kernels whose out-of-tree btrfs kmod is rejected under Secure Boot |
+| Encryption: none | ✅ | |
+| Encryption: `tpm2-luks` | 🟡 | [#33](https://github.com/tuna-os/wootc/issues/33) fixed (`bffd284`, 2026-08-10) — Phase-2 dracut regen works; green cell re-verification pending under the failure-ledger harness |
+| BitLocker FDE (unencrypted-volume path) | ✅ | refusal path green 2026-08-22; full install path is the v0.3.0-beta gate — [#34](https://github.com/tuna-os/wootc/issues/34). Setup carves unencrypted volume E: for `root.disk` while C: stays encrypted |
+| Offline (`-nic none`, pre-downloaded image) | ⚪ | code path shipped (branded builds / `WOOTC_PRELOAD=1`); matrix axis tracked as [#217](https://github.com/tuna-os/wootc/issues/217) |
+
+The full three-phase chain (Windows seed → deploy → Phase-2 bridge →
+Phase-3 native disk → seeded file on the native disk) is **green end-to-end
+on `bluefin:lts`** — both via the script path (29/29) and driven entirely
+through the real `wootc.exe` GUI (drive mode), and it gates every release.
+
+## Running the E2E yourself
+
+The E2E harness drives a Windows 11 VM (via
+[dockur/windows](https://github.com/dockur/windows)) over the QEMU Guest
+Agent — no guest networking required. It needs a host with KVM, UEFI Secure
+Boot, and TPM 2.0.
+
+```bash
+just remote-sync               # push + reset a runner to origin/main
+just remote-e2e                # fresh install + deploy (~30 min)
+just remote-e2e-quick          # reuse the installed disk (~5 min)
+
+just remote-logs               # tail the run
+just remote-serial             # watch the deployer serial console
+just remote-status             # grep PASS/FAIL markers
+```
+
+Every E2E run records a sped-up timelapse to
+`tests/e2e/storage/artifacts/<run>/video/`. To refresh the
+[walkthrough](https://tuna-os.github.io/wootc/e2e/latest/) on the README,
+publish a passing run's clip:
+
+```bash
+tests/e2e/publish-visual.sh --from-host <host>   # or a local artifact dir
+git add pages && git commit -m 'docs: refresh E2E walkthrough' && git push origin main
+```
+
+A GitHub-hosted workflow (`.github/workflows/pages.yml`) then deploys it to
+Pages — no self-hosted runner required. The README hero is a committed
+relative path, so it renders inline on GitHub even before Pages redeploys.


### PR DESCRIPTION
The README was reading as a dev log: a giant status matrix with stale honesty caveats, "not yet a released installer" (false since `v0.1.0-alpha.1` this morning), and a features table still describing Windows-Style Mode as opt-in/off-by-default (stale since #244). This makes it the product page and gives the backstory a proper home.

## The new README

Hero timelapse (kept — it's the best asset the project has) + badges (release, nightly E2E, CI, license), then: what it is in one paragraph, **"Setup asks for as much as a Mac's first-run assistant would: a password"** as the second paragraph, Get it (download / winget / branded), How it works (the same 4-step flow, tightened), What you get (bullets, current — look/Wi-Fi defaults included), **Trust, engineered** (the E2E-gated release story), a docs table, short contributing, license. Every claim current.

## Where the story went (nothing lost)

- **`docs/status.md`** — the verification ladder, the full build/test matrix with its dated caveats, and the E2E how-to. Rows refreshed to current evidence while moving: dakota Phase-2 → 🔴 #209, btrfs → ✅ (bonito cell, 2026-08-22), BitLocker split into refusal-path-green vs full-install-path (the #34 beta gate), offline axis added (#217).
- **`docs/philosophy.md`** — the North Star and its consequences, the ask-nothing-macOS-wouldn't principle, the Wubi heritage / why-a-file rationale, evidence-not-claims, and the uninstall promise.

## Pointer integrity

The old `README.md#buildtest-matrix` anchor was load-bearing — updated in CONTRIBUTING.md, AGENTS.md, docs/RELEASING.md, docs/finish-plan.md, and docs/gui-phase1-architecture.md. All relative links in the three touched pages verified to resolve; fast tier green (no test pinned README text).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki