### PR TITLE
walkthroughs: branded installers on camera, readable pacing, un-break latest

### DIFF
--- a/.github/workflows/e2e-gui.yml
+++ b/.github/workflows/e2e-gui.yml
@@ -153,8 +153,12 @@ jobs:
           git rm -rf --cached . >/dev/null
           # The whole gallery, not just latest: every brand's current cut plus
           # the index ride the assets branch (still a single orphan commit —
-          # history never accumulates, wootc#87 holds).
-          git add pages/e2e
+          # history never accumulates, wootc#87 holds). -f is LOAD-BEARING:
+          # .gitignore excludes pages/e2e/latest media to keep it off MAIN,
+          # and a plain `git add` silently honored that on the assets branch
+          # too — every publish shipped the gallery with a media-less
+          # latest/ (the README hero 404'd while the per-slug cuts worked).
+          git add -f pages/e2e
           git commit -m "e2e visual: refresh walkthrough media, slug=$slug (${{ github.run_id }})"
           git push -f origin HEAD:pages-assets
 

--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -163,8 +163,23 @@ jobs:
         run: |
           set -euo pipefail
           ( cd app/frontend && npm ci --silent && npm run build )
+          # Wear the brand that matches the image under test: a bluefin run
+          # drives the Bluefin-branded installer, exactly what a real user
+          # downloads — the walkthrough videos must show that installer, not
+          # the generic one. No matching brand directory → generic build.
+          # (Preload is separately forced off in the guest via
+          # WOOTC_PRELOAD=0 until the offline axis (#217) is green.)
+          image="${{ inputs.image }}"
+          name=$(basename "${image%:*}")
+          BRAND_FLAG=""
+          if [ -d "app/branding/$name" ]; then
+            BRAND_FLAG="-X main.brandID=$name"
+            echo "building BRANDED installer: $name"
+          else
+            echo "no brand directory for '$name' — building the generic installer"
+          fi
           ( cd app && GOOS=windows GOARCH=amd64 \
-              go build -tags desktop,production -ldflags "-w -s" \
+              go build -tags desktop,production -ldflags "-w -s $BRAND_FLAG" \
               -o ../tests/e2e/wootc-files/wootc.exe . )
           ls -lh tests/e2e/wootc-files/wootc.exe
 

