### PR TITLE
e2e: drive MokManager from inside the Phase-2 wait — no timing bets (#248)

### DIFF
--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -3548,8 +3548,22 @@ mok_sendkey() {
         'import socket,time,sys; s=socket.socket(socket.AF_UNIX); s.connect("/run/shm/monitor.sock"); time.sleep(.2); s.recv(4096); s.sendall(("sendkey %s\n" % sys.argv[1]).encode()); time.sleep(.3); s.recv(4096); s.close()' \
         "$1" >/dev/null 2>&1 || true
 }
-mok_sequence() {  # interrupt the countdown, then walk the enrollment menu
+mok_sequence() {  # returns 0 only when the MokManager MENU was confirmed and driven
+    # The first keypress must land while the countdown is still running. If
+    # it landed late, the machine is already past MokManager (GRUB menu, or
+    # mid-boot) — and the rest of the sequence contains 'e', which at a GRUB
+    # menu opens the editor and STRANDS the machine there, ending the loop
+    # that would have brought MokManager back. So confirm the menu actually
+    # opened (MokManager renders 'Enroll MOK' on the serial once entered)
+    # before any further key is sent; a lone stray 'ret' at a GRUB menu just
+    # boots the selected entry into the same bad-shim cycle — recoverable.
+    local pre
+    pre=$(wc -c < "$PTY" 2>/dev/null || echo 0)
     mok_sendkey ret;  sleep 3                             # leave press-any-key
+    snapshot_serial
+    if ! tail -c +"$((pre + 1))" "$PTY" 2>/dev/null | grep -aq 'Enroll MOK'; then
+        return 1
+    fi
     mok_sendkey down; sleep 2; mok_sendkey ret; sleep 4   # Enroll MOK
     mok_sendkey down; sleep 2; mok_sendkey ret; sleep 4   # Continue (past View key)
     mok_sendkey down; sleep 2; mok_sendkey ret; sleep 4   # Yes
@@ -3557,61 +3571,23 @@ mok_sequence() {  # interrupt the countdown, then walk the enrollment menu
     for ch in u n i v e r s a l b l u e; do mok_sendkey "$ch"; sleep 1; done
     mok_sendkey ret; sleep 5                              # confirm password
     mok_sendkey ret; sleep 2                              # Reboot (top item post-enroll)
-}
-drive_mok_manager() {
-    snapshot_serial
-    grep -aq 'MOK enrollment queued' "$PTY" || return 0
-    step "Deploy queued a MOK enrollment — watching for MokManager..."
-    local mok_from mok_deadline new_out attempts=0
-    mok_from=$(wc -c < "$PTY" 2>/dev/null || echo 0)
-    mok_deadline=$(deadline_in 300)
-    while ! past_deadline "$mok_deadline"; do
-        sleep 2
-        snapshot_serial
-        new_out=$(tail -c +"$((mok_from + 1))" "$PTY" 2>/dev/null || true)
-        if printf '%s' "$new_out" | grep -aq 'Press any key to perform MOK management'; then
-            mok_from=$(wc -c < "$PTY" 2>/dev/null || echo 0)
-            attempts=$((attempts + 1))
-            info "  MokManager on screen (sighting $attempts) — driving: Enroll MOK, password universalblue"
-            mok_sequence
-            MOK_EXTRA=300
-            if [ "$attempts" -ge 2 ]; then
-                warn "  two MokManager sequences sent — Phase 2 wait will decide"
-                return 0
-            fi
-            # Fresh window for the post-enroll boot.
-            mok_deadline=$(deadline_in 180)
-        elif printf '%s' "$new_out" | grep -aq 'bad shim signature'; then
-            # Kernel still untrusted; the firmware loops back into
-            # MokManager — keep watching from here for the next sighting.
-            mok_from=$(wc -c < "$PTY" 2>/dev/null || echo 0)
-            [ "$attempts" -gt 0 ] && info "  kernel still untrusted after the sequence — waiting for MokManager to reappear"
-        elif [ "$attempts" -gt 0 ] && printf '%s' "$new_out" | grep -aq 'GRUB version'; then
-            # A banner after a driven sequence looks like success — but the
-            # bad-shim error prints seconds AFTER the banner, so hold a beat
-            # and re-read before declaring anything.
-            mok_from=$(wc -c < "$PTY" 2>/dev/null || echo 0)
-            sleep 12
-            snapshot_serial
-            if tail -c +"$((mok_from + 1))" "$PTY" 2>/dev/null | grep -aq 'bad shim signature'; then
-                mok_from=$(wc -c < "$PTY" 2>/dev/null || echo 0)
-                info "  kernel still untrusted after the sequence — waiting for MokManager to reappear"
-            else
-                pass "MOK enrolled — GRUB proceeded without a shim rejection"
-                MOK_EXTRA=300
-                return 0
-            fi
-        fi
-    done
-    if [ "$attempts" -eq 0 ]; then
-        info "  MokManager never appeared on serial (already enrolled?) — continuing"
-    else
-        warn "  MokManager window closed after $attempts sequence(s) — Phase 2 wait will decide"
-        MOK_EXTRA=300
-    fi
     return 0
 }
-drive_mok_manager
+# The DRIVING happens inside the Phase-2 wait loop below — the only vantage
+# point with no assumption about WHEN the boot happens. Run 32657382594:
+# the reboot command was issued, a fixed 300s pre-loop watch window opened —
+# and Windows took over five minutes to actually restart, so MokManager
+# appeared AFTER the window closed, unanswered, while the watcher had
+# already concluded it was never coming. Here we only record whether an
+# enrollment is pending (and widen the boot budget for the extra reboots).
+MOK_PENDING=false
+MOK_SIGHTINGS=0
+snapshot_serial
+if grep -aq 'MOK enrollment queued' "$PTY" 2>/dev/null; then
+    MOK_PENDING=true
+    MOK_EXTRA=300
+    step "Deploy queued a MOK enrollment — the Phase-2 wait will drive MokManager when it appears"
+fi
 
 mark_phase phase2
 step "Waiting for Phase 2 Linux system to boot..."
@@ -3636,6 +3612,31 @@ while ! past_deadline "$BOOT_DEADLINE"; do
     [ "$CURRENT_BYTE" -lt "$LAST_BYTE" ] && LAST_BYTE=0
     if [ "$CURRENT_BYTE" -gt "$LAST_BYTE" ]; then
         NEW_OUTPUT=$(tail -c "+$((LAST_BYTE + 1))" "$PTY")
+        # MokManager surfaces MID-WAIT (see the mok_sequence block above):
+        # drive it the moment its marker shows in fresh serial. Each driven
+        # sequence ends in a reboot, so the enrolled boot gets a fresh full
+        # budget; a sighting whose menu cannot be confirmed (countdown
+        # already expired) is skipped — the bad-shim cycle brings the screen
+        # back around for the next poll.
+        if [ "$MOK_PENDING" = true ] && printf '%s\n' "$NEW_OUTPUT" | grep -aq 'Press any key to perform MOK management'; then
+            if mok_sequence; then
+                MOK_SIGHTINGS=$((MOK_SIGHTINGS + 1))
+                info "MokManager driven (sequence $MOK_SIGHTINGS): Enroll MOK, password universalblue"
+                if [ "$MOK_SIGHTINGS" -ge 2 ]; then
+                    warn "  two MokManager sequences sent — the boot verdict decides"
+                    MOK_PENDING=false
+                fi
+                BOOT_DEADLINE=$(deadline_in "$TIMEOUT")
+            else
+                info "MokManager sighted but its menu was not confirmed (countdown expired?) — catching the next cycle"
+            fi
+            # Consume everything the sequence itself painted (menu redraws
+            # repeat the marker) — or the next poll would re-trigger on our
+            # own keystrokes' output and spray keys into the post-enroll boot.
+            snapshot_serial || true
+            LAST_BYTE=$(stat -c%s "$PTY" 2>/dev/null || echo 0)
+            continue
+        fi
         # A real Phase-2 boot means the system reached its ACTUAL root, not just
         # that the initramfs started. "ostree=" matches the kernel cmdline echo
         # inside the initramfs, so it fired even when the boot then dropped to an

--- a/tests/unit/mok-enrollment.bats
+++ b/tests/unit/mok-enrollment.bats
@@ -75,26 +75,35 @@ E2E=tests/e2e/run-e2e.sh
     grep -q 'find "${MOK_CERT_STASH:-/run/wootc-mok-certs}"' "$DEPLOY"
 }
 
-@test "the harness drives MokManager from its own serial marker, not GRUB's absence" {
-    # Run 32651824930 disproved the original model: MokManager DOES write to
-    # serial ('Press any key to perform MOK management' + a countdown) and
-    # AUTO-CONTINUES into GRUB after 10 seconds — where the untrusted kernel
-    # dies 'bad shim signature' and the firmware loops back into MokManager.
-    # The old no-GRUB-banner discriminator read that pass-through banner as
-    # 'no MokManager this boot', stood down, and the box sat unanswered for
-    # the rest of the run. The driver must key off MokManager's own marker,
-    # and a GRUB banner may prove success only after a driven sequence AND a
-    # re-read that shows no fresh shim rejection (the error prints seconds
-    # AFTER the banner).
-    grep -q "grep -aq 'MOK enrollment queued' \"\$PTY\" || return 0" "$E2E"
+@test "MokManager is driven from inside the Phase-2 wait, on its own serial marker" {
+    # Two runs, two disproven assumptions:
+    #   32651824930 — MokManager DOES write to serial ('Press any key to
+    #     perform MOK management' + a countdown) and AUTO-CONTINUES into
+    #     GRUB after 10s, so a GRUB banner proves nothing about its absence;
+    #   32657382594 — a fixed pre-boot watch window is a timing bet: the
+    #     reboot command was issued, Windows took 5+ minutes to actually
+    #     restart, and MokManager appeared AFTER the window closed.
+    # So the sequence fires from the Phase-2 wait loop, on the marker, with
+    # a menu confirmation before any further key — the sequence contains
+    # 'e', which at a GRUB menu opens the editor and strands the machine.
+    grep -q 'MOK_PENDING=true' "$E2E"
     grep -q 'Press any key to perform MOK management' "$E2E"
-    grep -q 'bad shim signature' "$E2E"
-    grep -q 'GRUB proceeded without a shim rejection' "$E2E"
+    # The marker check lives INSIDE the Phase-2 wait loop (after its
+    # NEW_OUTPUT read), not in a separate pre-boot watcher.
+    local hook_line loop_line
+    loop_line=$(grep -n 'PHASE2_BYTE0=\$LAST_BYTE' "$E2E" | head -1 | cut -d: -f1)
+    hook_line=$(grep -n 'MOK_PENDING" = true.*Press any key to perform MOK management' "$E2E" | head -1 | cut -d: -f1)
+    [ -n "$loop_line" ] && [ -n "$hook_line" ]
+    [ "$hook_line" -gt "$loop_line" ]
+    # Menu confirmed before the dangerous keys; a stale sighting sends at
+    # most one harmless 'ret'.
+    grep -q "grep -aq 'Enroll MOK'" "$E2E"
     run grep -q 'no MokManager this boot' "$E2E"
     [ "$status" -ne 0 ]
-    # Bounded retry across the bad-shim loop, and the Phase-2 budget still
-    # stretches for the extra reboot(s).
+    # Bounded retry, fresh budget per driven sequence, widened overall
+    # budget while an enrollment is pending.
     grep -q 'two MokManager sequences sent' "$E2E"
+    grep -q 'BOOT_DEADLINE=$(deadline_in "$TIMEOUT")' "$E2E"
     grep -q 'TIMEOUT=$((300 + MOK_EXTRA))' "$E2E"
 }
 


### PR DESCRIPTION
## What run 32657382594 showed

The #267 driver keyed off the right marker but still made a timing bet: it opened a fixed 300-second watch window when the Phase-2 reboot *command* was issued. Windows then took over five minutes to actually restart — so MokManager appeared **after** the window closed, unanswered ("MokManager never appeared on serial (already enrolled?)"), while the failure-time serial tail shows the box, the countdown, the pass-through into GRUB, and `bad shim signature`. Also visible in that tail: Windows Boot Manager booting first after the deployer — the #264 boot-order fix holding on bazzite.

## The fix: no separate watcher at all

The Phase-2 wait loop is the only vantage point with no assumption about when the boot happens — it already scans every fresh serial chunk. The MokManager hook now lives there:

- On the marker (`Press any key to perform MOK management`) in fresh output, run the keystroke sequence; each driven sequence ends in a reboot, so the boot deadline resets to a full budget.
- **Menu confirmation before any dangerous key**: `mok_sequence` sends one `ret`, then requires `Enroll MOK` to appear in serial past the pre-keystroke offset. A late keypress means the machine is already at the GRUB menu, where the password's `e` would open the editor and strand the machine — a lone stray `ret` just boots the selected entry back into the recoverable bad-shim cycle.
- After a sequence the loop consumes everything the sequence itself painted (menu redraws repeat the marker), so it can't re-trigger on its own keystrokes' output.
- Bounded at two driven sequences; `MOK_EXTRA` widens the overall budget the moment an enrollment is pending.

`mok-enrollment.bats` pins the loop placement (line-order check), the menu-confirmation gate, the retry cap, and the budget resets. Full unit suite 464/464 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_