### PR TITLE
e2e: catalog-member images wear their parent brand on camera

### DIFF
--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -190,7 +190,19 @@ jobs:
             BRAND_FLAG="-X main.brandID=$name"
             echo "building BRANDED installer: $name"
           else
-            echo "no brand directory for '$name' — building the generic installer"
+            # An image can belong to a brand's catalog without a brand of
+            # its own — dakota ships inside the Bluefin installer. A real
+            # Dakota user downloads Bluefin's exe, so that is the installer
+            # the walkthrough must show. Find the brand whose catalog lists
+            # this image id; generic only when no brand claims it.
+            for b in app/branding/*/; do
+              if grep -q "\"$name\"" "$b/brand.json" 2>/dev/null; then
+                BRAND_FLAG="-X main.brandID=$(basename "$b")"
+                echo "building BRANDED installer: $(basename "$b") (its catalog carries '$name')"
+                break
+              fi
+            done
+            [ -z "$BRAND_FLAG" ] && echo "no brand claims '$name' — building the generic installer"
           fi
           ( cd app && GOOS=windows GOARCH=amd64 \
               go build -tags desktop,production -ldflags "-w -s $BRAND_FLAG" \

--- a/tests/unit/artifact-retention.bats
+++ b/tests/unit/artifact-retention.bats
@@ -200,4 +200,12 @@ mkrun() {
     grep -q 'app/branding/\$name' .github/workflows/e2e-hosted.yml
     grep -q 'set WOOTC_PRELOAD=0' tests/e2e/run-e2e.sh
     grep -q 'os.Getenv("WOOTC_PRELOAD") == "0"' app/app.go
+    # An image without a brand directory of its own can still belong to a
+    # brand's CATALOG — dakota ships inside the Bluefin installer, and a
+    # real Dakota user downloads Bluefin's exe, so that is the installer the
+    # walkthrough must show. The derivation falls through to the brand whose
+    # brand.json lists the image id; generic only when no brand claims it.
+    grep -q 'brand.json' .github/workflows/e2e-hosted.yml
+    grep -q "its catalog carries" .github/workflows/e2e-hosted.yml
+    grep -q '"dakota"' app/branding/bluefin/brand.json
 }


### PR DESCRIPTION
Prep for adding **Dakota to the walkthrough gallery**: dakota has no brand directory of its own — it ships inside the Bluefin installer (`app/branding/bluefin/brand.json` catalog: `bluefin, dakota, bluefin-lts`). A real Dakota user downloads Bluefin's exe, so that's the installer a dakota walkthrough must show; the old derivation only checked `app/branding/$name` and would have fallen back to the generic build.

The brand derivation now falls through to the brand whose `brand.json` lists the image id, and goes generic only when no brand claims it. Direct matches (aurora, bazzite, bluefin) are unchanged — the directory check still wins first.

Pinned in `artifact-retention.bats` alongside the existing branded-build contract. After merge: dispatch `e2e-gui.yml` with `ghcr.io/projectbluefin/dakota:latest`, `phase3: false` — a green run publishes the `dakota` gallery cut (slug from `dakota:latest` → `dakota`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_