--- a/app/app.go
+++ b/app/app.go
@@ -914,6 +914,15 @@ func runPipeline(ctx context.Context, cfg InstallConfig, emit func(ProgressEvent
 			// network already failed while Windows could still say so —
 			// discovering that after the reboot would strand the user at a
 			// splash screen instead of an error they can act on.
+			// WOOTC_PRELOAD=0 force-disables even for branded builds: the
+			// E2E harness runs BRANDED exes (the walkthrough videos must
+			// show the installer users actually get) but the offline bundle
+			// path has its own matrix axis (#217) — until that is green,
+			// the harness proves branding and deploy separately from
+			// preload. Real users never run with this variable set.
+			if os.Getenv("WOOTC_PRELOAD") == "0" {
+				return nil
+			}
 			if !effectiveBranding().PreloadImage && os.Getenv("WOOTC_PRELOAD") == "" {
 				return nil
 			}

--- a/tests/e2e/record-video.sh
+++ b/tests/e2e/record-video.sh
@@ -21,8 +21,9 @@ RUNTIME="${WOOTC_CONTAINER_RUNTIME:-podman}"
 INTERVAL="${WOOTC_VIDEO_INTERVAL:-2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CARDS_DIR="$SCRIPT_DIR/titlecards"
-CARD_HOLD="${WOOTC_VIDEO_CARD_HOLD:-16}"   # frames a title card is held (~1.6s @10fps)
-command="${1:?usage: record-video.sh start|mark|stop <outdir> [card]}"
+CARD_HOLD="${WOOTC_VIDEO_CARD_HOLD:-50}"   # frames a title card is held (~5s @10fps)
+FREEZE_HOLD="${WOOTC_VIDEO_FREEZE_HOLD:-50}" # frames a frozen moment is held (~5s @10fps)
+command="${1:?usage: record-video.sh start|mark|freeze|stop <outdir> [card]}"
 outdir="${2:?outdir required}"
 
 snap_loop() {
@@ -85,7 +86,7 @@ build_sequence() {
     mkdir -p "$outdir/seq"; rm -f "$outdir/seq"/*.ppm 2>/dev/null || true
     local out=0 idx=0 f cardppm
     for f in $(find "$outdir/frames" -maxdepth 1 -name 'f*.ppm' | sort); do
-        if [ -n "${CARD_AT[$idx]:-}" ]; then
+        if [ -n "${CARD_AT[$idx]:-}" ] && [ "${CARD_AT[$idx]}" != "@freeze" ]; then
             cardppm=$(make_card "${CARD_AT[$idx]}" "$w" "$h")
             if [ -n "$cardppm" ]; then
                 local k=0
@@ -97,7 +98,16 @@ build_sequence() {
         fi
         cp -l "$f" "$(printf '%s/seq/f%06d.ppm' "$outdir" "$out")" 2>/dev/null \
             || cp -f "$f" "$(printf '%s/seq/f%06d.ppm' "$outdir" "$out")"
-        out=$((out + 1)); idx=$((idx + 1))
+        out=$((out + 1))
+        if [ "${CARD_AT[$idx]:-}" = "@freeze" ]; then
+            # Freeze: hold this exact frame so the moment is readable.
+            local k=1
+            while [ "$k" -lt "$FREEZE_HOLD" ]; do
+                cp -f "$f" "$(printf '%s/seq/f%06d.ppm' "$outdir" "$out")"
+                out=$((out + 1)); k=$((k + 1))
+            done
+        fi
+        idx=$((idx + 1))
     done
     [ "$out" -gt 0 ] && echo "$outdir/seq" || echo "$outdir/frames"
 }
@@ -140,6 +150,14 @@ case "$command" in
         card="${3:?mark needs a card name}"
         n=$(find "$outdir/frames" -maxdepth 1 -name 'f*.ppm' 2>/dev/null | wc -l)
         printf '%s\t%s\n' "$n" "$card" >> "$outdir/markers.txt"
+        ;;
+    freeze)
+        # Hold the moment currently on screen: the just-captured frame is
+        # duplicated FREEZE_HOLD times at assembly, so a viewer gets ~5s to
+        # actually read the screen the timelapse would otherwise blink past
+        # (the migrated-files desktop, Disk Management, the done screen).
+        n=$(find "$outdir/frames" -maxdepth 1 -name 'f*.ppm' 2>/dev/null | wc -l)
+        [ "$n" -gt 0 ] && printf '%s\t@freeze\n' "$((n - 1))" >> "$outdir/markers.txt"
         ;;
     stop)
         if [ -f "$outdir/.recorder.pid" ]; then

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -2130,6 +2130,14 @@ mark_phase() {
     WOOTC_CONTAINER_RUNTIME="$DOCKER" "$SCRIPT_DIR/record-video.sh" mark "$VIDEO_DIR" "$1" 2>/dev/null || true
 }
 
+# Hold the frame currently on screen for ~5s in the assembled timelapse, so
+# the moments that carry the story (the done screen, the migrated files, the
+# untouched partition table) are readable instead of a blink.
+freeze_frame() {
+    [ "${VIDEO_STARTED:-false}" = true ] || return 0
+    WOOTC_CONTAINER_RUNTIME="$DOCKER" "$SCRIPT_DIR/record-video.sh" freeze "$VIDEO_DIR" 2>/dev/null || true
+}
+
 # ── Timelapse demo stages (video-only, never load-bearing) ───────────────────
 # Two showcase segments for the published walkthrough: the migrated files on
 # the live Linux desktop, and Windows coming back untouched. The FACTS are
@@ -2177,6 +2185,7 @@ demo_linux_userdata() {
         runuser -u wootc -- env "XDG_RUNTIME_DIR=/run/user/$uid" "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$uid/bus" \
             systemd-run --user --collect xdg-open /home/wootc/Documents' >/dev/null 2>&1 || true
     sleep "${WOOTC_E2E_DEMO_DWELL:-40}"
+    freeze_frame
     pass "Timelapse demo: Linux desktop segment recorded"
 }
 
@@ -2210,6 +2219,7 @@ schtasks /Create /TN wootc-e2e-demo /SC ONCE /ST $start /TR "C:\wootc\e2e-demo.c
 schtasks /Run /TN wootc-e2e-demo | Out-Null
 Write-Output "demo-task-scheduled"' >/dev/null 2>&1 || true
     sleep "${WOOTC_E2E_DEMO_DWELL:-40}"
+    freeze_frame
     qga_powershell 'cmd.exe /d /c "schtasks.exe /Delete /TN \"wootc-e2e-demo\" /F >NUL 2>&1"; Remove-Item C:\wootc\e2e-demo.cmd -Force -ErrorAction SilentlyContinue' >/dev/null 2>&1 || true
     pass "Timelapse demo: Windows-untouched segment recorded"
 }
@@ -2524,6 +2534,7 @@ foreach ($f in "deployer-vmlinuz","deployer-initramfs.img","shimx64.efi","grubx6
 Remove-Item C:\wootc\e2e-drive.json,C:\wootc\e2e-drive-state.json -Force -ErrorAction SilentlyContinue
 @"
 set WOOTC_E2E_DRIVE=1
+set WOOTC_PRELOAD=0
 start `"`" C:\wootc\wootc.exe
 "@ | Set-Content -Path C:\wootc\launch-gui.cmd -Encoding ascii
 Stop-Process -Name wootc -Force -ErrorAction SilentlyContinue
@@ -2773,6 +2784,8 @@ if ($left.Count -ne 1) { Write-Output ("SINGLE-INSTANCE-UNPROVEN: " + $left.Coun
         fi
         if printf '%s' "$drive_state" | grep -q '"screen":"done"'; then
             pass "GUI-driven install completed — real pipeline reached the done screen"
+            # Let the done screen actually appear in a capture, then hold it.
+            sleep 4; freeze_frame
             break
         fi
         if printf '%s' "$drive_state" | grep -q '"error":"'; then

--- a/tests/unit/artifact-retention.bats
+++ b/tests/unit/artifact-retention.bats
@@ -166,7 +166,11 @@ mkrun() {
     local wf=".github/workflows/e2e-gui.yml"
     grep -q 'git fetch --depth 1 origin pages-assets' "$wf"
     grep -q 'git checkout FETCH_HEAD -- pages/e2e' "$wf"
-    grep -q 'git add pages/e2e$' "$wf"
+    # -f is load-bearing: .gitignore excludes latest/ media to keep it off
+    # MAIN, and a plain add silently honored that on the assets branch too —
+    # every publish shipped a media-less latest/ (hero 404) while the
+    # per-slug cuts worked.
+    grep -q 'git add -f pages/e2e$' "$wf"
     # Slug derivation exists and latest keeps being refreshed for the README.
     grep -q 'slug="\$name' "$wf" || grep -q 'slug=' "$wf"
     grep -q 'pages/e2e/latest "pages/e2e/\$slug"' "$wf"
@@ -174,4 +178,26 @@ mkrun() {
     # The green-only gate still stands in front of all of it.
     grep -q 'name .passed' tests/e2e/publish-visual.sh
     grep -q '\.passed' "$wf"
+}
+
+@test "the timelapse gives viewers time to read: 5s cards and freeze-frames" {
+    # Field review (2026-08-23): cards blinked past at 1.6s and the demo
+    # money shots compressed to ~2s of screen time — unreadable. Cards hold
+    # ~5s, and the harness freezes the frames that carry the story.
+    grep -q 'WOOTC_VIDEO_CARD_HOLD:-50' tests/e2e/record-video.sh
+    grep -q 'WOOTC_VIDEO_FREEZE_HOLD:-50' tests/e2e/record-video.sh
+    grep -q '@freeze' tests/e2e/record-video.sh
+    # The three story moments: done screen, migrated files, untouched Windows.
+    [ "$(grep -c 'freeze_frame$' tests/e2e/run-e2e.sh)" -ge 3 ]
+}
+
+@test "brand runs drive the BRANDED installer" {
+    # The walkthrough video for bluefin must show the Bluefin installer —
+    # the one a real user downloads — not the generic build. Brand derived
+    # from the image under test; preload force-disabled in the guest until
+    # the offline axis (#217) is green.
+    grep -q 'main.brandID=\$name' .github/workflows/e2e-hosted.yml
+    grep -q 'app/branding/\$name' .github/workflows/e2e-hosted.yml
+    grep -q 'set WOOTC_PRELOAD=0' tests/e2e/run-e2e.sh
+    grep -q 'os.Getenv("WOOTC_PRELOAD") == "0"' app/app.go
 }


### PR DESCRIPTION
Fixes the three findings from the maintainer's field review of the gallery on mobile:

## 1. Viewers get time to read

Title cards held 1.6s and the demo money shots compressed to ~2s of screen time. Now: cards hold **~5s** (`CARD_HOLD` 16→50), and `record-video.sh` gains a **`freeze`** command — the just-captured frame is duplicated ~5s at assembly. The harness freezes the three story moments: the **done screen**, the **migrated-files desktop** (welcome dashboard + Files on the bridged Documents), and **Disk Management over the untouched partition table**.

## 2. `latest` un-404'd

`.gitignore` excludes `pages/e2e/latest` media to keep it off **main** (wootc#87) — and the publish step's plain `git add pages/e2e` silently honored that on the **assets branch** too, so every publish shipped the gallery with a media-less `latest/` while the per-slug cuts worked (exactly the symptom on the phone: aurora/bluefin posters fine, latest broken). `git add -f` on the orphan branch is the fix.

## 3. Brand runs drive the BRANDED installer

The harness always built plain `wootc.exe`, so the bluefin/aurora videos showed an unbranded app. `e2e-hosted.yml` now derives the brand from the image under test (`app/branding/<image-name>/` exists → `-X main.brandID=<name>`): a bluefin run drives the Bluefin-branded installer — the exe users actually download. Branded builds imply `preloadImage`; until the offline axis (#217) is green, the guest launcher sets `WOOTC_PRELOAD=0`, which now force-disables preload even for branded builds (E2E-only escape hatch, documented in the gate).

## After merge

Re-run aurora and bluefin (serially — one pending dispatch at a time) so their gallery films show the branded installers with the new pacing; bazzite follows once its MOK run proves out. All three pinned in `artifact-retention.bats`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_