### PR TITLE
walkthroughs: one video per distribution; drive-mode image integrity

### DIFF
--- a/.github/workflows/e2e-gui.yml
+++ b/.github/workflows/e2e-gui.yml
@@ -85,13 +85,54 @@ jobs:
             find /tmp/evidence -maxdepth 3 -type d >&2 || true
             exit 1
           fi
-          echo "Publishing GUI-driven timelapse from $vd"
-          mkdir -p pages/e2e/latest
-          cp "$vd/preview.webp" pages/e2e/latest/preview.webp
-          [ -f "$vd/e2e.webm" ] && cp "$vd/e2e.webm" pages/e2e/latest/e2e.webm || echo "(poster only; no e2e.webm)"
-          cp "$vd/.passed" pages/e2e/latest/.passed 2>/dev/null || true
+          # One walkthrough PER DISTRIBUTION, plus "latest" for the README
+          # hero. Slug from the image that actually ran: bazzite:stable →
+          # bazzite, bluefin:lts → bluefin-lts (a stable/latest tag adds
+          # nothing; any other tag disambiguates).
+          image="${{ inputs.image || 'ghcr.io/projectbluefin/bluefin:lts' }}"
+          name=$(basename "${image%:*}")
+          tag="${image##*:}"
+          [ "$tag" = "$image" ] && tag=""
+          slug="$name"
+          case "$tag" in ''|stable|latest) ;; *) slug="$name-$tag" ;; esac
+          echo "Publishing GUI-driven timelapse from $vd (slug: $slug)"
 
