### PR TITLE
boot arm retried as a unit (#74) + live download progress on the splash

### DIFF
--- a/app/installer_esp.go
+++ b/app/installer_esp.go
@@ -480,49 +480,64 @@ func configureBCD(bootloader string) error {
 	// inheriting the ESP device/partition settings, so no drive letter is needed.
 	// This is the proven approach from WubiUEFI (millions of users).
 	//
-	// Retry, and say what the firmware list looked like when it fails (#74).
-	// This step failed on 2 of 3 runs of one cell with two different messages,
-	// both about the DISPLAY ORDER:
+	// Retry the WHOLE arm, and say what the firmware list looked like when it
+	// fails (#74). The transient BCD-store errors —
 	//     "Illegal operation attempted on a registry key marked for deletion"
 	//     "The data area passed to a system call is too small"
-	// The first reads as a transient BCD-store state; the second is what
-	// bcdedit reports when the firmware boot entry list has grown large.
+	// — were first seen on /copy (2 of 3 runs of one cell), so only /copy got
+	// the retry. Then bluefin run 32642504000 hit the SAME "marked for
+	// deletion" transient on the bootsequence step, which had no protection,
+	// and the install died on a one-shot flake. A fresh entry whose registry
+	// key has gone bad cannot be repaired by re-running one command against
+	// it — the retry must discard it (sweep) and rebuild from /copy. So the
+	// loop now wraps copy → parse → path → bootsequence as one attempt.
 	//
-	// deleteWootcBCDEntries above removes stale entries by GUID but does not
-	// repair the display order — leaving dangling references that cause
-	// /copy to fail when it internally reads or touches the display order.
-	// Repairing the display order before the copy (idempotent /addfirst of
-	// {bootmgr}) plus a bounded retry with sweep covers both failure modes.
-	var out string
+	// deleteWootcBCDEntries removes stale entries by GUID but does not repair
+	// the display order — dangling references make /copy fail when it reads
+	// or touches the display order, so each attempt repairs it first
+	// (idempotent /addfirst of {bootmgr}).
+	re := regexp.MustCompile(`\{([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\}`)
+	var out, guid string
 	var err error
 	for attempt := 1; attempt <= 3; attempt++ {
-		// Repair the display order before each attempt: deleteWootcBCDEntries
-		// above (and between attempts below) can leave dangling GUID refs.
+		guid = ""
 		runCmd("bcdedit", "/displayorder", "{bootmgr}", "/addfirst") //nolint:errcheck
 		out, err = runCmd("bcdedit", "/copy", "{bootmgr}", "/d", "wootc")
+		if err == nil {
+			if m := re.FindStringSubmatch(out); m == nil {
+				err = fmt.Errorf("could not parse GUID from bcdedit output: %q", out)
+			} else {
+				guid = "{" + m[1] + "}"
+				// One-shot bootsequence only: nothing permanent changes in
+				// the user's boot order until TunaOS is known to work.
+				// displayorder promotion is a post-deploy, user-confirmed
+				// action, not part of the install.
+				for _, args := range [][]string{
+					{"bcdedit", "/set", guid, "path", efiRelPath},
+					{"bcdedit", "/set", "{fwbootmgr}", "bootsequence", guid, "/addfirst"},
+				} {
+					if out, err = runCmd(args[0], args[1:]...); err != nil {
+						err = fmt.Errorf("bcdedit %v: %w (output: %s)", args[1:], err, out)
+						break
+					}
+				}
+			}
+		}
 		if err == nil {
 			break
 		}
 		if attempt < 3 {
-			// A partially-created entry from the failed attempt would itself
-			// lengthen the list, so sweep before trying again.
+			// A partially-created or gone-bad entry from the failed attempt
+			// would itself poison the next one, so sweep before retrying.
 			deleteWootcBCDEntries()
 			time.Sleep(time.Duration(attempt) * 2 * time.Second)
 		}
 	}
 	if err != nil {
 		enum, _ := runCmd("bcdedit", "/enum", "firmware")
-		return fmt.Errorf("bcdedit /create: %w (output: %s) — firmware entries at failure: %d\n%s",
-			err, out, strings.Count(enum, "identifier"), tail(enum, 2000))
+		return fmt.Errorf("bcdedit arm: %w — firmware entries at failure: %d\n%s",
+			err, strings.Count(enum, "identifier"), tail(enum, 2000))
 	}
-
-	// Parse the new GUID
-	re := regexp.MustCompile(`\{([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\}`)
-	m := re.FindStringSubmatch(out)
-	if m == nil {
-		return fmt.Errorf("could not parse GUID from bcdedit output: %q", out)
-	}
-	guid := "{" + m[1] + "}"
 
 	// Persist the GUID where setup-wootc.ps1 also records it: the E2E
 	// harness schedules the PHASE-2 loopback boot by re-arming exactly this
@@ -533,18 +548,6 @@ func configureBCD(bootloader string) error {
 		fmt.Printf("warning: could not persist bcd-guid.txt: %v\n", err)
 	}
 
-	// One-shot bootsequence only: nothing permanent changes in the user's
-	// boot order until TunaOS is known to work. displayorder promotion is a
-	// post-deploy, user-confirmed action, not part of the install.
-	cmds := [][]string{
-		{"bcdedit", "/set", guid, "path", efiRelPath},
-		{"bcdedit", "/set", "{fwbootmgr}", "bootsequence", guid, "/addfirst"},
-	}
-	for _, args := range cmds {
-		if out, err := runCmd(args[0], args[1:]...); err != nil {
-			return fmt.Errorf("bcdedit %v: %w (output: %s)", args[1:], err, out)
-		}
-	}
 	// Enforce the bootsequence-only promise: /copy can register the clone in
 	// the permanent firmware displayorder too (position varies by firmware),
 	// and an entry there outlives the one-shot — after the deploy the machine

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -192,10 +192,12 @@ SCRATCH_LOOP=""
 SCRATCH_IMG=""
 JOURNAL_STREAM_PID=""
 HEARTBEAT_PID=""
+PULL_WATCH_PID=""
 cleanup() {
     local _rc=$? mount
     [[ -n "$JOURNAL_STREAM_PID" ]] && kill "$JOURNAL_STREAM_PID" 2>/dev/null || true
     [[ -n "$HEARTBEAT_PID" ]] && kill "$HEARTBEAT_PID" 2>/dev/null || true
+    [[ -n "$PULL_WATCH_PID" ]] && kill "$PULL_WATCH_PID" 2>/dev/null || true
 
     # On FAILURE, put the deployer's own log tail on the SERIAL. log() writes to
     # $PERSIST_LOG on the NTFS, and err() to stderr — so on a failed deploy,
@@ -1346,10 +1348,70 @@ log "Fisherman recipe:"
 # the disk-unlock secret in either one.
 jq 'if .encryption.passphrase then .encryption.passphrase = "<redacted>" else . end' "$RECIPE"
 
+# ── Live download progress on the splash ────────────────────────────────────
+# The fisherman phase is one splash band (26→86), but nearly all of its wall
+# time is the image pull — the easing animator reaches the band ceiling in a
+# couple of minutes and then the bar PARKS there for however long a multi-GB
+# download takes. A bar frozen at one number is exactly the "is it hung?"
+# fear this screen exists to prevent. Drive it from evidence instead: every
+# pulled blob lands in the scratch filesystem, so scratch growth IS the
+# download progressing. The message carries a live byte counter (a number
+# that keeps ticking is proof of life even when the percent is uncertain),
+# and when the registry told us the expected download size, the bar tracks
+# real bytes across the band. Notes on honesty:
+#   - containers-storage holds compressed blobs AND their unpacked layers,
+#     so raw growth runs ~2x the compressed total — divide that back out;
+#   - the percent is monotonic and capped at 85 inside the band, so an
+#     estimate can run slow but never claims more than reality earned;
+#   - the ceiling passed to the animator is pct+2, not 86 — letting the
+#     easing sprint ahead and then yanking it back each sample would show
+#     the bar moving BACKWARDS, which reads worse than parking;
+#   - unknown total (inspect failed): the counter still ticks and the bar
+#     crawls ~1%/30s toward 80 — the pace the old animator implied, now with
+#     visible evidence attached.
+start_pull_progress_watch() {
+    splash_on || return 0
+    local total_bytes=0 base_kib
+    if [[ "$WOOTC_OFFLINE" == 1 ]]; then
+        total_bytes=$(du -sk "$BUNDLE_OCI" 2>/dev/null | awk '{print $1 * 1024}' || true)
+    else
+        total_bytes=$(timeout 60 skopeo inspect --retry-times 2 "docker://${IMAGE}" 2>/dev/null \
+            | jq '[.LayersData[]?.Size] | add // 0' 2>/dev/null || true)
+    fi
+    [[ "$total_bytes" =~ ^[0-9]+$ ]] || total_bytes=0
+    base_kib=$(df -Pk /var/fisherman-tmp 2>/dev/null | awk 'NR==2{print $3}' || true)
+    [[ "$base_kib" =~ ^[0-9]+$ ]] || return 0
+    (
+        lastpct=26 tick=0
+        while :; do
+            sleep 10
+            tick=$((tick + 1))
+            used=$(df -Pk /var/fisherman-tmp 2>/dev/null | awk 'NR==2{print $3}' || true)
+            [[ "$used" =~ ^[0-9]+$ ]] || continue
+            done_kib=$(( used > base_kib ? used - base_kib : 0 ))
+            gib=$(awk -v k="$done_kib" 'BEGIN{printf "%.1f", k/1048576}')
+            if (( total_bytes > 0 )); then
+                cand=$(( 26 + done_kib * 1024 * 60 / (total_bytes * 2) ))
+            else
+                cand=$(( 26 + tick / 3 ))
+                (( cand > 80 )) && cand=80
+            fi
+            (( cand > 85 )) && cand=85
+            (( cand > lastpct )) && lastpct=$cand
+            splash_set "$lastpct" "$((lastpct + 2))" \
+                "Downloading and installing your Linux system - ${gib} GB done so far..."
+        done
+    ) &
+    PULL_WATCH_PID=$!
+}
+
 # ── Run fisherman ───────────────────────────────────────────────────────────
 phase "fisherman"
 log "Running fisherman — this pulls the image and deploys it..."
+start_pull_progress_watch
 fisherman "$RECIPE"
+[[ -n "$PULL_WATCH_PID" ]] && kill "$PULL_WATCH_PID" 2>/dev/null || true
+PULL_WATCH_PID=""
 
 losetup -d "$LOOP_DEV"
 LOOP_DEV=""

--- a/tests/unit/north-star-boot.bats
+++ b/tests/unit/north-star-boot.bats
@@ -153,3 +153,25 @@ MODSETUP="payload/deployer/module-setup.sh"
     printf '%s' "$body" | grep -q '"bootsequence", guid, "/addfirst"'
     printf '%s' "$body" | grep -q 'deleteWootcBCDEntries()'
 }
+
+@test "the download shows live progress, not a parked bar" {
+    # Field review (aurora walkthrough, 2026-08-23): the fisherman splash
+    # band's easing reached its ceiling in ~2 minutes and PARKED there for
+    # the entire multi-GB pull — a frozen number next to a time promise
+    # reads as a hang, the exact fear the splash exists to prevent. The
+    # splash now ticks a real byte counter (scratch growth = blobs landing)
+    # and tracks the expected download size when the registry provides it.
+    local D=payload/deployer/deploy.sh
+    grep -q 'start_pull_progress_watch' "$D"
+    grep -q 'GB done so far' "$D"
+    # Evidence-driven, not animated: scratch usage delta as the numerator,
+    # skopeo-inspected layer sizes as the denominator.
+    grep -q 'LayersData' "$D"
+    grep -q 'df -Pk /var/fisherman-tmp' "$D"
+    # Monotonic and capped inside the band: an estimate may run slow but
+    # never claims more than reality earned, and never moves backwards.
+    grep -q '(( cand > lastpct )) && lastpct=' "$D"
+    grep -q '(( cand > 85 )) && cand=85' "$D"
+    # The watcher dies with the pull, and cleanup kills a stray one.
+    [ "$(grep -c 'PULL_WATCH_PID' "$D")" -ge 4 ]
+}

--- a/tests/unit/north-star-boot.bats
+++ b/tests/unit/north-star-boot.bats
@@ -139,3 +139,17 @@ MODSETUP="payload/deployer/module-setup.sh"
     grep -q 'bcdedit /set {fwbootmgr} displayorder \$g /remove' tests/e2e/run-e2e.sh
     grep -q 'bcdedit /delete \$g' tests/e2e/run-e2e.sh
 }
+
+@test "the one-shot arm retries as a unit — bootsequence included" {
+    # bluefin run 32642504000: the "registry key marked for deletion"
+    # transient (#74) struck the bootsequence step, which sat OUTSIDE the
+    # /copy retry loop — one flake of an unprotected command killed the whole
+    # install. A fresh entry whose registry key went bad cannot be repaired
+    # by re-running one command against it; the retry must sweep and rebuild
+    # from /copy whenever ANY arm step fails. Pin: the bootsequence set and
+    # the between-attempts sweep both live inside the attempt loop.
+    local body
+    body=$(awk '/for attempt := 1; attempt <= 3/,/bcdedit arm:/' app/installer_esp.go)
+    printf '%s' "$body" | grep -q '"bootsequence", guid, "/addfirst"'
+    printf '%s' "$body" | grep -q 'deleteWootcBCDEntries()'
+}


### PR DESCRIPTION
Two changes riding together — the arm fix that unblocks the bluefin re-run, and the splash improvement spotted in the aurora walkthrough.

## 1. Boot arm: retry the whole arm as a unit (#74)

Bluefin branded run 32642504000 died at "Making Linux bootable on your machine":

```
bcdedit /set {fwbootmgr} bootsequence {55e6ce1f-…} /addfirst: exit status 1
Illegal operation attempted on a registry key that has been marked for deletion.
```

That's #74's known BCD-store transient — striking the **bootsequence** step, which sat *outside* the existing retry loop (only `/copy` was protected). A fresh entry whose registry key has gone bad can't be repaired by re-running one command against it — the bounded attempt loop now wraps **copy → parse GUID → set path → set bootsequence** as one unit, with the display-order repair before each attempt and the sweep between attempts. The `bcd-guid.txt` persist and the displayorder-remove of the fresh entry (#264) run once, after a fully successful arm. (The flake classifier correctly wrote no verdict for this run — a real defect, honestly red.)

## 2. Splash: a byte counter that ticks, not a parked bar

The fisherman splash band (26→86) eases to its ceiling in ~2 minutes and then **parks** there for the entire multi-GB pull — a frozen number next to "usually takes 5 to 15 minutes" reads as a hang. Now the splash is driven by evidence: every pulled blob lands in the scratch filesystem, so its growth *is* the download progressing.

- The message ticks a live counter every 10s: *"Downloading and installing your Linux system - 2.1 GB done so far..."* — a moving number is proof of life even when the percent is uncertain.
- With the expected size from `skopeo inspect` (offline bundles: `du` of the OCI layout), the bar tracks real bytes across the band — halving raw growth since containers-storage holds compressed blobs *and* unpacked layers.
- Monotonic, capped at 85 inside the band, animator ceiling pct+2 — it may run slow but never claims more than reality earned and never moves backwards.
- Unknown total: counter still ticks, bar crawls ~1%/30s (the pace the old animator implied, now with evidence attached).
- Watcher dies with the pull; cleanup kills strays; all piped assignments carry `|| true` (the `set -e` guard in backend-detection.bats caught the first draft).

Two new `north-star-boot.bats` pins (arm-retry unity, live-progress contract). Full unit suite 464/464; `go build`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki