### PR TITLE
Add .golangci.yml and codecov.yml

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+version: "2"
+
+linters:
+  default: standard

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 45%
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+        informational: true
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary

- Adds `.golangci.yml` (v2 schema, `standard` preset), satisfying the ACMM L0 "code style config" prerequisite (`acmm:prereq-code-style`). This repo's core product (`app/*.go`, the Windows/Linux migration tool) is Go — CI already runs `go vet` but has no lint config. Verified locally: `golangci-lint run ./...` (GOOS=windows, matching how `app` is actually built) loads this config and runs cleanly, surfacing only pre-existing findings in application code (mostly unchecked `Close()` errors and a couple of capitalized error strings), which are left as-is per the usual scope for this kind of change.
- Adds `codecov.yml`, satisfying the ACMM L0 "coverage gate" prerequisite (`acmm:prereq-coverage-gate`), in the same style already used elsewhere in the org (e.g. `tuna-os/bootc-installer`). `patch.default.informational` stays `true` since there's no coverage-producing CI step yet.

Closes #306
Closes #307