### PR TITLE
e2e: auto-retry harness-classified flakes, exactly once, never real reds

### DIFF
--- a/.github/workflows/e2e-gui.yml
+++ b/.github/workflows/e2e-gui.yml
@@ -20,6 +20,10 @@ on:
         description: 'Graduate to a native disk (Phase 3). Off = the run ends back in Windows, so the timelapse closes on the untouched-Windows demo — the right cut for showcase videos.'
         type: boolean
         default: true
+      flake_retry:
+        description: 'Internal: set by the auto-retry job on its single re-dispatch of a flake-classified failure. Leave empty when dispatching by hand.'
+        type: string
+        default: ''
   schedule:
     # Nightly, offset from the headless canary so they do not contend for
     # the hosted runner pool.
@@ -28,6 +32,7 @@ on:
 permissions:
   contents: write        # commit the refreshed timelapse to pages/
   packages: read
+  actions: write         # the flake-retry job re-dispatches this workflow once
 
 concurrency:
   group: e2e-gui-publish
@@ -51,6 +56,36 @@ jobs:
     # secret to this job for no reason; the other three callers of this
     # reusable workflow (e2e-matrix.yml, e2e-nightly.yml, release.yml) already
     # call it with no secrets: block at all. See #153.
+
+  # ── flake auto-retry ──────────────────────────────────────────────────────
+  # A failure the harness ITSELF classified as infrastructure losing the
+  # evidence channel (flake-verdict.txt: qga-channel-lost, serial-feed-lost)
+  # gets exactly ONE automated re-dispatch of the same inputs. Everything
+  # about this is deliberately narrow:
+  #   - a retry is a fresh, full run that must go green on its own — no gate
+  #     is ever weakened and a red is never re-labeled;
+  #   - an UNCLASSIFIED failure is never retried: the day this landed, two
+  #     real bugs (#263's cert ordering, #264's boot-order leak) wore
+  #     flake-shaped symptoms until a human read the serial;
+  #   - the re-dispatch carries flake_retry=1 and this job skips when it is
+  #     already set, so one flake costs at most one extra run — a retry that
+  #     flakes again waits for a human (or the next nightly);
+  #   - the concurrency group holds the new run PENDING until this one ends,
+  #     and a single pending run is never cancelled by it.
+  flake-retry:
+    needs: run
+    if: ${{ always() && needs.run.result == 'failure' && needs.run.outputs.flake_verdict != '' && (github.event_name == 'schedule' || inputs.flake_retry == '') }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      IMAGE: ${{ inputs.image || 'ghcr.io/projectbluefin/bluefin:lts' }}
+      PHASE3: ${{ github.event_name == 'schedule' && 'true' || (inputs.phase3 && 'true' || 'false') }}
+      VERDICT: ${{ needs.run.outputs.flake_verdict }}
+    steps:
+      - run: |
+          echo "Re-dispatching once: harness classified the failure as '$VERDICT'"
+          gh workflow run e2e-gui.yml --repo "${{ github.repository }}" --ref "${{ github.ref_name }}" \
+            -f image="$IMAGE" -f phase3="$PHASE3" -f flake_retry=1
 
   publish:
     needs: run

--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -46,6 +46,14 @@ on:
       # C:\OEM). The walkthrough timelapse from a GUI-driven run is the one
       # the README publishes.
       gui_install: { type: boolean, default: false }
+    outputs:
+      # Non-empty ONLY when run-e2e.sh classified its own failure as a known
+      # infrastructure flake (qga-channel-lost, serial-feed-lost). Callers may
+      # use it to re-dispatch the same run once; an unclassified failure must
+      # never be retried automatically — the day this was added, two real bugs
+      # wore flake-shaped symptoms until a human read the serial.
+      flake_verdict:
+        value: ${{ jobs.e2e.outputs.flake_verdict }}
 
 permissions:
   contents: read
@@ -55,6 +63,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 330          # under the 6 h hard cap, with headroom
+    outputs:
+      flake_verdict: ${{ steps.flake.outputs.verdict }}
     steps:
       - uses: actions/checkout@v7
         with: { submodules: recursive }
@@ -242,6 +252,18 @@ jobs:
           # diagnosed for hours — the evidence artifact is the only way in.
           set -o pipefail
           bash run-e2e.sh "$WOOTC_TARGET_IMAGE" $FLAGS 2>&1 | tee /tmp/run-e2e-console.log
+
+      # Surface the harness's own flake classification (written ONLY when the
+      # failure matched a known infra signature — see note_flake in
+      # run-e2e.sh). Callers gate a single automated re-dispatch on this;
+      # empty means real failure, never retried.
+      - name: Read flake verdict
+        id: flake
+        if: always()
+        run: |
+          v=$(cat tests/e2e/storage/flake-verdict.txt 2>/dev/null | head -1 | tr -cd 'a-z-')
+          echo "verdict=$v" >> "$GITHUB_OUTPUT"
+          [ -n "$v" ] && echo "::notice::run-e2e.sh classified this failure as a flake: $v" || true
 
       - name: Collect evidence
         if: always()

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -135,6 +135,24 @@ fail() {
     printf '%s\n' "$*" >> "$WOOTC_FAILURE_LEDGER" 2>/dev/null || true
 }
 info() { printf '%b[INFO]%b %s\n' "$YELLOW" "$NC" "$*"; }
+
+# ── flake classifier ────────────────────────────────────────────────────────
+# Some failures are infrastructure losing the EVIDENCE channel, not the
+# product failing: the QGA virtio-serial goes deaf mid-run (#220), or the
+# QEMU serial feed freezes while the deployer keeps working (aurora run
+# 32631919777: last serial byte at 85s of deployer uptime, guest CPU still
+# pulling blobs). Re-running those by hand costs a human round-trip per
+# flake. note_flake records a MACHINE-READABLE verdict beside the artifacts;
+# the workflow reads it and re-dispatches the SAME run ONCE — a retry is a
+# fresh full run that must go green on its own merits. Real failures write
+# no verdict and are never retried: the day this classifier was written,
+# two genuine bugs (a MOK cert ordering bug and a firmware boot-order
+# leak) wore flake-shaped symptoms until diagnosed — auto-retrying an
+# unclassified red would have buried both.
+note_flake() {
+    printf '%s\n' "$1" > "$STORAGE_DIR/flake-verdict.txt" 2>/dev/null || true
+    warn "flake suspected ($1) — recorded for a single automated re-run"
+}
 # WOOTC_LAST_STEP is carried into the exit stamp. Without it the EXIT trap
 # overwrote stage= with a bare "exited (status 1)", discarding the only record
 # of WHERE a run died — three hosted win10 cells (run 30230608430) failed
@@ -176,6 +194,10 @@ export WOOTC_E2E_STORAGE_VOL="$STORAGE_DIR"
 # advisory lock open for the lifetime of this shell; it is released
 # automatically if the runner exits or is killed.
 mkdir -p "$STORAGE_DIR"
+# A previous run's flake verdict must never speak for this run: the retry
+# gate reads this file after the run ends, and a stale one would let a REAL
+# failure inherit a flake classification and get silently re-dispatched.
+rm -f "$STORAGE_DIR/flake-verdict.txt"
 exec 9>"$STORAGE_DIR/.run-e2e.lock"
 if ! flock -n 9; then
     echo "[FAIL] Another run-e2e.sh already owns $STORAGE_DIR/.run-e2e.lock" >&2
@@ -2848,6 +2870,9 @@ if (Test-Path $cfg) { Write-Output "grub.cfg first line:"; Write-Output ("  " + 
             fail "  QGA answers ping NOW — so this is the installer, not the channel"
         else
             fail "  QGA does NOT answer ping — the verdict above may be a lost channel, not a stalled install"
+            # The discriminator that keeps this honest: an installer that
+            # stalled with a LIVE channel writes no verdict and is a real red.
+            note_flake "qga-channel-lost"
         fi
         capture_vm_diagnostics
         exit 1
@@ -3280,6 +3305,15 @@ while ! past_deadline "$DEPLOY_DEADLINE"; do
             fail "  serial feed disconnected during the handover."
             info "  Last 20 lines of serial (may show a kernel panic or firmware messages):"
             tail -c 4000 "$PTY" 2>/dev/null | tr -d '\000' | tail -20 | sed 's/^/    /' || true
+            # Discriminate feed loss from a real boot failure: dracut lines on
+            # the PTY prove the deployer's userspace was alive and writing —
+            # so the missing [wootc] marker is the FEED dying, not the boot
+            # (aurora 32631919777: last serial byte at 85s, blobs still
+            # pulling). A panic or firmware bounce leaves no dracut output
+            # and stays a real, unretried red.
+            if tail -c 200000 "$PTY" 2>/dev/null | tr -d '\000' | grep -aq 'dracut-initqueue'; then
+                note_flake "serial-feed-lost"
+            fi
             capture_vm_diagnostics
             exit 1
         fi

--- a/tests/unit/e2e-failure-ledger.bats
+++ b/tests/unit/e2e-failure-ledger.bats
@@ -225,3 +225,39 @@ setup() {
     # images BEFORE they are green), so the requested card is selectable.
     grep -q 'WOOTC_E2E_DRIVE' app/app.go
 }
+
+@test "flake auto-retry: only harness-classified flakes are ever re-dispatched" {
+    # Two failure families are infrastructure losing the EVIDENCE channel,
+    # not the product failing: QGA going deaf mid-run (#220) and the QEMU
+    # serial feed freezing while the guest keeps working (aurora
+    # 32631919777). Those — and ONLY those — earn one automated re-dispatch.
+    # The day this landed, two real bugs (#263 cert ordering, #264 firmware
+    # boot-order leak) wore flake-shaped symptoms; an unclassified red must
+    # therefore never be retried, and a retry is a fresh full run, never a
+    # weakened gate.
+    local E2E=tests/e2e/run-e2e.sh HOSTED=.github/workflows/e2e-hosted.yml GUI=.github/workflows/e2e-gui.yml
+    # 1. The classifier writes a machine-readable verdict; stale verdicts
+    #    from a previous run are cleared before this run can fail.
+    grep -q 'note_flake()' "$E2E"
+    grep -q 'flake-verdict.txt' "$E2E"
+    grep -q 'rm -f "\$STORAGE_DIR/flake-verdict.txt"' "$E2E"
+    # 2. Exactly the two known signatures, each behind its discriminator:
+    #    qga-channel-lost only when QGA does NOT answer (a stall with a live
+    #    channel is the installer's fault), serial-feed-lost only when dracut
+    #    output proves the deployer's userspace was alive on the dead feed.
+    grep -q 'note_flake "qga-channel-lost"' "$E2E"
+    grep -B3 'note_flake "qga-channel-lost"' "$E2E" | grep -q 'QGA does NOT answer ping'
+    grep -q 'note_flake "serial-feed-lost"' "$E2E"
+    grep -B2 'note_flake "serial-feed-lost"' "$E2E" | grep -q "grep -aq 'dracut-initqueue'"
+    # 3. The reusable workflow surfaces the verdict as an output...
+    grep -q 'flake_verdict' "$HOSTED"
+    grep -q 'steps.flake.outputs.verdict' "$HOSTED"
+    # 4. ...and the retry job fires only on a FAILED run WITH a verdict, at
+    #    most once (a re-dispatched run carries flake_retry=1 and skips).
+    grep -q "needs.run.result == 'failure'" "$GUI"
+    grep -q "needs.run.outputs.flake_verdict != ''" "$GUI"
+    grep -q 'flake_retry=1' "$GUI"
+    grep -q "inputs.flake_retry == ''" "$GUI"
+    # 5. The green-only publish gate is untouched — retries never publish red.
+    grep -q 'name .passed' tests/e2e/publish-visual.sh
+}


### PR DESCRIPTION
## The false-red problem

Today's ledger makes the case: the nightly stalled with a dead QGA channel, and aurora attempt #1 lost its serial feed at 85s of deployer uptime while the guest kept pulling blobs at 200% CPU. Both were infrastructure losing the *evidence channel*, both burned a human round-trip to re-dispatch. But the same day also produced two real bugs (#263's cert ordering, #264's boot-order leak) that *looked* like flakes until the serial was read — so blanket auto-retry would bury real regressions.

## The design: the harness classifies, the workflow retries once

1. **`note_flake` in run-e2e.sh** writes a machine-readable verdict (`flake-verdict.txt`) at exactly two fail sites, each behind a discriminator that keeps it honest:
   - `qga-channel-lost` — only when QGA does **not** answer ping at the 30m GUI verdict. A stalled installer with a live channel writes no verdict and stays red.
   - `serial-feed-lost` — only when the dead PTY carries dracut output proving the deployer's userspace was alive and writing. A kernel panic or firmware bounce leaves none and stays red.
   - Stale verdicts are cleared at run start so a real failure can't inherit one.
2. **e2e-hosted.yml** surfaces the verdict as a `workflow_call` output (`flake_verdict`, empty = real failure).
3. **e2e-gui.yml** gains a `flake-retry` job: fires only on `failure` **and** a non-empty verdict, re-dispatches the identical inputs with `flake_retry=1`, and a retried run skips its own retry job — one flake costs at most one extra run; a double flake waits for a human or the next nightly. The concurrency group holds the re-dispatch pending (a single pending run is never cancelled).

**What never changes:** a retry is a fresh, full run that must go green on its own; the green-only publish gate is untouched; no red is ever re-labeled.

New `e2e-failure-ledger.bats` test pins the classifier sites, both discriminators, the output plumbing, the single-retry cap, and the publish gate. Full unit suite 462/462; both workflows YAML-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_