### PR TITLE
docs: add real hardware test report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/manual-test-report.yml
+++ b/.github/ISSUE_TEMPLATE/manual-test-report.yml
@@ -1,0 +1,120 @@
+name: Real hardware test report
+description: Report a wootc install and recovery run on physical Windows hardware.
+title: "[hardware] "
+labels:
+  - hardware
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing wootc on a real machine. Please do not attach passwords,
+        recovery keys, private keys, or other secrets. See [manual testing](../../docs/manual-testing.md)
+        for the preparation and log-collection steps.
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Hardware
+      description: Vendor, model, CPU architecture, and firmware/BIOS version.
+      placeholder: "Example: Framework 13 AMD, x86_64, UEFI 3.19"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: secure-boot
+    attributes:
+      label: Secure Boot
+      options:
+        - Enabled
+        - Disabled
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: tpm
+    attributes:
+      label: TPM 2.0
+      options:
+        - Present and enabled
+        - Present but disabled
+        - Not present
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network during deploy
+      description: Select Wi-Fi-only when no wired adapter was available.
+      options:
+        - Wired
+        - Wi-Fi only
+        - Offline/preloaded
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: wootc-version
+    attributes:
+      label: wootc version or commit
+      placeholder: "Example: v0.2.0-alpha.1"
+    validations:
+      required: true
+
+  - type: input
+    id: image
+    attributes:
+      label: Image reference
+      placeholder: "Example: ghcr.io/projectbluefin/dakota:stable"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: journey
+    attributes:
+      label: Journey checkpoints
+      options:
+        - label: Installer completed and requested a reboot
+        - label: Linux deployed and reached a login or desktop
+        - label: Windows files were present in Linux
+        - label: Reboot returned to Windows
+        - label: Uninstall completed and restored the machine
+
+  - type: dropdown
+    id: result
+    attributes:
+      label: Overall result
+      options:
+        - Green — full journey passed
+        - Fixed or retried — eventually passed
+        - Red — reproducible failure
+        - Inconclusive — needs maintainer review
+    validations:
+      required: true
+
+  - type: textarea
+    id: symptoms
+    attributes:
+      label: Observed result and symptoms
+      description: Include timestamps, exact messages, and whether the problem reproduced.
+      placeholder: "Describe what happened at each failed checkpoint."
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized evidence
+      description: Attach sanitized logs or a photo of the screen. Remove secrets and recovery keys.
+      placeholder: "List attached files and the relevant log paths/timestamps."
+
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I have a backup and removed passwords, recovery keys, and private keys from attached evidence.
+          required: true

--- a/.github/ISSUE_TEMPLATE/manual-test-report.yml
+++ b/.github/ISSUE_TEMPLATE/manual-test-report.yml
@@ -2,7 +2,7 @@ name: Real hardware test report
 description: Report a wootc install and recovery run on physical Windows hardware.
 title: "[hardware] "
 labels:
-  - hardware
+  - field-report
 body:
   - type: markdown
     attributes:
@@ -12,11 +12,47 @@ body:
         for the preparation and log-collection steps.
 
   - type: input
+    id: build
+    attributes:
+      label: Build or tag tested
+      placeholder: "Example: v0.2.0-alpha.1 or commit SHA"
+    validations:
+      required: true
+
+  - type: input
+    id: brand
+    attributes:
+      label: Brand executable
+      description: Name the exe used, such as wootc.exe, Bluefin-Installer.exe, or Aurora-Installer.exe.
+      placeholder: "Example: Bluefin-Installer.exe"
+    validations:
+      required: true
+
+  - type: input
     id: hardware
     attributes:
       label: Hardware
       description: Vendor, model, CPU architecture, and firmware/BIOS version.
       placeholder: "Example: Framework 13 AMD, x86_64, UEFI 3.19"
+    validations:
+      required: true
+
+  - type: input
+    id: windows
+    attributes:
+      label: Windows version and edition
+      placeholder: "Example: Windows 11 Pro 24H2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: bitlocker
+    attributes:
+      label: BitLocker
+      options:
+        - Off
+        - On
+        - Unknown
     validations:
       required: true
 
@@ -72,10 +108,24 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Furthest journey phase
+      options:
+        - Windows preflight or installer
+        - Deployer boot
+        - First Linux boot
+        - Windows return
+        - Uninstall and restore
+        - Full journey
+    validations:
+      required: true
+
   - type: checkboxes
     id: journey
     attributes:
-      label: Journey checkpoints
+      label: Journey checkpoints completed
       options:
         - label: Installer completed and requested a reboot
         - label: Linux deployed and reached a login or desktop
@@ -95,21 +145,25 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: symptoms
-    attributes:
-      label: Observed result and symptoms
-      description: Include timestamps, exact messages, and whether the problem reproduced.
-      placeholder: "Describe what happened at each failed checkpoint."
-    validations:
-      required: true
-
-  - type: textarea
+  - type: checkboxes
     id: logs
     attributes:
-      label: Sanitized evidence
-      description: Attach sanitized logs or a photo of the screen. Remove secrets and recovery keys.
-      placeholder: "List attached files and the relevant log paths/timestamps."
+      label: Evidence collected
+      description: Check each item attached or pasted below. Remove secrets and recovery keys.
+      options:
+        - label: Installer log and state (`C:\\wootc\\logs\\` and `C:\\wootc\\install\\state.json`)
+        - label: Deployer log (`C:\\wootc\\logs\\deployer.log`)
+        - label: Deployer journal snapshot (`C:\\wootc\\logs\\deployer-last-journal.log`)
+        - label: Photo or screenshot of what the screen said
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Sanitized evidence and symptoms
+      description: Include timestamps, exact messages, links to attachments, and whether the problem reproduced.
+      placeholder: "Describe what happened and list attached files. Never include passwords, recovery keys, or private keys."
+    validations:
+      required: true
 
   - type: checkboxes
     id: safety

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -58,7 +58,9 @@ in the pipeline) one one-time boot entry — and a failure or cancel removes
 the boot entry again. A failed deploy boot returns to Windows by itself
 after 30 seconds.
 
-Collect, in this order, and attach to a GitHub issue:
+Collect, in this order, and attach to a GitHub issue. The
+[real hardware test report form](../.github/ISSUE_TEMPLATE/manual-test-report.yml)
+asks for each item and records the machine details needed to triage it:
 
 | What | Where |
 |---|---|


### PR DESCRIPTION
Relates to tuna-os/wootc#210

Complete the M2.1 field-report form with the specified build/tag, brand executable, Windows edition, BitLocker state, furthest phase, journey checkpoints, and four evidence-path checkboxes. Link the form from the manual hardware testing guide so testers can file a complete triage report without follow-up questions.

Validation: form/docs structure checks, `bash -n tests/run.sh`, and `git diff --check`.

---
🐝 **Hive Agent**: `contributor` | **SHA:** `ea3c50a`
— hive: backend=pi model=openai-codex/gpt-5.6-luna