### PR TITLE
boot arm: a wootc firmware entry must never survive in the permanent boot order

### DIFF
--- a/app/installer_esp.go
+++ b/app/installer_esp.go
@@ -545,6 +545,14 @@ func configureBCD(bootloader string) error {
 			return fmt.Errorf("bcdedit %v: %w (output: %s)", args[1:], err, out)
 		}
 	}
+	// Enforce the bootsequence-only promise: /copy can register the clone in
+	// the permanent firmware displayorder too (position varies by firmware),
+	// and an entry there outlives the one-shot — after the deploy the machine
+	// would boot Linux by default instead of returning to Windows. Removing
+	// it from displayorder leaves the entry itself (and the bootsequence
+	// pointing at it) intact. Best-effort: firmwares that never added it
+	// report a harmless error here.
+	runCmd("bcdedit", "/set", "{fwbootmgr}", "displayorder", guid, "/remove") //nolint:errcheck
 	return nil
 }
 
@@ -578,11 +586,25 @@ func tail(s string, n int) string {
 
 // deleteWootcBCDEntries removes every firmware entry named exactly
 // "wootc" (identifier precedes description in bcdedit output).
+//
+// Each entry is pulled out of the PERMANENT firmware displayorder before the
+// delete, because the delete itself is not reliable: /copy can fail
+// transiently ("registry key marked for deletion", #74) leaving a
+// half-created entry that /delete then fails on the same way — and that
+// zombie sat in the firmware BootOrder AHEAD of Windows, so the first boot
+// after a verified deploy went straight into Linux instead of returning to
+// Windows (aurora run 32633715971: Boot0004 "wootc" from a failed first
+// /copy booted Phase 2 while Boot0003 "Windows Boot Manager" never ran).
+// That is the exact surprise the done screen promises cannot happen. The
+// displayorder removal is a separate, smaller NVRAM write that succeeds even
+// when the object delete does not — an undeletable entry that is in no boot
+// order is inert.
 func deleteWootcBCDEntries() {
 	out, _ := runCmd("bcdedit", "/enum", "firmware")
 	re := regexp.MustCompile(`(?ms)identifier\s+(\{[^}]+\})[^{]*?description\s+wootc\s*$`)
 	for _, m := range re.FindAllStringSubmatch(out, -1) {
-		runCmd("bcdedit", "/delete", m[1]) //nolint:errcheck
+		runCmd("bcdedit", "/set", "{fwbootmgr}", "displayorder", m[1], "/remove") //nolint:errcheck
+		runCmd("bcdedit", "/delete", m[1])                                        //nolint:errcheck
 	}
 }
 

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -973,6 +973,31 @@ if ($after) { Write-Output ("SWEEP-INCOMPLETE: " + ($after -join "; ")) } else {
             warn "ESP sweep could not reach the ESP ($esp_letter); the GUI ownership guard may refuse this install"
             ;;
     esac
+    # Sweep stale "wootc" FIRMWARE entries too, not just ESP files. A prior
+    # attempt's half-created bcdedit /copy (#74's transient) leaves an entry
+    # the app's own sweep may fail to delete, and if it sits in the firmware
+    # BootOrder ahead of Windows, the post-deploy boot goes straight into
+    # Linux instead of returning to Windows — the harness then correctly
+    # refuses the run (aurora 32633715971: stale Boot0004 "wootc" booted
+    # Phase 2; Boot0003 "Windows Boot Manager" never ran). Pull each entry
+    # out of displayorder first — that smaller NVRAM write succeeds even when
+    # the object delete repeats the transient — then delete it.
+    local fw_sweep
+    fw_sweep=$(qga_powershell '$ErrorActionPreference = "SilentlyContinue"
+$enum = cmd.exe /d /c "bcdedit /enum firmware" | Out-String
+$guids = @()
+$id = ""
+foreach ($line in ($enum -split "`r?`n")) {
+    if ($line -match "^identifier\s+(\{[0-9a-fA-F-]+\})") { $id = $Matches[1] }
+    elseif ($line -match "^description\s+wootc\s*$" -and $id) { $guids += $id; $id = "" }
+}
+if (-not $guids) { Write-Output "fw: clean"; exit 0 }
+foreach ($g in $guids) {
+    cmd.exe /d /c "bcdedit /set {fwbootmgr} displayorder $g /remove >NUL 2>&1" | Out-Null
+    cmd.exe /d /c "bcdedit /delete $g >NUL 2>&1" | Out-Null
+    Write-Output "fw: swept stale wootc entry $g"
+}' 2>&1) || true
+    printf '%s\n' "$fw_sweep" | sed 's/^/    fw-sweep: /'
     rm -f "$STORAGE_DIR/qemu.pty"
     printf '%s run_id=%s reset prior OEM handoff state\n' "$(date -u +%FT%TZ)" "$RUN_ID" > "$STORAGE_DIR/e2e-timeline.log"
     pass "Prior OEM handoff state cleared"

--- a/tests/unit/north-star-boot.bats
+++ b/tests/unit/north-star-boot.bats
@@ -117,3 +117,25 @@ MODSETUP="payload/deployer/module-setup.sh"
     grep -q 'pre-trigger/10-wootc-early-splash.sh' "$MODSETUP"
     grep -q 'early-splash.sh' "$CONTAINERFILE"
 }
+
+@test "a wootc firmware entry can never survive in the permanent boot order" {
+    # The done screen promises "Windows stays your default until Linux has
+    # proven it works". A half-created bcdedit /copy (#74's transient) left a
+    # zombie "wootc" entry in the firmware BootOrder ahead of Windows, so the
+    # first boot after a verified deploy went straight into Linux (aurora run
+    # 32633715971: stale Boot0004 booted Phase 2; Boot0003 "Windows Boot
+    # Manager" never ran). Three legs:
+    #   1. the sweep pulls every wootc entry out of displayorder BEFORE the
+    #      delete — the smaller NVRAM write succeeds when /delete repeats the
+    #      transient, and an entry in no boot order is inert;
+    #   2. the fresh entry is removed from displayorder after arming — the
+    #      one-shot lives in bootsequence alone;
+    #   3. the E2E reset sweeps firmware entries too, not just ESP files, so
+    #      one run's zombie cannot fail the next.
+    grep -q '"bcdedit", "/set", "{fwbootmgr}", "displayorder", m\[1\], "/remove"' app/installer_esp.go
+    # ...and the delete still follows it (removal alone would leak objects).
+    grep -A1 'displayorder", m\[1\], "/remove"' app/installer_esp.go | grep -q '"bcdedit", "/delete", m\[1\]'
+    grep -q '"bcdedit", "/set", "{fwbootmgr}", "displayorder", guid, "/remove"' app/installer_esp.go
+    grep -q 'bcdedit /set {fwbootmgr} displayorder \$g /remove' tests/e2e/run-e2e.sh
+    grep -q 'bcdedit /delete \$g' tests/e2e/run-e2e.sh
+}


### PR DESCRIPTION
## What broke

Aurora branded re-run 32633715971 deployed successfully, then the machine booted **straight into Phase-2 Linux** instead of returning to Windows. Serial evidence: firmware started stale `Boot0004 "wootc"` post-deploy; `Boot0003 "Windows Boot Manager"` never ran. The green aurora control run (32613697020) had exactly one wootc entry and booted Windows at the same point.

The stale entry came from #74's known transient: `bcdedit /copy` can fail with "registry key marked for deletion" *after* half-creating the entry, and the retry loop's best-effort sweep then fails to `/delete` the zombie the same way. The zombie stayed registered in the firmware's permanent BootOrder ahead of Windows — so the first post-deploy boot went to Linux by default. For a real user, that's precisely the surprise the done screen promises can't happen ("Windows stays your default until Linux has proven it works"); for the E2E, it correctly fails the run.

## The fix (three legs)

1. **`deleteWootcBCDEntries` removes each entry from `{fwbootmgr}` displayorder before deleting it.** The displayorder removal is a separate, smaller NVRAM write that succeeds even when the object delete repeats the transient — an undeletable entry that's in no boot order is inert.
2. **After arming, the fresh entry is removed from displayorder too.** The one-shot lives in `bootsequence` alone, keeping the nothing-permanent-changes promise literal.
3. **The E2E reset sweeps stale wootc firmware entries** (displayorder removal + delete via bcdedit over QGA), not just ESP files, so one run's zombie cannot fail the next run on the same NVRAM.

New `north-star-boot.bats` test pins all three legs. Full unit suite 461/461 green; `go build`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_