### PR TITLE
e2e: the North Star read polls the bridge instead of racing it

### DIFF
--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -4022,8 +4022,22 @@ step "Verifying seeded user data is visible in Phase 2 \$HOME..."
 # bound nothing. Reporting that as data loss is the same defect this harness
 # keeps producing, in the one assertion that matters most.
 USERDATA_PROBE=$(qga_call exec /bin/sh -c 'echo WOOTC_AGENT_OK' 2>/dev/null || true)
-USERDATA_HOME=$(qga_call exec /bin/sh -c \
-    'cat /home/wootc/Documents/wootc-e2e-userdata.txt 2>/dev/null' 2>/dev/null || true)
+# POLL, do not race. The bridge is a boot-time SERVICE, not a filesystem
+# property: on dakota (run 32700041245) the root was reached at 07:50:40 and
+# wootc-passthrough finished its binds at 07:52:14 — 94 seconds later, the
+# cloud-provider scan running first — so a single-shot read reported the
+# North Star failed while its own diagnostic printed the completed
+# Documents bind. A real user reaches their desktop minutes after boot; the
+# honest assertion is "visible once the bridge has run", bounded here at
+# two minutes.
+USERDATA_HOME=""
+_ud_deadline=$(deadline_in 120)
+while ! past_deadline "$_ud_deadline"; do
+    USERDATA_HOME=$(qga_call exec /bin/sh -c \
+        'cat /home/wootc/Documents/wootc-e2e-userdata.txt 2>/dev/null' 2>/dev/null || true)
+    printf '%s' "$USERDATA_HOME" | grep -q "$RUN_ID" && break
+    sleep 5
+done
 if ! printf '%s' "$USERDATA_PROBE" | grep -q WOOTC_AGENT_OK; then
     fail "Cannot verify user data: the Phase-2 guest agent never answered, so the bridge was NOT measured"
     info "  This is an INCONCLUSIVE check, not proof of data loss — the file may well be there."

--- a/tests/unit/e2e-failure-ledger.bats
+++ b/tests/unit/e2e-failure-ledger.bats
@@ -261,3 +261,18 @@ setup() {
     # 5. The green-only publish gate is untouched — retries never publish red.
     grep -q 'name .passed' tests/e2e/publish-visual.sh
 }
+
+@test "the North Star read polls the bridge, it does not race it" {
+    # The user-data bridge is a boot-time SERVICE: on dakota (run
+    # 32700041245) wootc-passthrough finished its binds 94 seconds after the
+    # root was reached (its cloud-provider scan runs first), and the old
+    # single-shot read declared the North Star failed while its own
+    # diagnostic printed the completed Documents bind. The read must retry
+    # under a deadline; the agent-answered gate and the layered diagnostic
+    # stay as they were.
+    local E2E=tests/e2e/run-e2e.sh
+    grep -q '_ud_deadline=$(deadline_in 120)' "$E2E"
+    grep -B3 'cat /home/wootc/Documents/wootc-e2e-userdata.txt' "$E2E" | grep -q 'while ! past_deadline "$_ud_deadline"'
+    grep -q 'WOOTC_AGENT_OK' "$E2E"
+    grep -q 'User data NOT visible in Phase 2' "$E2E"
+}


### PR DESCRIPTION
## Dakota gallery run 32700041245 — the bridge worked, the check raced it

Everything the run's own failure diagnostic printed says the migration **worked**: host NTFS mounted, profile found, seed file readable at the host path with the right RUN_ID, `Documents` bound into `/var/home/wootc/Documents`, passthrough service finished. The run still failed "User data NOT visible in Phase 2 $HOME" — because the check does **one** read right after boot (07:51:40), and on dakota `wootc-passthrough` finished its binds at 07:52:14, 94 seconds after root (its cloud-provider scan runs first).

The bridge is a boot-time *service*, not a filesystem property, and a real user reaches their desktop minutes after boot. The read now polls every 5s under a two-minute deadline. Unchanged: the agent-answered gate (an unreachable agent stays inconclusive, never "data loss") and the layered diagnostic (a genuinely missing bind still fails with the same evidence block).

Also confirmed by that run: the #275 catalog-brand alias works — `building BRANDED installer: bluefin (its catalog carries 'dakota')`.

Pinned in `e2e-failure-ledger.bats`. After merge: re-dispatch the dakota gallery run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_