### PR TITLE
fix(windows): suppress console window on launch and attach parent console for headless CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Build wootc.exe (windows/amd64)
         run: |
           cd app
-          GOOS=windows GOARCH=amd64 go build -tags desktop,production -ldflags "-w -s" -o wootc.exe .
+          GOOS=windows GOARCH=amd64 go build -tags desktop,production -ldflags "-H windowsgui -w -s" -o wootc.exe .
           GOOS=windows GOARCH=amd64 go vet ./...
 
       - name: Build Linux migration dashboard

--- a/.github/workflows/e2e-hosted.yml
+++ b/.github/workflows/e2e-hosted.yml
@@ -156,7 +156,7 @@ jobs:
           set -euo pipefail
           ( cd app/frontend && npm ci --silent && npm run build )
           ( cd app && GOOS=windows GOARCH=amd64 \
-              go build -tags desktop,production -ldflags "-w -s" \
+              go build -tags desktop,production -ldflags "-H windowsgui -w -s" \
               -o ../tests/e2e/wootc-files/wootc.exe . )
           ls -lh tests/e2e/wootc-files/wootc.exe
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           cd app/frontend && npm ci && npm run build && cd ..
           GOOS=windows GOARCH=amd64 go build -tags desktop,production \
-            -ldflags "-w -s" -o wootc.exe .
+            -ldflags "-H windowsgui -w -s" -o wootc.exe .
           ls -lh wootc.exe
 
       - name: Record what gated this build

--- a/app/console_other.go
+++ b/app/console_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func attachParentConsole() {}

--- a/app/console_windows.go
+++ b/app/console_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// attachParentConsole attaches the process to the console of its parent process.
+// When wootc is compiled with -ldflags "-H windowsgui", Windows does not allocate
+// a console window on launch. For headless CLI subcommands (install, status, uninstall)
+// invoked from an existing terminal (e.g. PowerShell, cmd.exe), attaching to the
+// parent console enables stdout/stderr to print directly to that terminal.
+func attachParentConsole() {
+	modkernel32 := syscall.NewLazyDLL("kernel32.dll")
+	procAttachConsole := modkernel32.NewProc("AttachConsole")
+
+	// ATTACH_PARENT_PROCESS is (DWORD)-1
+	const attachParentProcess = ^uintptr(0)
+	r1, _, _ := procAttachConsole.Call(attachParentProcess)
+	if r1 == 0 {
+		return
+	}
+
+	hStdout, err := windows.GetStdHandle(windows.STD_OUTPUT_HANDLE)
+	if err == nil && hStdout != windows.InvalidHandle {
+		os.Stdout = os.NewFile(uintptr(hStdout), "/dev/stdout")
+	}
+	hStderr, err := windows.GetStdHandle(windows.STD_ERROR_HANDLE)
+	if err == nil && hStderr != windows.InvalidHandle {
+		os.Stderr = os.NewFile(uintptr(hStderr), "/dev/stderr")
+	}
+	hStdin, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
+	if err == nil && hStdin != windows.InvalidHandle {
+		os.Stdin = os.NewFile(uintptr(hStdin), "/dev/stdin")
+	}
+}

--- a/app/headless.go
+++ b/app/headless.go
@@ -28,6 +28,7 @@ func isHeadlessInvocation(args []string) bool {
 // runHeadless dispatches the CLI subcommand and returns the process exit
 // code. It never launches the webview.
 func runHeadless(args []string) int {
+	attachParentConsole()
 	switch args[1] {
 	case "install":
 		return headlessInstall(args[2:])

--- a/tests/e2e/phase1/run-phase1.sh
+++ b/tests/e2e/phase1/run-phase1.sh
@@ -36,7 +36,7 @@ if [ "$SKIP_BUILD" = false ]; then
     step "Building wootc.exe (frontend + windows/amd64)..."
     (cd "$APP_DIR/frontend" && npm install --silent && npm run build >/dev/null)
     (cd "$APP_DIR" && GOOS=windows GOARCH=amd64 \
-        go build -tags desktop,production -ldflags "-w -s" -o "$FILES_DIR/wootc.exe" .)
+        go build -tags desktop,production -ldflags "-H windowsgui -w -s" -o "$FILES_DIR/wootc.exe" .)
 fi
 [ -f "$FILES_DIR/wootc.exe" ] || fail "wootc.exe not found in $FILES_DIR"
 

--- a/tests/gui/run-cdp.sh
+++ b/tests/gui/run-cdp.sh
@@ -28,6 +28,11 @@
 # but exposes no CDP endpoint. The native tag switches to Microsoft's
 # official loader, which honors the env var.
 #
+# Process behavior note: wootc.exe is linked with -H windowsgui so GUI launches
+# never flash or allocate a console window. Headless subcommands attach to the
+# parent console if present. In CDP mode, launching via `start "" C:\wootc\wootc.exe`
+# runs without a console window.
+#
 # Prerequisites: a running wootc-e2e-windows container on the host
 # (run-e2e.sh --keep) with QGA responsive and the "wootc" user logged on;
 # node+go here for the build (or --skip-build with a staged wootc.exe).
@@ -73,7 +78,7 @@ if [ "$SKIP_BUILD" = false ]; then
     step "Building wootc.exe (frontend + windows/amd64)..."
     (cd "$APP_DIR/frontend" && npm install --silent && npm run build >/dev/null)
     (cd "$APP_DIR" && GOOS=windows GOARCH=amd64 \
-        go build -tags desktop,production,native_webview2loader -ldflags "-w -s" -o "$FILES_DIR/wootc.exe" .)
+        go build -tags desktop,production,native_webview2loader -ldflags "-H windowsgui -w -s" -o "$FILES_DIR/wootc.exe" .)
 fi
 [ -f "$FILES_DIR/wootc.exe" ] || fail "wootc.exe not found in $FILES_DIR"
 


### PR DESCRIPTION
Closes tuna-os/wootc#219
Closes tuna-os/wootc#179

### Summary of Changes
- **Console window suppression for GUI launches**: Added `-ldflags "-H windowsgui -w -s"` to Windows build targets across CI workflows (`ci.yml`, `e2e-hosted.yml`, `release.yml`) and E2E test build scripts (`run-phase1.sh`, `run-cdp.sh`).
- **Parent console attachment for headless CLI**: Implemented `attachParentConsole()` using `AttachConsole(ATTACH_PARENT_PROCESS)` and handle redirection so headless subcommands (`wootc.exe install`, `wootc.exe status`, `wootc.exe uninstall`) continue to write to stdout/stderr when invoked from a terminal (PowerShell, Command Prompt, etc.).
- **E2E CDP note**: Added documentation note to `tests/gui/run-cdp.sh` regarding the `-H windowsgui` behavior.

### Validation
- Validated fast test tier (`bash tests/run.sh fast`) passing.
- Validated cross-compilation for Windows (`GOOS=windows GOARCH=amd64 go build -tags desktop,production -ldflags "-H windowsgui -w -s"`) and `go vet`.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `451a032`