### PR TITLE
deployer: harvest MOK certs before the verify tree is unmounted (#248)

### DIFF
--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -3239,6 +3239,40 @@ GRUBEOF
         log "  [PASS] Phase-3 executable present; SELinux is permissive/disabled — labels not required (setfiles absent)"
     fi
 
+    # ── MOK cert harvest (#248) — must happen HERE, while trees exist ──────
+    # queue_mok_enrollment runs after /mnt/verify is unmounted and the verify
+    # loop detached, so a $DEPLOY_ROOT glob there dereferences an empty mount
+    # point — found=0 forever, on EVERY image (run 32624885089 reported "no
+    # distribution certs" on bazzite:stable for exactly this reason). And even
+    # while mounted, a composefs deployment's on-disk /usr is a stub and its
+    # /etc only the writable upper layer, so the cert bazzite actually ships —
+    # /etc/pki/akmods/certs/akmods-ublue.der, the exact file its own
+    # `ujust enroll-secure-boot-key` imports — appears in NEITHER tree. The
+    # container image is the one place image /etc content is always readable
+    # (podman materializes the full rootfs; the scratch teardown comes later).
+    # Harvest to tmpfs now; enrollment imports from the stash.
+    MOK_CERT_STASH=/run/wootc-mok-certs
+    if [[ "$(read_cmdline wootc.mok "")" == "enroll" ]]; then
+        mkdir -p "$MOK_CERT_STASH"
+        shopt -s nullglob
+        for _c in "$DEPLOY_ROOT"/usr/share/ublue-os/sb_pubkey.der \
+                  "$DEPLOY_ROOT"/etc/pki/akmods/certs/*.der \
+                  "$DEPLOY_ROOT"/usr/share/ublue-os/certs/*.der; do
+            cp -f "$_c" "$MOK_CERT_STASH/" 2>/dev/null \
+                && err "  MOK: cert harvested from deployment: $(basename "$_c")"
+        done
+        shopt -u nullglob
+        if ! compgen -G "$MOK_CERT_STASH/*.der" >/dev/null; then
+            err "  MOK: deployment tree carries no certs (composefs keeps image /etc out of it) — asking the container image"
+            timeout 180 podman run --rm "$IMAGE" sh -c \
+                'find /etc/pki/akmods/certs /usr/share/ublue-os -maxdepth 3 -type f -name "*.der" 2>/dev/null | head -8 | tar -cf - -T - 2>/dev/null' \
+                2>/dev/null | tar -xf - -C "$MOK_CERT_STASH" 2>/dev/null || true
+            while IFS= read -r _c; do
+                err "  MOK: cert harvested from container image: ${_c#"$MOK_CERT_STASH"/}"
+            done < <(find "$MOK_CERT_STASH" -type f -name '*.der' 2>/dev/null)
+        fi
+    fi
+
     vstage "verify-complete (all stages passed; Phase-2 ESP is staged)"
     # The composefs target ESP is mounted UNDER boot/, so it must go first or
     # the boot umount fails busy.
@@ -3319,16 +3353,12 @@ queue_mok_enrollment() {
     # mokutil needs efivarfs; mount is idempotent and UEFI-only.
     mount -t efivarfs efivarfs /sys/firmware/efi/efivars 2>/dev/null || true
     mokutil --sb-state 2>/dev/null | grep -qi 'enabled' || { err "  MOK: Secure Boot not enabled; no enrollment needed"; return 0; }
-    # Cert locations by lineage: bazzite ships its Secure Boot public key at
-    # /usr/share/ublue-os/sb_pubkey.der (its own installer hook imports
-    # exactly that path — installer/titanoboa_hook_postrootfs.sh); classic
-    # akmods layouts use /etc/pki/akmods/certs. The instrumented run
-    # 32614088877 proved the akmods paths empty on bazzite:stable.
+    # Certs come from the tmpfs stash the verify block harvested while the
+    # deployment (and, under composefs, the container image itself) was still
+    # reachable — by the time this runs, /mnt/verify is unmounted and the
+    # loop detached, so no on-disk path is readable from here.
     local cert found=0
-    for cert in "$DEPLOY_ROOT"/usr/share/ublue-os/sb_pubkey.der \
-                "$DEPLOY_ROOT"/etc/pki/akmods/certs/*.der \
-                "$DEPLOY_ROOT"/usr/share/ublue-os/certs/*.der; do
-        [[ -f "$cert" ]] || continue
+    while IFS= read -r cert; do
         found=1
         if mokutil --test-key "$cert" 2>/dev/null | grep -qi 'already enrolled'; then
             err "  MOK: key already enrolled: $(basename "$cert")"
@@ -3343,8 +3373,8 @@ queue_mok_enrollment() {
         else
             err "  [WARN] could not queue MOK enrollment for $(basename "$cert") — Secure Boot may reject this image's kernel"
         fi
-    done
-    [[ "$found" == 0 ]] && err "  MOK: no distribution certs in this image ($DEPLOY_ROOT/etc/pki/akmods/certs); nothing to enroll"
+    done < <(find "${MOK_CERT_STASH:-/run/wootc-mok-certs}" -type f -name '*.der' 2>/dev/null | sort)
+    [[ "$found" == 0 ]] && err "  MOK: no distribution certs harvested (searched deployment + container image: /etc/pki/akmods/certs, /usr/share/ublue-os); nothing to enroll"
     return 0
 }
 queue_mok_enrollment || true

--- a/tests/unit/mok-enrollment.bats
+++ b/tests/unit/mok-enrollment.bats
@@ -31,9 +31,9 @@ E2E=tests/e2e/run-e2e.sh
     grep -q 'wootc.mok=enroll' app/installer_esp.go
     grep -q 'func imageNeedsMok' app/app.go
     grep -q 'read_cmdline wootc.mok' "$DEPLOY"
-    # Secure Boot check next (no-op otherwise), cert discovery in the
-    # deployed root, upstream's own documented password, and a serial marker
-    # the harness gates its driver on.
+    # Secure Boot check next (no-op otherwise), cert discovery via the
+    # harvested stash, upstream's own documented password, and a serial
+    # marker the harness gates its driver on.
     grep -q 'mokutil --sb-state' "$DEPLOY"
     # bazzite's actual key path (its own installer imports exactly this file),
     # plus the classic akmods layouts for other lineages.
@@ -51,6 +51,28 @@ E2E=tests/e2e/run-e2e.sh
     grep -q 'mokutil' payload/deployer/Containerfile
     grep -cq 'mokutil' payload/deployer/Containerfile
     [ "$(grep -c 'mokutil' payload/deployer/Containerfile)" -ge 3 ]
+}
+
+@test "MOK certs are harvested before the verify tree is unmounted" {
+    # queue_mok_enrollment runs after /mnt/verify is unmounted and the loop
+    # detached — a $DEPLOY_ROOT glob there reads an empty mount point, so
+    # every image reported "no distribution certs" (run 32624885089, bazzite,
+    # which DOES ship /etc/pki/akmods/certs/akmods-ublue.der). Discovery must
+    # happen inside the verify block, and composefs images must be asked via
+    # the container image — the deployment's /usr is a stub and its /etc only
+    # the writable upper layer, so image-shipped certs appear in neither.
+    local harvest umount_line queue_line
+    harvest=$(grep -n 'MOK_CERT_STASH=/run/wootc-mok-certs' "$DEPLOY" | head -1 | cut -d: -f1)
+    umount_line=$(grep -n 'umount /mnt/verify 2>/dev/null || err' "$DEPLOY" | head -1 | cut -d: -f1)
+    queue_line=$(grep -n '^queue_mok_enrollment || true' "$DEPLOY" | head -1 | cut -d: -f1)
+    [ -n "$harvest" ] && [ -n "$umount_line" ] && [ -n "$queue_line" ]
+    [ "$harvest" -lt "$umount_line" ]
+    [ "$umount_line" -lt "$queue_line" ]
+    # The composefs answer: certs pulled out of the container image rootfs.
+    grep -q 'cert harvested from container image' "$DEPLOY"
+    grep -q 'find /etc/pki/akmods/certs /usr/share/ublue-os' "$DEPLOY"
+    # Enrollment consumes the stash, never the (dead) on-disk paths.
+    grep -q 'find "${MOK_CERT_STASH:-/run/wootc-mok-certs}"' "$DEPLOY"
 }
 
 @test "the harness drives MokManager only behind the no-GRUB discriminator" {


### PR DESCRIPTION
## Why bazzite attempt #4 still said "no distribution certs"

Run 32624885089 had the sb_pubkey.der path in the glob and *still* found nothing — because the cert discovery could never find anything, on any image:

1. **`queue_mok_enrollment` runs after the verify tree is gone.** `/mnt/verify` is unmounted and the verify loop detached ~70 lines *before* the enrollment call, so every `$DEPLOY_ROOT/...` glob dereferenced an empty mount point. `found=0` was structural, not a path problem.
2. **Even inside the verify window, composefs hides the cert.** The deployment's on-disk `/usr` is a stub (documented at the qemu-ga staging comment) and its `/etc` is only the writable upper layer — image-shipped `/etc` files live in the sealed image, not on disk. Bazzite genuinely ships `/etc/pki/akmods/certs/akmods-ublue.der` (the exact file its own `ujust enroll-secure-boot-key` imports), and neither tree ever shows it.

## The fix

- **Harvest inside the verify block**, before the unmounts: deployment paths first (classic ostree layouts), then a bounded `podman run` extraction of `*.der` files from the container image rootfs — the one place image `/etc` content is always readable (podman materializes the full rootfs; the scratch teardown comes later). Certs land in a tmpfs stash `/run/wootc-mok-certs`, all branches logged via `err()` so the serial shows the decision chain.
- **`queue_mok_enrollment` imports from the stash**, never from on-disk paths that are dead by then. Marker strings the E2E MokManager driver gates on are unchanged.
- New bats test pins the harvest-before-unmount ordering (line-number comparison), the container-image fallback, and stash consumption. Full unit suite: 460/460 green.

Closes nothing yet — #248 stays open until a bazzite run boots Phase 2 under Secure Boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_