### PR TITLE
catalog: bazzite is green — the MOK chain is proven end to end (#248)

### DIFF
--- a/.github/workflows/e2e-gui.yml
+++ b/.github/workflows/e2e-gui.yml
@@ -24,6 +24,10 @@ on:
         description: 'Internal: set by the auto-retry job on its single re-dispatch of a flake-classified failure. Leave empty when dispatching by hand.'
         type: string
         default: ''
+      uninstall_check:
+        description: 'After the run returns to Windows: run the documented uninstaller and verify every cleanup claim (adds a Windows reboot; not for showcase cuts).'
+        type: boolean
+        default: false
   schedule:
     # Nightly, offset from the headless canary so they do not contend for
     # the hosted runner pool.
@@ -51,6 +55,8 @@ jobs:
       phase3: ${{ github.event_name == 'schedule' && true || inputs.phase3 }}
       use_base_image: true
       require_podman_major: ${{ inputs.require_podman_major || '' }}
+      # Same coercion-trap guard as phase3: scheduled runs never uninstall.
+      uninstall_check: ${{ github.event_name != 'schedule' && inputs.uninstall_check || false }}
     # No secrets: block — e2e-hosted.yml only uses secrets.GITHUB_TOKEN, which
     # every job gets automatically. `secrets: inherit` exposed every repo
     # secret to this job for no reason; the other three callers of this
@@ -80,12 +86,13 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       IMAGE: ${{ inputs.image || 'ghcr.io/projectbluefin/bluefin:lts' }}
       PHASE3: ${{ github.event_name == 'schedule' && 'true' || (inputs.phase3 && 'true' || 'false') }}
+      UNCHK: ${{ github.event_name != 'schedule' && inputs.uninstall_check && 'true' || 'false' }}
       VERDICT: ${{ needs.run.outputs.flake_verdict }}
     steps:
       - run: |
           echo "Re-dispatching once: harness classified the failure as '$VERDICT'"
           gh workflow run e2e-gui.yml --repo "${{ github.repository }}" --ref "${{ github.ref_name }}" \
-            -f image="$IMAGE" -f phase3="$PHASE3" -f flake_retry=1
+            -f image="$IMAGE" -f phase3="$PHASE3" -f uninstall_check="$UNCHK" -f flake_retry=1
 
   publish:
     needs: run

--- a/app/data/images.json
+++ b/app/data/images.json
@@ -193,7 +193,7 @@
     "bootloader": "grub2",
     "composeFs": false,
     "family": "fedora",
-    "status": "experimental",
+    "status": "green",
     "mokEnroll": "universalblue"
   },
   {


### PR DESCRIPTION
## The run that closes #248

[Run 32679831098](https://github.com/tuna-os/wootc/actions/runs/32679831098) — GUI-driven, Secure Boot on, the Bazzite-branded installer on camera:

1. Phase 1 armed through the real GUI (branded build, drive mode)
2. Deployer harvested `akmods-ublue.der`, queued the MOK enrollment
3. Windows returned post-deploy (boot order intact, #264)
4. Harness sighted MokManager mid-wait, confirmed the menu, drove the enrollment
5. Caught the Windows return inside the consumed span (#271), re-armed the one-shot
6. **The enrolled kernel booted Phase 2** — user data intact — and returned to Windows

Ten attempts; every failure was diagnosed to a specific defect and fixed on the way: #251, #260, #261, #263, #264, #266, #267, #268, #269, #271. The walkthrough is live at https://tuna-os.github.io/wootc/e2e/bazzite/.

## Changes

- `bazzite:stable` graduates **experimental → green** — the alpha channel now offers it. `bazzite-deck` stays experimental until it earns its own run.
- `e2e-gui.yml` gains the `uninstall_check` passthrough (schedule-guarded like `phase3`, forwarded by the flake-retry re-dispatch) so the uninstall verification stage (#270) is reachable from the dispatch surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_