### PR TITLE
e2e: re-arm Phase 2 after MokManager's reboot lands in Windows (#248)

### DIFF
--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -3637,6 +3637,33 @@ while ! past_deadline "$BOOT_DEADLINE"; do
             LAST_BYTE=$(stat -c%s "$PTY" 2>/dev/null || echo 0)
             continue
         fi
+        # MokManager's post-enroll reboot lands in WINDOWS: the BCD one-shot
+        # was consumed booting INTO MokManager, and MokManager's own reboot
+        # follows the firmware default (run 32668924852: sequence 1 driven,
+        # then 'starting Boot0003 Windows Boot Manager' — the newly enrolled
+        # kernel never got a boot and the wait timed out). Re-arm the same
+        # one-shot once and reboot, so the enrolled kernel is actually
+        # exercised. Real users are covered by the app's own re-arm paths;
+        # this is the harness closing the same loop for the observed run.
+        if [ "$MOK_SIGHTINGS" -gt 0 ] && [ "${MOK_REARMED:-false}" = false ] \
+            && printf '%s\n' "$NEW_OUTPUT" | grep -aq 'starting Boot.* "Windows Boot Manager"'; then
+            MOK_REARMED=true
+            info "Windows returned after the MokManager sequence (one-shot consumed) — re-arming Phase 2"
+            # Soft wait: qga_wait's timeout branch writes to the failure
+            # ledger, and this re-arm must not be able to fail the run on
+            # its own — the boot verdict below owns the verdict.
+            _mok_qga_deadline=$(deadline_in 300)
+            while ! past_deadline "$_mok_qga_deadline"; do
+                qga_probe && break
+                sleep 10
+            done
+            qga_powershell "bcdedit --% /set {fwbootmgr} bootsequence $PHASE2_GUID /addfirst" >/dev/null 2>&1 || true
+            qga_powershell 'cmd.exe /c "shutdown.exe /a >NUL 2>&1 & shutdown.exe /r /t 1 /f >NUL 2>&1"' >/dev/null 2>&1 || true
+            BOOT_DEADLINE=$(deadline_in "$TIMEOUT")
+            snapshot_serial || true
+            LAST_BYTE=$(stat -c%s "$PTY" 2>/dev/null || echo 0)
+            continue
+        fi
         # A real Phase-2 boot means the system reached its ACTUAL root, not just
         # that the initramfs started. "ostree=" matches the kernel cmdline echo
         # inside the initramfs, so it fired even when the boot then dropped to an

--- a/tests/unit/mok-enrollment.bats
+++ b/tests/unit/mok-enrollment.bats
@@ -115,3 +115,21 @@ E2E=tests/e2e/run-e2e.sh
     grep -q 'mokEnroll' app/frontend/src/screens/done.js
     grep -q 'Enroll MOK' app/frontend/src/screens/done.js
 }
+
+@test "the enrolled kernel actually gets a boot: re-arm after MokManager lands in Windows" {
+    # Run 32668924852: sequence 1 drove the enrollment, MokManager rebooted —
+    # and the firmware booted WINDOWS (the BCD one-shot was consumed booting
+    # INTO MokManager; MokManager's own reboot follows the firmware default).
+    # The newly enrolled kernel never got a boot and the wait timed out with
+    # everything having worked. The harness must re-arm the same one-shot
+    # once and reboot when Windows comes back after a driven sequence.
+    local E2E=tests/e2e/run-e2e.sh
+    grep -q 'starting Boot.\* "Windows Boot Manager"' "$E2E"
+    grep -q 'MOK_REARMED=true' "$E2E"
+    # Gated on a driven sequence and once-only — a re-arm loop could bounce
+    # the machine forever.
+    grep -q 'MOK_SIGHTINGS" -gt 0 \] && \[ "${MOK_REARMED:-false}" = false' "$E2E"
+    # The soft QGA wait cannot write the failure ledger (qga_wait's timeout
+    # branch calls fail(); this must not be able to fail the run on its own).
+    grep -q '_mok_qga_deadline=' "$E2E"
+}


### PR DESCRIPTION
## Furthest run yet — and the last gap

Bazzite run 32668924852: cert harvested ✓, enrollment queued ✓, MokManager sighted mid-wait ✓, menu confirmed ✓, **sequence 1 driven ✓** — the #268 driver worked end to end. Then MokManager rebooted the box and the firmware booted **Windows**: the BCD one-shot was consumed booting *into* MokManager, and MokManager's own reboot follows the firmware default. The freshly enrolled kernel never got a boot, and the Phase-2 wait timed out with every piece having worked.

## The fix

The Phase-2 wait loop closes the loop: after a driven sequence, seeing `starting Boot.* "Windows Boot Manager"` in fresh serial triggers a **one-time** re-arm — soft-wait for QGA (deliberately not `qga_wait`, whose timeout branch writes the failure ledger and could fail the run on its own), re-set the same bootsequence one-shot via the persisted GUID, reboot, fresh boot budget. The boot verdict remains the only verdict; the once-only gate prevents any re-arm bounce loop.

Real users are covered by the app's post-deploy loop and the Windows boot-menu entry — this is the harness closing the same loop for the observed run.

New `mok-enrollment.bats` test pins the Windows-return detector, the once-only gate, and the ledger-safe soft wait. Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_