### PR TITLE
deployer: find bazzite's MOK key where bazzite ships it; promote aurora + bluefin to green

### DIFF
--- a/app/data/images.json
+++ b/app/data/images.json
@@ -25,7 +25,7 @@
     "bootloader": "grub2",
     "composeFs": false,
     "family": "fedora",
-    "status": "experimental"
+    "status": "green"
   },
   {
     "id": "dakota",
@@ -179,7 +179,7 @@
     "bootloader": "grub2",
     "composeFs": false,
     "family": "fedora",
-    "status": "experimental"
+    "status": "green"
   },
   {
     "id": "bazzite",

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -3319,8 +3319,14 @@ queue_mok_enrollment() {
     # mokutil needs efivarfs; mount is idempotent and UEFI-only.
     mount -t efivarfs efivarfs /sys/firmware/efi/efivars 2>/dev/null || true
     mokutil --sb-state 2>/dev/null | grep -qi 'enabled' || { err "  MOK: Secure Boot not enabled; no enrollment needed"; return 0; }
+    # Cert locations by lineage: bazzite ships its Secure Boot public key at
+    # /usr/share/ublue-os/sb_pubkey.der (its own installer hook imports
+    # exactly that path — installer/titanoboa_hook_postrootfs.sh); classic
+    # akmods layouts use /etc/pki/akmods/certs. The instrumented run
+    # 32614088877 proved the akmods paths empty on bazzite:stable.
     local cert found=0
-    for cert in "$DEPLOY_ROOT"/etc/pki/akmods/certs/*.der \
+    for cert in "$DEPLOY_ROOT"/usr/share/ublue-os/sb_pubkey.der \
+                "$DEPLOY_ROOT"/etc/pki/akmods/certs/*.der \
                 "$DEPLOY_ROOT"/usr/share/ublue-os/certs/*.der; do
         [[ -f "$cert" ]] || continue
         found=1

--- a/tests/unit/mok-enrollment.bats
+++ b/tests/unit/mok-enrollment.bats
@@ -35,6 +35,9 @@ E2E=tests/e2e/run-e2e.sh
     # deployed root, upstream's own documented password, and a serial marker
     # the harness gates its driver on.
     grep -q 'mokutil --sb-state' "$DEPLOY"
+    # bazzite's actual key path (its own installer imports exactly this file),
+    # plus the classic akmods layouts for other lineages.
+    grep -q '/usr/share/ublue-os/sb_pubkey.der' "$DEPLOY"
     grep -q '/etc/pki/akmods/certs/\*.der' "$DEPLOY"
     grep -q "printf 'universalblue\\\\nuniversalblue\\\\n' | mokutil --import" "$DEPLOY"
     grep -q 'MOK enrollment queued' "$DEPLOY"


### PR DESCRIPTION
## The bazzite MOK chain, one leg further

The serial-visibility fix (#260) did its job — run 32614088877 shows exactly which leg breaks:

```
[wootc]   MOK: cmdline wootc.mok=enroll                     ← app-side flag works
[wootc]   MOK: no distribution certs in this image (…/etc/pki/akmods/certs)   ← glob empty
```

Bazzite doesn't use the classic akmods cert layout. Its Secure Boot public key ships at **`/usr/share/ublue-os/sb_pubkey.der`** — the exact path bazzite's own installer hook `mokutil --import`s (`installer/titanoboa_hook_postrootfs.sh` in ublue-os/bazzite). That path now leads the deployer's glob; the akmods layouts stay for other lineages. Pinned in `mok-enrollment.bats`.

## Promotions earned tonight

Both runs executed with the drive-mode image-integrity gate active, so each provably installed its own image through the real GUI, migrated data, and returned to a verified-untouched Windows:

- **bluefin → green** ([run 32604804979](https://github.com/tuna-os/wootc/actions/runs/32604804979))
- **aurora → green** ([run 32613697020](https://github.com/tuna-os/wootc/actions/runs/32613697020))

Their walkthrough videos auto-published to the per-distribution gallery. **bazzite stays experimental** until its own run is green — next attempt goes out when this merges.

Refs #248, #226, #260.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_