-          if git diff --quiet -- pages/e2e/latest; then
+          # Carry every previously published cut forward: the assets branch
+          # is force-pushed as a fresh orphan each run, so without restoring
+          # its tree first, publishing bazzite would erase bluefin's video
+          # and vice versa. Only 'latest' and this run's slug are replaced.
+          if git fetch --depth 1 origin pages-assets 2>/dev/null; then
+            git checkout FETCH_HEAD -- pages/e2e 2>/dev/null || true
+            git reset -q HEAD -- pages/e2e 2>/dev/null || true
+          fi
+
+          for dest in pages/e2e/latest "pages/e2e/$slug"; do
+            mkdir -p "$dest"
+            cp "$vd/preview.webp" "$dest/preview.webp"
+            [ -f "$vd/e2e.webm" ] && cp "$vd/e2e.webm" "$dest/e2e.webm" || echo "(poster only; no e2e.webm)"
+            cp "$vd/.passed" "$dest/.passed" 2>/dev/null || true
+            # Ship the player with every cut: slug dirs exist only on the
+            # assets branch, so they cannot rely on a committed page.
+            cp pages/e2e/latest/index.html "$dest/index.html" 2>/dev/null || true
+          done
+
+          # Rebuild the gallery from whatever cuts now exist.
+          {
+            printf '%s\n' '<!doctype html>' '<html lang="en">' '<meta charset="utf-8">' \
+              '<meta name="viewport" content="width=device-width, initial-scale=1">' \
+              '<title>wootc — walkthrough gallery</title>' \
+              '<style>:root{color-scheme:dark}body{max-width:960px;margin:2rem auto;padding:0 1rem;background:#0d1117;color:#e6edf3;font:16px/1.6 system-ui,sans-serif}h1{font-size:1.5rem}a.card{display:inline-block;width:288px;margin:.5rem;text-decoration:none;color:#e6edf3}a.card img{width:100%;border-radius:8px;background:#000}a.card span{display:block;margin-top:.3rem;text-align:center;color:#7dd3fc}</style>' \
+              '<h1>wootc — end-to-end walkthroughs</h1>' \
+              '<p>Every video is a real, green acceptance run: Windows 11 → installer GUI → native Linux from <code>root.disk</code> → back to Windows. Only passing runs are ever published.</p>'
+            for d in pages/e2e/*/; do
+              s=$(basename "$d")
+              [ -f "$d/preview.webp" ] || continue
+              printf '<a class="card" href="%s/"><img src="%s/preview.webp" alt="%s walkthrough"><span>%s</span></a>\n' "$s" "$s" "$s" "$s"
+            done
+            printf '%s\n' '</html>'
+          } > pages/e2e/index.html
+
+          if [ -z "$(git status --porcelain pages/e2e)" ]; then
             echo "Timelapse unchanged — nothing to commit."
             exit 0
           fi
@@ -110,8 +151,11 @@ jobs:
           # commit to main required.
           git checkout --orphan pages-assets
           git rm -rf --cached . >/dev/null
-          git add pages/e2e/latest
-          git commit -m "e2e visual: refresh GUI-driven walkthrough media (${{ github.run_id }})"
+          # The whole gallery, not just latest: every brand's current cut plus
+          # the index ride the assets branch (still a single orphan commit —
+          # history never accumulates, wootc#87 holds).
+          git add pages/e2e
+          git commit -m "e2e visual: refresh walkthrough media, slug=$slug (${{ github.run_id }})"
           git push -f origin HEAD:pages-assets
 
           # Ask pages.yml to redeploy with the refreshed media -- it only

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,12 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Fetch latest E2E timelapse from pages-assets branch
+      - name: Fetch E2E walkthrough media from pages-assets branch
         run: |
           if ! git fetch --depth 1 origin pages-assets; then
             echo "pages-assets branch not published yet — deploying the committed pages/ tree as-is."
           else
-            git checkout FETCH_HEAD -- pages/e2e/latest
+            # The whole gallery — per-distribution cuts and the index, not
+            # just latest — rides the assets branch.
+            git checkout FETCH_HEAD -- pages/e2e
           fi
 
       - uses: actions/configure-pages@v6

--- a/app/app.go
+++ b/app/app.go
@@ -359,6 +359,15 @@ func (a *App) GetSupportPolicy() SupportPolicy {
 	if effectiveBranding().HideCustomImage {
 		pol.CustomImageAllowed = false
 	}
+	// The E2E harness exists precisely to test images BEFORE they are green;
+	// in drive mode the channel gate must not hide them, or a directive for
+	// an experimental image finds no card and the run silently installs the
+	// default instead (run 32581422435: "bazzite" installed bluefin-lts —
+	// the drive loop now also refuses on mismatch, this is the enabling
+	// half). Real users never run with this environment variable set.
+	if os.Getenv("WOOTC_E2E_DRIVE") == "1" {
+		pol.ExperimentalImages = true
+	}
 	return pol
 }
 

--- a/app/data/images.json
+++ b/app/data/images.json
@@ -193,7 +193,7 @@
     "bootloader": "grub2",
     "composeFs": false,
     "family": "fedora",
-    "status": "experimental"
+    "status": "green"
   },
   {
     "id": "bazzite-deck",

--- a/app/data/images.json
+++ b/app/data/images.json
@@ -193,7 +193,7 @@
     "bootloader": "grub2",
     "composeFs": false,
     "family": "fedora",
-    "status": "green"
+    "status": "experimental"
   },
   {
     "id": "bazzite-deck",

--- a/app/frontend/src/lib/e2e.js
+++ b/app/frontend/src/lib/e2e.js
@@ -52,6 +52,16 @@ function driveInstall(directive, state) {
     if (input.oninput) input.oninput();
   }
 
+  // INTEGRITY GATE: install ONLY the image the directive named. When the
+  // requested image has no catalog card (e.g. status-gated out of GetImages)
+  // and no custom-ref field is available, the selection silently stays the
+  // DEFAULT — and clicking Install here would run a full green E2E against
+  // the wrong distribution while the harness records the requested one
+  // (run 32581422435 "bazzite" installed bluefin-lts exactly this way).
+  // Refuse, and let reportState carry the mismatch so the harness fails
+  // loudly instead of the run lying quietly.
+  if (directive.image && state.selected?.imageRef !== directive.image) return;
+
   const installButton = document.getElementById('install-btn');
   if (installButton && !installButton.disabled) {
     window.__e2eInstallDriven = true;
@@ -60,6 +70,10 @@ function driveInstall(directive, state) {
 }
 
 async function reportState(state) {
+  // The harness reads imageMismatch to fail FAST when the directive's image
+  // cannot be selected (see the integrity gate in driveInstall) — the
+  // alternative is a silent install of the default image.
+  const wantRef = window.__e2eWantImage || '';
   await E2EDriveReport(JSON.stringify({
     screen: state.screen,
     installDriven: !!window.__e2eInstallDriven,
@@ -67,6 +81,9 @@ async function reportState(state) {
     hint: (document.getElementById('install-hint') || {}).textContent || '',
     progressStep: state.progress?.step || '',
     error: state.progress?.error || null,
+    selectedRef: state.selected?.imageRef || '',
+    imageMismatch: !!(wantRef && state.screen === 'launchpad' &&
+      !window.__e2eInstallDriven && state.selected?.imageRef !== wantRef),
   }));
 }
 
@@ -82,7 +99,10 @@ export function startE2EDrive(state) {
     try {
       if (raw) {
         const directive = JSON.parse(raw);
-        if (directive.action === 'install') driveInstall(directive, state);
+        if (directive.action === 'install') {
+          window.__e2eWantImage = directive.image || '';
+          driveInstall(directive, state);
+        }
         if (directive.action === 'reboot' && state.screen === 'done' && !window.__e2eRebootDriven) {
           window.__e2eRebootDriven = true;
           Reboot();

--- a/docs/branded-walkthroughs.md
+++ b/docs/branded-walkthroughs.md
@@ -10,6 +10,14 @@ that the build wears its own name, mark and look (and, for branded builds,
 never the word "wootc"). Re-running the Playwright suite refreshes every
 image below.
 
+**Live video walkthroughs** — every distribution that has passed a full
+GUI-driven E2E gets its own timelapse (a real Windows VM installing that
+image through the real GUI, migrating data, and returning to Windows) in
+the gallery at **https://tuna-os.github.io/wootc/e2e/** ; the most recent
+green run of any image is always at
+[/e2e/latest/](https://tuna-os.github.io/wootc/e2e/latest/). Cuts publish
+automatically on green (`e2e-gui.yml`), one directory per distribution.
+
 The journey per brand: **launchpad** (the brand's catalog, its default
 pre-selected) → **progress** (the reassurance screen in the brand's look) →
 **done** (celebrating with the brand's own mark) → **manage** (the branded

--- a/pages/e2e/latest/index.html
+++ b/pages/e2e/latest/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>wootc — latest end-to-end walkthrough</title>
+<title>wootc — end-to-end walkthrough</title>
 <style>
   :root { color-scheme: dark; }
   body { max-width: 960px; margin: 2rem auto; padding: 0 1rem;
@@ -18,9 +18,10 @@
   code { background: #161b22; padding: .1rem .35rem; border-radius: 4px; }
 </style>
 
-<h1>wootc — latest end-to-end walkthrough</h1>
+<h1>wootc — end-to-end walkthrough</h1>
 <p class="sub">Sped-up capture of a full acceptance run:
-  Windows 11 → wootc deployer → native Linux from <code>root.disk</code> → back to Windows 11.</p>
+  Windows 11 → wootc deployer → native Linux from <code>root.disk</code> → back to Windows 11.
+  <a href="../">All distribution walkthroughs →</a></p>
 
 <video controls autoplay muted loop playsinline poster="preview.webp">
   <source src="e2e.webm" type="video/webm">

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -2725,6 +2725,22 @@ if ($left.Count -ne 1) { Write-Output ("SINGLE-INSTANCE-UNPROVEN: " + $left.Coun
             last_screen="$screen"
         fi
 
+        # INTEGRITY: the drive loop refuses to click Install when the
+        # directive's image is not the one actually selected on the form
+        # (e.g. gated out of the catalog) — without this gate, the run
+        # installs the DEFAULT image while the harness records the requested
+        # one (run 32581422435: "bazzite" installed bluefin-lts and every
+        # image-agnostic assertion passed). A persisting mismatch will never
+        # resolve on its own, so fail now with the two refs side by side.
+        if [ "$driven" = false ] && printf '%s' "$drive_state" | grep -q '"imageMismatch":true'; then
+            local _sel
+            _sel=$(printf '%s' "$drive_state" | sed -n 's/.*"selectedRef":"\([^"]*\)".*/\1/p' | head -1)
+            fail "Drive mode cannot select the requested image: wanted $IMAGE_REF, form has '${_sel:-<none>}'"
+            fail "  The image is likely gated out of the offered catalog — the drive loop refuses to install the default in its place."
+            capture_vm_diagnostics
+            exit 1
+        fi
+
         if [ "$driven" = false ] && printf '%s' "$drive_state" | grep -q '"installDriven":true'; then
             driven=true
             pass "GUI form filled and Install clicked through the live bridge"

--- a/tests/unit/artifact-retention.bats
+++ b/tests/unit/artifact-retention.bats
@@ -154,3 +154,24 @@ mkrun() {
     grep -q 'not a GREEN run' "$pv"
     grep -q 'ALLOW_RED' "$pv"
 }
+
+@test "per-distribution walkthrough cuts survive each publish" {
+    # The pages-assets branch is a fresh orphan every run (wootc#87 — main's
+    # history must never accumulate media). Without restoring the previous
+    # tree first, publishing one distribution's video would silently erase
+    # every other distribution's — bazzite's cut vanishing the night bluefin's
+    # nightly runs. The publish step must fetch the prior branch, overlay
+    # pages/e2e, and commit the whole gallery; pages.yml must deploy the
+    # whole gallery, not just latest.
+    local wf=".github/workflows/e2e-gui.yml"
+    grep -q 'git fetch --depth 1 origin pages-assets' "$wf"
+    grep -q 'git checkout FETCH_HEAD -- pages/e2e' "$wf"
+    grep -q 'git add pages/e2e$' "$wf"
+    # Slug derivation exists and latest keeps being refreshed for the README.
+    grep -q 'slug="\$name' "$wf" || grep -q 'slug=' "$wf"
+    grep -q 'pages/e2e/latest "pages/e2e/\$slug"' "$wf"
+    grep -q 'git checkout FETCH_HEAD -- pages/e2e$' ".github/workflows/pages.yml"
+    # The green-only gate still stands in front of all of it.
+    grep -q 'name .passed' tests/e2e/publish-visual.sh
+    grep -q '\.passed' "$wf"
+}

--- a/tests/unit/e2e-failure-ledger.bats
+++ b/tests/unit/e2e-failure-ledger.bats
@@ -205,3 +205,23 @@ setup() {
     verdict=$(grep -n 'fail "User data NOT visible in Phase 2' "$E2E" | head -1 | cut -d: -f1)
     [ "$probe" -lt "$verdict" ]
 }
+
+@test "drive mode can only install the image the directive named" {
+    # False-green class: with the requested image gated out of the catalog,
+    # the drive loop used to fill the form and click Install on the DEFAULT
+    # selection — a full E2E then went green against the wrong distribution
+    # while .passed recorded the requested one (run 32581422435: "bazzite"
+    # installed bluefin-lts; every image-agnostic assertion passed). Three
+    # layers now close it:
+    # 1. The drive loop refuses to click Install on a selection mismatch...
+    grep -q 'state.selected?.imageRef !== directive.image) return' \
+        app/frontend/src/lib/e2e.js
+    # 2. ...reports the mismatch so the harness can see it...
+    grep -q 'imageMismatch' app/frontend/src/lib/e2e.js
+    # ...and the harness fails FAST with both refs instead of timing out.
+    grep -q '"imageMismatch":true' tests/e2e/run-e2e.sh
+    grep -q 'Drive mode cannot select the requested image' tests/e2e/run-e2e.sh
+    # 3. Drive mode un-gates experimental images (the harness exists to test
+    # images BEFORE they are green), so the requested card is selectable.
+    grep -q 'WOOTC_E2E_DRIVE' app/app.go
+}


### PR DESCRIPTION
## What reviewing the "Bazzite" run actually found

Frame-by-frame review of run 32581422435 showed the Phase-2 desktop wearing **Bluefin**, not Bazzite: bazzite was `experimental`, the alpha channel's green gate hid it from `GetImages`, drive mode found no card to click, and Install fired on the **default selection** — every image-agnostic assertion passed and `.passed` recorded the requested image. A textbook member of this repo's dominant bug class (status derived from a proxy). The run also proved the publisher has been a **silent no-op since #163**: media is untracked on main, `git diff --quiet` cannot see untracked files, so every "publish" exited "unchanged" — the README hero has been serving a 404.

## The fixes (three commits)

**1. One video per distribution** (first commit): every green run publishes to `pages/e2e/<slug>/` *and* refreshes `latest`; the publish step restores the prior assets tree first so other distributions' cuts survive the orphan force-push; a gallery index is rebuilt at `pages/e2e/`; `pages.yml` deploys the whole gallery. The new `git status --porcelain` guard also fixes the untracked-media no-op — publishing works again.

**2. Drive-mode image integrity** (third commit):
- `driveInstall` refuses to click Install unless the live selection's `imageRef` equals the directive's image; `reportState` carries `selectedRef` + `imageMismatch`.
- `run-e2e.sh` fails FAST on a persisting mismatch, printing both refs, instead of timing out undiagnosed.
- `GetSupportPolicy` un-gates experimental images when `WOOTC_E2E_DRIVE=1` — the harness exists to test images *before* they're green; real users never run with that variable.

**3. Bazzite promotion reverted** (was in the first commit, undone in the third): the run that justified it installed the wrong image. Bazzite stays `experimental` until a run provably installs bazzite — which the integrity gate now makes checkable.

## Tests

`artifact-retention.bats`: per-distribution cuts survive each publish, gallery deploys, green-only gate intact. `e2e-failure-ledger.bats`: the three-layer image-integrity contract. Fast tier, Go suites, YAML validation, `run-e2e.sh` syntax — all green.

Refs #226 (the honest Bazzite cell comes from the re-run after this merges).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki