### PR TITLE
app: derive human identity under UAC and gate volume removal on label (#225)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -223,6 +223,22 @@ func sanitizeHostname(name string) string {
 	return out
 }
 
+// deriveHumanUsername derives the machine's human user for Linux account creation (#197, #225).
+// When running elevated under over-the-shoulder UAC, user.Current() gives the
+// elevating admin. We resolve the user in order of preference:
+//  1. Environment variables passed across the elevation boundary (e.g. WOOTC_ORIGINAL_USER)
+//  2. The interactive desktop user (e.g. Win32_ComputerSystem.UserName / explorer.exe owner)
+//  3. The current process user (fallback)
+func deriveHumanUsername(envUser, interactiveUser, currentUser string) string {
+	if s := sanitizeUsername(envUser); s != "" {
+		return s
+	}
+	if s := sanitizeUsername(interactiveUser); s != "" {
+		return s
+	}
+	return suggestUsername(currentUser)
+}
+
 // suggestUsername and suggestHostname wrap the sanitisers with the fallbacks
 // the bare-minimum launchpad contract requires: identity must ALWAYS derive,
 // because a derived identity is what keeps those fields under Advanced and
@@ -246,6 +262,15 @@ func suggestHostname(raw string) string {
 		return b
 	}
 	return "tunaos"
+}
+
+// DedicatedVolumeLabel is the required filesystem label for a wootc-created partition (#197, #225).
+const DedicatedVolumeLabel = "wootc-data"
+
+// isDedicatedVolume reports whether a volume with the given non-system items count
+// and filesystem label belongs to wootc and is safe to remove.
+func isDedicatedVolume(itemsCount int, label string) bool {
+	return itemsCount == 0 && strings.EqualFold(strings.TrimSpace(label), DedicatedVolumeLabel)
 }
 
 // DataPartition is a candidate unencrypted volume for root.disk.
@@ -662,6 +687,7 @@ type UninstallInfo struct {
 	DiskSizeGB     float64 `json:"diskSizeGB"`
 	OnDedicatedVol bool    `json:"onDedicatedVol"` // wootc-created data partition
 	ReclaimGB      float64 `json:"reclaimGB"`      // space freed if the volume is removed
+	VolumeLabel    string  `json:"volumeLabel,omitempty"` // verified volume label (e.g. "wootc-data")
 	// Orphaned: no root.disk anywhere, but leftover boot arming (bcd-guid /
 	// state.json) exists — the "user deleted the folder by hand" case, which
 	// previously had NO GUI path to clean up the boot entry.

--- a/app/disk_windows.go
+++ b/app/disk_windows.go
@@ -55,21 +55,29 @@ func listDataPartitions() []DataPartition {
 // is safe to remove and fold back into C:) and how much space that frees.
 func dedicatedVolumeInfo(d string) (bool, float64) {
 	// A wootc-created volume is labeled "wootc-data" and contains nothing
-	// but the wootc dir (ignoring system folders).
+	// but the wootc dir (ignoring system folders) (#197, #225).
 	out, err := runPowerShellOutput(fmt.Sprintf(
 		`$items = @(Get-ChildItem '%s:\' -Force -ErrorAction SilentlyContinue | Where-Object { `+
 			`$_.Name -notin @('$RECYCLE.BIN','System Volume Information','wootc') }); `+
 			`$v = Get-Volume -DriveLetter %s -ErrorAction SilentlyContinue; `+
-			`'{0}|{1}' -f $items.Count, [math]::Round($v.Size/1GB,1)`, d, d))
+			`'{0}|{1}|{2}' -f $items.Count, [math]::Round($v.Size/1GB,1), $(if ($v) { $v.FileSystemLabel } else { '' })`, d, d))
 	if err != nil {
 		return false, 0
 	}
 	f := strings.Split(strings.TrimSpace(out), "|")
-	if len(f) != 2 {
+	if len(f) < 2 {
 		return false, 0
 	}
+	label := ""
+	if len(f) >= 3 {
+		label = f[2]
+	}
 	sizeGB, _ := strconv.ParseFloat(f[1], 64)
-	return f[0] == "0", sizeGB
+	itemsCount, err := strconv.Atoi(strings.TrimSpace(f[0]))
+	if err != nil {
+		return false, 0
+	}
+	return isDedicatedVolume(itemsCount, label), sizeGB
 }
 
 // CreateDataPartition shrinks C: and creates a new unencrypted NTFS
@@ -115,10 +123,12 @@ Write-Output $np.DriveLetter`, sizeGB)
 func removePartitionAndExtendC(drive string) error {
 	script := fmt.Sprintf(`
 $ErrorActionPreference = 'Stop'
+$v = Get-Volume -DriveLetter %s -ErrorAction SilentlyContinue
+if (-not $v -or $v.FileSystemLabel -ne '%s') { throw "Partition %s: does not have the '%s' label" }
 $p = Get-Partition -DriveLetter %s
 Remove-Partition -DriveLetter %s -Confirm:$false
 $supported = Get-PartitionSupportedSize -DriveLetter C
-Resize-Partition -DriveLetter C -Size $supported.SizeMax`, drive, drive)
+Resize-Partition -DriveLetter C -Size $supported.SizeMax`, drive, DedicatedVolumeLabel, drive, DedicatedVolumeLabel, drive, drive)
 	out, err := runPowerShellOutput(script)
 	if err != nil {
 		return fmt.Errorf("%w (output: %s)", err, strings.TrimSpace(out))

--- a/app/frontend/src/screens/control.js
+++ b/app/frontend/src/screens/control.js
@@ -82,8 +82,9 @@ export function renderControlPanel() {
   opts.appendChild(checkbox('deleteRootDisk', 'Also delete my Linux data',
     'Removes root.disk. Your Linux files are permanently deleted. Leave unchecked to keep them for later.', true));
   if (u.onDedicatedVol && u.reclaimGB) {
+    const label = u.volumeLabel || 'wootc-data';
     opts.appendChild(checkbox('removePartition', `Give the ${Math.round(u.reclaimGB)} GB back to Windows`,
-      `Removes the wootc-data drive (${u.storageDrive}:) and extends C: into the freed space.`, false));
+      `Removes the ${label} drive (${u.storageDrive}:) and extends C: into the freed space.`, false));
   }
   screen.appendChild(opts);
 
@@ -121,10 +122,14 @@ export function renderControlPanel() {
 
 async function confirmUninstall() {
   const o = state.uninstallOpts || {};
+  const u = state.uninstallInfo || {};
   let msg = `Remove ${distroName()}?\n\nThis removes the boot entry, the ESP files, and the deployer files.`;
   if (o.deleteRootDisk) msg += '\n\n⚠ Your Linux data (root.disk) will be permanently deleted.';
   else msg += '\n\nYour Linux data (root.disk) will be kept.';
-  if (o.removePartition) msg += '\n⚠ The wootc-data drive will be removed and its space returned to C:.';
+  if (o.removePartition) {
+    const label = u.volumeLabel || 'wootc-data';
+    msg += `\n⚠ The ${label} drive (${u.storageDrive || 'D'}:) will be removed and its space returned to C:.`;
+  }
   if (!confirm(msg)) return;
   try {
     await UninstallWith({ deleteRootDisk: !!o.deleteRootDisk, removePartition: !!o.removePartition });

--- a/app/hostname_test.go
+++ b/app/hostname_test.go
@@ -133,3 +133,143 @@ func TestSuggestIdentityNeverEmpty(t *testing.T) {
 		t.Errorf("suggestHostname(empty) = %q, want the brand name", got)
 	}
 }
+
+// #197 / #225: Under over-the-shoulder UAC, user.Current() is the elevating
+// admin. deriveHumanUsername must derive the machine's human user rather than
+// the admin, preferring explicit elevation-boundary environment variables, then
+// the interactive desktop session owner (Win32_ComputerSystem.UserName /
+// explorer.exe process owner), falling back to the current process user.
+func TestDeriveHumanUsernameUAC(t *testing.T) {
+	cases := []struct {
+		name            string
+		envUser         string
+		interactiveUser string
+		currentUser     string
+		want            string
+	}{
+		{
+			name:            "standard UAC: interactive human preferred over elevating admin",
+			envUser:         "",
+			interactiveUser: `CORP\Alice`,
+			currentUser:     `LocalAdmin`,
+			want:            "alice",
+		},
+		{
+			name:            "elevation environment variable takes highest precedence",
+			envUser:         "Bob Smith",
+			interactiveUser: `CORP\Alice`,
+			currentUser:     `LocalAdmin`,
+			want:            "bob-smith",
+		},
+		{
+			name:            "fallback to current user when interactive user is unavailable",
+			envUser:         "",
+			interactiveUser: "",
+			currentUser:     `LocalAdmin`,
+			want:            "localadmin",
+		},
+		{
+			name:            "fallback to winuser when all signals are empty or invalid",
+			envUser:         "",
+			interactiveUser: "",
+			currentUser:     "",
+			want:            "winuser",
+		},
+		{
+			name:            "interactive user with domain stripped",
+			envUser:         "",
+			interactiveUser: `WORKGROUP\charlie`,
+			currentUser:     `Administrator`,
+			want:            "charlie",
+		},
+		{
+			name:            "interactive user with email/AzureAD stripped",
+			envUser:         "",
+			interactiveUser: `MicrosoftAccount\dana@example.com`,
+			currentUser:     `LocalAdmin`,
+			want:            "dana",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveHumanUsername(tc.envUser, tc.interactiveUser, tc.currentUser)
+			if got != tc.want {
+				t.Errorf("deriveHumanUsername(%q, %q, %q) = %q, want %q",
+					tc.envUser, tc.interactiveUser, tc.currentUser, got, tc.want)
+			}
+		})
+	}
+}
+
+// #197 / #225: dedicatedVolumeInfo and removePartitionAndExtendC must require
+// the "wootc-data" volume label before claiming ownership of a partition. An
+// empty personal partition without the label must return false so RemovePartition
+// is never offered and user data cannot be destroyed.
+func TestDedicatedVolumeLabelGate(t *testing.T) {
+	cases := []struct {
+		name       string
+		itemsCount int
+		label      string
+		want       bool
+	}{
+		{
+			name:       "valid wootc partition with exact label and 0 extra items",
+			itemsCount: 0,
+			label:      "wootc-data",
+			want:       true,
+		},
+		{
+			name:       "case-insensitive label matching",
+			itemsCount: 0,
+			label:      "WOOTC-DATA",
+			want:       true,
+		},
+		{
+			name:       "label with surrounding whitespace",
+			itemsCount: 0,
+			label:      "  wootc-data  ",
+			want:       true,
+		},
+		{
+			name:       "empty personal partition without label must not be claimed",
+			itemsCount: 0,
+			label:      "",
+			want:       false,
+		},
+		{
+			name:       "empty personal partition with user label must not be claimed",
+			itemsCount: 0,
+			label:      "Personal",
+			want:       false,
+		},
+		{
+			name:       "empty partition labeled Data must not be claimed",
+			itemsCount: 0,
+			label:      "Data",
+			want:       false,
+		},
+		{
+			name:       "partition with wootc-data label but extraneous files must not be claimed",
+			itemsCount: 1,
+			label:      "wootc-data",
+			want:       false,
+		},
+		{
+			name:       "partition with wrong label and files must not be claimed",
+			itemsCount: 3,
+			label:      "Backup",
+			want:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isDedicatedVolume(tc.itemsCount, tc.label)
+			if got != tc.want {
+				t.Errorf("isDedicatedVolume(%d, %q) = %v, want %v",
+					tc.itemsCount, tc.label, got, tc.want)
+			}
+		})
+	}
+}

--- a/app/installer_windows.go
+++ b/app/installer_windows.go
@@ -30,13 +30,15 @@ func getSystemInfo() SystemInfo {
 	info.SuggestedHostname = suggestHostname(rawHost)
 	// Same idea for the account name, so the launchpad can collect only a
 	// password by default instead of asking the user to invent an identity
-	// they already have. os/user gives DOMAIN\User on Windows; the sanitiser
-	// takes the account part.
-	var rawUser string
+	// they already have. Under over-the-shoulder UAC, user.Current() is the
+	// elevating admin — derive the machine's interactive human instead (#197, #225).
+	envUser := getElevationEnvUser()
+	interactiveUser := queryInteractiveUser()
+	var currentUser string
 	if u, err := user.Current(); err == nil {
-		rawUser = u.Username
+		currentUser = u.Username
 	}
-	info.SuggestedUsername = suggestUsername(rawUser)
+	info.SuggestedUsername = deriveHumanUsername(envUser, interactiveUser, currentUser)
 
 	// OS version
 	v := windows.RtlGetVersion()
@@ -169,6 +171,9 @@ func getUninstallInfo() UninstallInfo {
 			}
 			if d != "C" {
 				info.OnDedicatedVol, info.ReclaimGB = dedicatedVolumeInfo(d)
+				if info.OnDedicatedVol {
+					info.VolumeLabel = DedicatedVolumeLabel
+				}
 			}
 			return info
 		}
@@ -324,3 +329,48 @@ func rebootWindows() error {
 		"/c", effectiveBranding().ProductName+" is rebooting to start the installer")
 	return err
 }
+
+// ── Interactive user derivation (over-the-shoulder UAC) ───────────────────────
+
+func getElevationEnvUser() string {
+	for _, env := range []string{"WOOTC_ORIGINAL_USER", "WOOTC_INTERACTIVE_USER"} {
+		if val := strings.TrimSpace(os.Getenv(env)); val != "" {
+			return val
+		}
+	}
+	return ""
+}
+
+func queryInteractiveUser() string {
+	// Under over-the-shoulder UAC, user.Current() gives the elevating admin.
+	// Win32_ComputerSystem.UserName or explorer.exe process owner identifies
+	// the interactive desktop user (#197, #225).
+	psScript := `$u = (Get-CimInstance Win32_ComputerSystem -ErrorAction SilentlyContinue).UserName
+if (-not $u) { $u = (Get-WmiObject Win32_ComputerSystem -ErrorAction SilentlyContinue).UserName }
+if (-not $u) {
+    $exp = Get-CimInstance Win32_Process -Filter "Name = 'explorer.exe'" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($exp) {
+        $owner = Invoke-CimMethod -InputObject $exp -MethodName GetOwner -ErrorAction SilentlyContinue
+        if ($owner -and $owner.User) {
+            if ($owner.Domain) { $u = "$($owner.Domain)\$($owner.User)" } else { $u = $owner.User }
+        }
+    }
+}
+if (-not $u) {
+    $exp = Get-WmiObject Win32_Process -Filter "name='explorer.exe'" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($exp) {
+        $o = $exp.GetOwner()
+        if ($o -and $o.User) {
+            if ($o.Domain) { $u = "$($o.Domain)\$($o.User)" } else { $u = $o.User }
+        }
+    }
+}
+if ($u) { Write-Output $u }`
+
+	out, err := runPowerShellOutput(psScript)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+

--- a/tests/e2e/phase1/assert-phase1.ps1
+++ b/tests/e2e/phase1/assert-phase1.ps1
@@ -22,6 +22,12 @@ Assert-True ($stateRaw -match '"state":\s*"armed"') "state.json reports armed"
 # ── root disk ────────────────────────────────────────────────────────────────
 Assert-True (Test-Path C:\wootc\disks\root.vhdx) "root.vhdx exists"
 
+# ── dedicated volume label (when separate Linux data partition exists) ───────
+$dataVol = Get-Volume | Where-Object { $_.DriveType -eq 'Fixed' -and $_.DriveLetter -and $_.DriveLetter -ne 'C' -and (Test-Path "$($_.DriveLetter):\wootc") } | Select-Object -First 1
+if ($dataVol) {
+    Assert-True ($dataVol.FileSystemLabel -eq "wootc-data") "dedicated data partition has label 'wootc-data' (found '$($dataVol.FileSystemLabel)')"
+}
+
 # ── vault ────────────────────────────────────────────────────────────────────
 $vault = Get-Content C:\wootc\install\vault.json -Raw -ErrorAction SilentlyContinue
 Assert-True ($null -ne $vault) "vault.json exists"

--- a/tests/gui/gui.spec.js
+++ b/tests/gui/gui.spec.js
@@ -82,13 +82,41 @@ test('installer — done screen', async ({ page }) => {
 test('control panel — partition-aware uninstall options', async ({ page }) => {
   await boot(page, { mode: 'installer', images: IMAGES, sysinfo: SYSINFO, existing: true,
     uninstall: { found: true, storageDrive: 'D', diskPath: 'D:\\wootc\\disks\\root.vhdx',
-      diskSizeGB: 40, onDedicatedVol: true, reclaimGB: 60 } });
+      diskSizeGB: 40, onDedicatedVol: true, reclaimGB: 60, volumeLabel: 'wootc-data' } });
   await expect(page.locator('.screen-title')).toContainText('Manage TunaOS');
   // Reversible by default: keeping data is the unchecked default.
   await expect(page.getByText('Also delete my Linux data')).toBeVisible();
   // Partition-aware option appears for a wootc-created volume.
   await expect(page.getByText(/Give the 60 GB back to Windows/)).toBeVisible();
+  await expect(page.getByText(/Removes the wootc-data drive \(D:\)/)).toBeVisible();
   await shot(page, '05-control-panel');
+});
+
+test('control panel — personal partition without wootc-data label never offers RemovePartition', async ({ page }) => {
+  await boot(page, { mode: 'installer', images: IMAGES, sysinfo: SYSINFO, existing: true,
+    uninstall: { found: true, storageDrive: 'E', diskPath: 'E:\\wootc\\disks\\root.vhdx',
+      diskSizeGB: 40, onDedicatedVol: false, reclaimGB: 0 } });
+  await expect(page.locator('.screen-title')).toContainText('Manage TunaOS');
+  await expect(page.getByText('Also delete my Linux data')).toBeVisible();
+  // Remove partition option must NOT be present
+  await expect(page.getByText(/Give the .* GB back to Windows/)).toBeHidden();
+  await expect(page.getByText(/Removes the .* drive/)).toBeHidden();
+});
+
+test('control panel — uninstall confirmation names the verified volume label', async ({ page }) => {
+  let dialogMessage = '';
+  page.on('dialog', async dialog => {
+    dialogMessage = dialog.message();
+    await dialog.dismiss();
+  });
+  await boot(page, { mode: 'installer', images: IMAGES, sysinfo: SYSINFO, existing: true,
+    uninstall: { found: true, storageDrive: 'D', diskPath: 'D:\\wootc\\disks\\root.vhdx',
+      diskSizeGB: 40, onDedicatedVol: true, reclaimGB: 60, volumeLabel: 'wootc-data' } });
+  // Check the remove partition option
+  await page.locator('input[type="checkbox"]').nth(1).check();
+  await page.getByRole('button', { name: /Uninstall/ }).click();
+  expect(dialogMessage).toContain('wootc-data');
+  expect(dialogMessage).toContain('D:');
 });
 
 test('control panel — Boot in VM offered when available (§6.2)', async ({ page }) => {


### PR DESCRIPTION
## Summary
Fixes #225 (Milestone #211 / Tracker #197 items 2 + 3).

### 1. Identity Derivation under Over-the-Shoulder UAC
When a standard user elevates with another account's credentials, `user.Current()` in the elevated process returns the elevating administrator rather than the machine's interactive human.
- `deriveHumanUsername` checks:
  1. Elevation environment variables passed across the elevation boundary (`WOOTC_ORIGINAL_USER`, `WOOTC_INTERACTIVE_USER`).
  2. The interactive desktop user via `Win32_ComputerSystem.UserName` or `explorer.exe` process owner (`queryInteractiveUser()`).
  3. Falls back to `user.Current()`, sanitised and defaulted to `"winuser"` if empty/unresolvable.

### 2. Dedicated Volume Label Verification before RemovePartition
- `dedicatedVolumeInfo` and `removePartitionAndExtendC` now strictly require the `"wootc-data"` volume label (`DedicatedVolumeLabel`) and zero extraneous non-system files before claiming ownership of a partition (`isDedicatedVolume()`).
- Empty personal partitions without the label receive `OnDedicatedVol: false`, preventing `RemovePartition` from ever being offered or executed on user volumes.
- `UninstallInfo` records the verified `VolumeLabel`.
- The frontend control panel and uninstall confirmation dialog explicitly name the verified volume label (`"wootc-data"`).

### 3. Tests & Verification
- Cross-platform unit tests in `app/hostname_test.go` covering `deriveHumanUsername` under UAC scenarios and `isDedicatedVolume` label gating across all edge cases.
- GUI tests in `tests/gui/gui.spec.js` asserting that personal partitions without the `wootc-data` label are never offered for partition removal and that the uninstall confirmation dialog names the verified volume label.
- Phase-1 E2E assertion in `tests/e2e/phase1/assert-phase1.ps1` verifying the dedicated partition label is set to `wootc-data`.

— hive: backend=agy model=gemini-3.7-flash-high effort=low