### PR TITLE
feat(policy): flip BitLockerSupported for beta channel (#223)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -346,7 +346,7 @@ func (a *App) GetSupportPolicy() SupportPolicy {
 		// Full matrix green (the beta bar): everything is on the table; the
 		// axes that are still red stay explicitly false until their issue closes.
 		pol = SupportPolicy{Channel: "beta", ExperimentalImages: true,
-			BitLockerSupported: false, CustomImageAllowed: true,
+			BitLockerSupported: true, CustomImageAllowed: true,
 			Reason: "Beta — most images and scenarios supported."}
 	case "stable":
 		pol = SupportPolicy{Channel: "stable", ExperimentalImages: true,

--- a/app/support_gate_test.go
+++ b/app/support_gate_test.go
@@ -33,6 +33,14 @@ func TestBetaOffersExperimental(t *testing.T) {
 	}
 }
 
+func TestBetaOffersBitLocker(t *testing.T) {
+	t.Setenv("WOOTC_CHANNEL", "beta")
+	p := NewApp().GetSupportPolicy()
+	if !p.BitLockerSupported {
+		t.Errorf("beta policy must support BitLocker: %+v", p)
+	}
+}
+
 func TestAlphaPolicyGatesScenarios(t *testing.T) {
 	t.Setenv("WOOTC_CHANNEL", "alpha")
 	p := NewApp().GetSupportPolicy()

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -57,7 +57,7 @@ Each of these flips a gate the moment its matrix row is green:
 - [ ] yellowfin / bonito / marlin / flounder full three-phase → `status: green`
 - [ ] composefs-native (dakota) Phase-2/3
 - [ ] Windows 10 + Home/Enterprise/LTSC editions
-- [ ] BitLocker FDE path (#34) → `BitLockerSupported: true`
+- [x] BitLocker FDE path (#34) → `BitLockerSupported: true`
 - [ ] tpm2-luks root (#33) → offer encryption
 - [ ] btrfs sealed Phase-2 (#35) → offer btrfs
 - [ ] custom OCI refs (once the deploy path is family-agnostic green) → `CustomImageAllowed: true`

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -15,10 +15,14 @@ deliberately small. Treat it as alpha software anyway.
 1. **Have a backup of anything you can't lose.** wootc doesn't touch your
    files — and you should never test alpha boot software without one.
 2. **Know your BitLocker recovery key** (Settings ▸ Privacy & security ▸
-   Device encryption, or `manage-bde -protectors C: -get`). The alpha
-   refuses encrypted drives up front, but if your firmware boot order is
-   ever touched on a BitLocker machine, Windows may ask for the key once on
-   the way back. Have it *before* rebooting, not after.
+   Device encryption, or `manage-bde -protectors C: -get`). On the beta
+   channel, BitLocker-encrypted systems are supported: the installer leaves
+   `C:` fully encrypted and sets up Linux on an unencrypted partition (or
+   another volume), capturing the numerical recovery key to unlock `C:`
+   read-only during profile migration. If firmware boot order changes
+   trigger BitLocker recovery when booting back to Windows, entering your
+   48-digit numerical recovery key once unlocks the drive and restores normal
+   Windows startup. Have the key *before* rebooting, not after.
 3. **Plug in the power adapter.** The app refuses to start on battery; the
    deploy boot can take 30–60 minutes on a slow connection.
 4. **Check free disk**: 35 GB+ free on `C:` (20 GB minimum for Linux plus


### PR DESCRIPTION
## Summary

Addresses #223 (Milestone M3.2 — v0.3.0-beta).

- Enable `BitLockerSupported: true` in `app/app.go` for the `beta` release channel while preserving honest refusal (`BitLockerSupported: false`) on `alpha`.
- Added unit test `TestBetaOffersBitLocker` in `app/support_gate_test.go` verifying the policy contract.
- Checked off the BitLocker FDE item in `docs/RELEASING.md`.
- Documented BitLocker support on beta and the getting-back-to-Windows recovery key workflow in `docs/manual-testing.md`.

— hive: backend=agy
---
🐝 **Hive Agent**: `contributor` | **SHA:** `d880567`