### PR TITLE
fix(windows): suppress console window for GUI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Build wootc.exe (windows/amd64)
         run: |
           cd app
-          GOOS=windows GOARCH=amd64 go build -tags desktop,production -ldflags "-w -s" -o wootc.exe .
+          GOOS=windows GOARCH=amd64 go build -tags desktop,production -ldflags "-H windowsgui -w -s" -o wootc.exe .
           GOOS=windows GOARCH=amd64 go vet ./...
 
       - name: Build Linux migration dashboard

--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -156,7 +156,7 @@ jobs:
           set -euo pipefail
           ( cd app/frontend && npm ci --silent && npm run build )
           ( cd app && GOOS=windows GOARCH=amd64 \
-              go build -tags desktop,production -ldflags "-w -s" \
+              go build -tags desktop,production -ldflags "-H windowsgui -w -s" \
               -o ../tests/e2e/wootc-files/wootc.exe . )
           ls -lh tests/e2e/wootc-files/wootc.exe
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cd app/frontend && npm ci && npm run build && cd ..
           GOOS=windows GOARCH=amd64 go build -tags desktop,production \
-            -ldflags "-w -s" -o wootc.exe .
+            -ldflags "-H windowsgui -w -s" -o wootc.exe .
           ls -lh wootc.exe
 
       - name: Record what gated this build

--- a/tests/e2e/phase1/run-phase1.sh
+++ b/tests/e2e/phase1/run-phase1.sh
@@ -36,7 +36,7 @@ if [ "$SKIP_BUILD" = false ]; then
     step "Building wootc.exe (frontend + windows/amd64)..."
     (cd "$APP_DIR/frontend" && npm install --silent && npm run build >/dev/null)
     (cd "$APP_DIR" && GOOS=windows GOARCH=amd64 \
-        go build -tags desktop,production -ldflags "-w -s" -o "$FILES_DIR/wootc.exe" .)
+        go build -tags desktop,production -ldflags "-H windowsgui -w -s" -o "$FILES_DIR/wootc.exe" .)
 fi
 [ -f "$FILES_DIR/wootc.exe" ] || fail "wootc.exe not found in $FILES_DIR"
 

--- a/tests/gui/run-cdp.sh
+++ b/tests/gui/run-cdp.sh
@@ -73,7 +73,7 @@ if [ "$SKIP_BUILD" = false ]; then
     step "Building wootc.exe (frontend + windows/amd64)..."
     (cd "$APP_DIR/frontend" && npm install --silent && npm run build >/dev/null)
     (cd "$APP_DIR" && GOOS=windows GOARCH=amd64 \
-        go build -tags desktop,production,native_webview2loader -ldflags "-w -s" -o "$FILES_DIR/wootc.exe" .)
+        go build -tags desktop,production,native_webview2loader -ldflags "-H windowsgui -w -s" -o "$FILES_DIR/wootc.exe" .)
 fi
 [ -f "$FILES_DIR/wootc.exe" ] || fail "wootc.exe not found in $FILES_DIR"
 


### PR DESCRIPTION
Closes tuna-os/wootc#179

Build the Windows Wails application with Go's `windowsgui` linker mode so launching `wootc.exe` does not open a console window before the app window. Apply the flag consistently to CI, release, hosted E2E, and local E2E build paths.

Validation: static checks for all Windows build commands and `git diff --check`.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `88b4e94`
— hive: backend=pi model=openai-codex/gpt-5.6-luna