### PR TITLE
app: fallback accounts for non-Latin profiles and exclude localized built-ins

### DIFF
--- a/app/profiles.go
+++ b/app/profiles.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -39,10 +40,48 @@ import (
 // after first boot but very often leaves the directory (with an NTUSER.DAT)
 // behind on OEM machines — exactly the empty stranger on the login screen
 // this list exists to prevent.
+//
+// In addition to English built-ins, localized names of Administrator, Guest,
+// and DefaultAccount for major Windows locales (French, German, Spanish,
+// Italian, Portuguese, Russian, Polish, Dutch, Swedish, Turkish, Chinese,
+// Japanese, Korean, Ukrainian, Czech, Hungarian, etc.) are included (#197).
 var systemProfiles = map[string]bool{
 	"public": true, "default": true, "default user": true,
 	"all users": true, "defaultaccount": true, "wdagutilityaccount": true,
-	"administrator": true, "defaultuser0": true,
+	"administrator": true, "defaultuser0": true, "guest": true,
+
+	// French
+	"administrateur": true, "invité": true, "invite": true, "compte par défaut": true, "compte par defaut": true,
+	// German
+	"gast": true, "standardkonto": true,
+	// Spanish
+	"administrador": true, "invitado": true, "cuenta predeterminada": true,
+	// Italian
+	"amministratore": true, "ospite": true, "account predefinito": true,
+	// Portuguese
+	"convidado": true, "conta padrão": true, "conta padrao": true,
+	// Russian
+	"администратор": true, "гость": true, "стандартная учетная запись": true,
+	// Ukrainian
+	"адміністратор": true, "гість": true, "стандартний обліковий запис": true,
+	// Polish
+	"gość": true, "gosc": true, "konto domyślne": true, "konto domyslne": true,
+	// Dutch
+	"beheerder": true, "gastaccount": true, "standaardaccount": true,
+	// Swedish
+	"gäst": true, "gastkonto": true, "standardkontoet": true,
+	// Turkish
+	"yönetici": true, "yonetici": true, "konuk": true, "varsayılan hesap": true, "varsayilan hesap": true,
+	// Chinese (Simplified & Traditional)
+	"管理员": true, "管理員": true, "来宾": true, "來賓": true, "默认帐户": true, "預設帳戶": true, "預設帳號": true,
+	// Japanese
+	"管理者": true, "ゲスト": true, "既定のアカウント": true,
+	// Korean
+	"관리자": true, "손님": true, "기본 계정": true,
+	// Czech
+	"správce": true, "spravce": true, "výchozí účet": true, "vychozi ucet": true,
+	// Hungarian
+	"rendszergazda": true, "vendég": true, "vendeg": true, "alapértelmezett fiók": true, "alapertelmezett fiok": true,
 }
 
 // profileMapping ties a Windows profile directory (the basename under
@@ -65,17 +104,35 @@ type profileMapping struct {
 // bridge matches on the DIRECTORY name under Users\, so anything the registry
 // reported that did not correspond to a directory would produce an account
 // with no data to bind — an empty stranger on the login screen.
+//
+// Profiles whose names sanitize to empty (e.g. non-Latin scripts like "田中"
+// or "Иван") or collide with existing accounts after truncation receive
+// generated fallback accounts ("winuser1", "winuser2", ...) so that no user's
+// data is silently dropped (#197, #224).
 func listProfilesIn(usersDir, primary, primaryDir string) []profileMapping {
 	entries, err := os.ReadDir(usersDir)
 	if err != nil {
 		return nil
 	}
 
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
 	seen := map[string]bool{}
 	if primary != "" {
 		seen[primary] = true
 	}
 	var out []profileMapping
+
+	fallbackIdx := 1
+	nextFallbackUser := func() string {
+		for {
+			cand := fmt.Sprintf("winuser%d", fallbackIdx)
+			fallbackIdx++
+			if !seen[cand] {
+				return cand
+			}
+		}
+	}
 
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -95,8 +152,11 @@ func listProfilesIn(usersDir, primary, primaryDir string) []profileMapping {
 			continue
 		}
 		linux := sanitizeUsername(name)
-		if linux == "" || seen[linux] {
+		if linux == primary {
 			continue
+		}
+		if linux == "" || seen[linux] {
+			linux = nextFallbackUser()
 		}
 		seen[linux] = true
 		out = append(out, profileMapping{WindowsDir: name, LinuxUser: linux})

--- a/app/profiles_test.go
+++ b/app/profiles_test.go
@@ -83,3 +83,86 @@ func TestListWindowsProfilesNoUsersDir(t *testing.T) {
 		t.Errorf("got %v, want nil when there is no Users directory", got)
 	}
 }
+
+// Non-Latin profiles (CJK, Cyrillic) and collisions after truncation must
+// receive winuserN fallback accounts instead of being silently dropped (#197, #224).
+func TestListWindowsProfilesNonLatinAndCollisionFallbacks(t *testing.T) {
+	users := filepath.Join(t.TempDir(), "Users")
+	createProfile := func(name string) {
+		d := filepath.Join(users, name)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "NTUSER.DAT"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	createProfile("田中")                               // CJK: sanitizes to "" -> winuser1
+	createProfile("Иван")                             // Cyrillic: sanitizes to "" -> winuser2
+	createProfile("very-long-profile-name-that-truncates-1111") // truncates to 32 chars
+	createProfile("very-long-profile-name-that-truncates-2222") // collides on same 32 chars -> winuser3
+
+	got := listProfilesIn(users, "primary", "PrimaryUser")
+
+	want := []profileMapping{
+		{WindowsDir: "very-long-profile-name-that-truncates-1111", LinuxUser: "very-long-profile-name-that-trun"},
+		{WindowsDir: "very-long-profile-name-that-truncates-2222", LinuxUser: "winuser1"},
+		{WindowsDir: "Иван", LinuxUser: "winuser2"},
+		{WindowsDir: "田中", LinuxUser: "winuser3"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d profiles (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("[%d] got %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+// Localized built-in system accounts (Administrator, Guest, DefaultAccount in
+// French, German, Spanish, Russian, Chinese, Japanese, etc.) must not become
+// login-screen accounts (#197, #224).
+func TestListWindowsProfilesLocalizedBuiltinsExcluded(t *testing.T) {
+	users := filepath.Join(t.TempDir(), "Users")
+	createProfile := func(name string) {
+		d := filepath.Join(users, name)
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "NTUSER.DAT"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Built-in accounts across locales
+	createProfile("Administrateur")           // French Admin
+	createProfile("Invité")                   // French Guest
+	createProfile("Gast")                     // German Guest
+	createProfile("Administrador")            // Spanish Admin
+	createProfile("Invitado")                 // Spanish Guest
+	createProfile("Администратор")            // Russian Admin
+	createProfile("Гость")                    // Russian Guest
+	createProfile("管理员")                    // Chinese Admin
+	createProfile("管理者")                    // Japanese Admin
+	createProfile("ゲスト")                    // Japanese Guest
+	createProfile("Guest")                    // English Guest
+	createProfile("All Users")                // English Builtin
+
+	// A real user
+	createProfile("realuser")
+
+	got := listProfilesIn(users, "admin", "admin")
+	want := []profileMapping{
+		{WindowsDir: "realuser", LinuxUser: "realuser"},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v (all localized built-ins must be excluded)", got, want)
+	}
+	if got[0] != want[0] {
+		t.Fatalf("got %v, want %v", got[0], want[0])
+	}
+}


### PR DESCRIPTION
## Summary

Addresses #224 (M3.3 — Non-Latin profile names get fallback accounts; localized built-ins excluded):

1. **Non-Latin profiles & collision fallbacks**: In `app/profiles.go`, profiles whose names sanitize to empty (such as CJK `田中` or Cyrillic `Иван`) or collide after 32-character truncation now receive deterministic generated fallback accounts (`winuser1`, `winuser2`, ...) rather than being dropped, fulfilling the all-data-migrated promise of #16.
2. **Localized built-in system account exclusions**: Expanded `systemProfiles` to exclude localized Administrator, Guest, and DefaultAccount names across major Windows locales (French, German, Spanish, Italian, Portuguese, Russian, Ukrainian, Polish, Dutch, Swedish, Turkish, Chinese, Japanese, Korean, Czech, Hungarian) so they do not become locked login-screen accounts.
3. **Unit tests**: Added unit test coverage in `app/profiles_test.go` covering CJK, Cyrillic, 32-character truncation collision fallbacks, and localized built-in exclusion across multiple locales.

Fixes #224

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6039555`