### PR TITLE
docs: record 1.0 scope decision cutting pre-install Try-in-VM (M4.3) (#231)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,10 +67,21 @@ Beta means the support policy stops saying "alpha" because the evidence exists.
 
 ### v0.9.0-rc — "Ship-shaped" *(tracking: milestone issue M4)*
 - **Code signing** (EV cert / Azure Trusted Signing): kills the SmartScreen wall — the single biggest first-impression fix, and a spend decision that needs the maintainer.
-- Try-in-VM (#178) productized (QEMU bundle in the release) or explicitly cut from 1.0.
+- **Try-in-VM (#178, #231)**: Explicitly cut from 1.0; Phase 1 Boot-in-VM on `root.disk` ([ADR 0001](docs/adr/0001-phase1-first-architecture.md)) provides the primary zero-risk VM test path without bundling ~100MB+ of QEMU/builder binaries.
 - Program-migrator plugin architecture (#203): interface decision made; in or out of 1.0 scope, documented either way.
 - Docs complete and truthful end-to-end; walkthrough imagery regenerated from the shipping build.
 - Soak begins: consecutive green nightlies counting toward the 1.0 gate, release-blocking regressions only.
+
+### Scope decisions
+
+#### Try-in-VM vs. Phase 1 Boot-in-VM (#178, #231)
+
+**Decision**: Pre-install "Try in VM" fresh image preview is **explicitly cut from 1.0**. Phase 1 **Boot in VM** is the supported 1.0 VM experience.
+
+- **Background**: Issue #178 and SPEC §6.1 initially proposed a pre-install "Try in VM" mode using a two-stage handoff (a headless Alpine builder VM synthesizing a temporary `preview.raw` virtual disk from an OCI image before booting an interactive preview).
+- **Architectural Rationale**: Under the accepted Phase 1-first architecture ([ADR 0001](docs/adr/0001-phase1-first-architecture.md)), wootc populates a single `root.disk` file directly on the NTFS volume without repartitioning. Upon install completion, the user can immediately choose **Boot in VM now** (SPEC §6.2) on Windows. Because `root.disk` is self-contained and uncommitted to firmware boot until Phase 2, Phase 1 provides the exact same "try before rebooting" safety guarantee on the real installed system.
+- **Distribution Footprint**: Shipping the builder kernel (`builder-vmlinuz`), initramfs (`builder-initramfs.img`), and a complete Windows QEMU runtime adds ~100+ MB of non-vendored binaries to the release installer without delivering safety or capabilities beyond Phase 1.
+- **Surfaces**: In 1.0 releases, the pre-install builder VM is cut from default user paths (`GetFreshVMCapability` remains capability-gated and unbundled, keeping the button hidden on standard builds). 1.0 documentation (`docs/user-guide.md`) directs users to Phase 1 Boot-in-VM. Pre-install builder bundling and offline packaging (#178) are deferred to post-1.0.
 
 ### v1.0.0 — "The North Star, checkable" *(tracking: milestone issue M5)*
 The four criteria at the top of this file, verified: 30 days of green nightlies, the real-hardware report corpus with zero data-loss incidents, signed + winget-stable binaries, blessed brands. Cut from the soak's final green SHA.
@@ -84,6 +95,7 @@ The four criteria at the top of this file, verified: 30 days of green nightlies,
 | Session token rewrap, target side | #1 | P1 (beta gate) |
 | Program migrator plugin architecture | #203 | P2 (rc decision) |
 | E2E runs as systemd user units instead of nohup jobs | #57 | P2 |
+| Try-in-VM pre-install builder VM | #178 | P3 (post-1.0; cut for 1.0 per #231 / ADR 0001) |
 
 ## How to contribute
 

--- a/app/frontend/src/screens/launchpad.js
+++ b/app/frontend/src/screens/launchpad.js
@@ -339,7 +339,8 @@ export function renderLaunchpad() {
   const installBtn = btn(`${installVerb()} →`, 'btn btn-primary', () => startInstall());
   installBtn.id = 'install-btn';
   footer.appendChild(btn('Cancel', 'btn btn-ghost', () => Quit()));
-  // Try-in-VM (§6.1): only when a fresh-build VM is possible on this host.
+  // Try-in-VM (§6.1): gated on fresh VM capability (deferred to post-1.0 per ADR 0001 / #231;
+  // available when builder artifacts are present in an offline bundle).
   if (state.freshVmCapability?.available && state.selected) {
     footer.appendChild(btn('Try in VM', 'btn btn-ghost', () => tryInVM()));
   }

--- a/app/vm_windows.go
+++ b/app/vm_windows.go
@@ -130,6 +130,9 @@ const previewIPCPort = 9099
 // GetFreshVMCapability reports whether "Try in VM" (fresh build) can run. It
 // needs QEMU + firmware + an accelerator (like §6.2) plus the bundled Alpine
 // builder kernel/initramfs that does the OCI→disk work.
+// Note: In 1.0, pre-install Try-in-VM is cut from standard releases (ADR 0001, #231)
+// in favor of Phase 1 Boot-in-VM, but the capability check is retained for offline
+// bundles or developer workflows where builder artifacts are provisioned.
 func (a *App) GetFreshVMCapability() VMCapability {
 	qemuPath, bundled := findQEMU()
 	cap := VMCapability{QEMUPath: qemuPath, Bundled: bundled}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -970,9 +970,11 @@ The Windows installer (`wootc.exe`) has four screens:
 ```
 
 **Button actions:**
-- **[Try in VM]**: Bypasses BCD modification. Launches a background Alpine
-  builder VM to pull the OCI image into a local virtual disk and starts
-  QEMU immediately (§6.1). No reboot.
+- **[Try in VM]**: (Optional / Post-1.0 offline bundle; gated by `GetFreshVMCapability`).
+  Bypasses BCD modification. Launches a background Alpine builder VM to pull
+  the OCI image into a local virtual disk and starts QEMU immediately (§6.1).
+  No reboot. In standard 1.0 builds, this affordance is hidden in favor of
+  post-install Phase 1 VM Boot (ADR 0001, #231).
 - **[Install]**: Validates fields, proceeds to pre-flight checks.
 
 #### Screen 1.5: Pre-Flight Mitigation (Conditional)
@@ -1436,6 +1438,13 @@ wootc can boot bootc images directly on Windows using QEMU with WHPX
 performance. Two distinct modes:
 
 ### 6.1 Fresh VM from OCI Image (Two-Stage QEMU Handoff)
+
+> **Status (1.0 Scope)**: Deferred to post-1.0 per [ADR 0001](adr/0001-phase1-first-architecture.md)
+> and [#231](https://github.com/tuna-os/wootc/issues/231). The 1.0 distribution relies on
+> §6.2 (Phase 1 Boot-in-VM) against the installed `root.disk`, avoiding bundling ~100MB+
+> of builder/QEMU binaries in standard installer releases while providing a zero-risk VM
+> trial of the real system. The underlying capability check and builder scripts are preserved
+> for evaluation and potential post-1.0 offline bundles.
 
 "Try before you install" — the user clicks **[Try in VM]** on the
 Launchpad, and wootc builds a bootable disk image and launches it in

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -129,15 +129,15 @@ keys, tokens, or credential stores — you sign in again where it matters.
 
 ## 5. Try it first, commit later
 
-Not ready to reboot? Two ways to preview:
+Not ready to reboot?
 
-- **Boot in VM** — run your installed Linux in a window *without* rebooting,
-  right from Windows. It's the same disk, so any changes you make persist.
-- **Try in VM (fresh)** — build a preview of an image and try it in a window; if
-  you like it, **Install for Real** promotes the very same disk to your
-  permanent install (no re-download, no re-deploy).
+- **Boot in VM (Phase 1)** — run your installed Linux in a window *without*
+  rebooting, right from Windows. Because wootc installs into a single `root.disk`
+  file on your existing drive without repartitioning, you can test drive your
+  actual configured Linux system safely before ever rebooting. Any changes you
+  make persist to the same disk.
 
-Either way, you're always one reboot away from Windows.
+You're always one reboot away from Windows.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR addresses and resolves **M4.3** ([#231](https://github.com/tuna-os/wootc/issues/231), milestone [#212](https://github.com/tuna-os/wootc/issues/212), tracking [#178](https://github.com/tuna-os/wootc/issues/178)), deciding and documenting the 1.0 scope boundary for **Try-in-VM** and aligning all shipping surfaces.

### Decision & Rationale
- **Decision**: Pre-install "Try in VM" fresh image preview via a two-stage headless Alpine builder VM (SPEC §6.1) is **explicitly cut from 1.0**. Post-install **Boot in VM** (Phase 1 / SPEC §6.2) on the shared `root.disk` serves as the primary supported zero-risk VM path.
- **Architecture**: Under the accepted Phase 1-first architecture ([ADR 0001](docs/adr/0001-phase1-first-architecture.md)), wootc populates `root.disk` directly on the NTFS volume without repartitioning or firmware modification. On install completion, the user can immediately launch Phase 1 "Boot in VM" in Windows to test drive their real configured system with zero risk.
- **Distribution Footprint**: Standard 1.0 installer builds do not bundle ~100+ MB of non-vendored Windows QEMU binaries and Alpine builder artifacts (`builder-vmlinuz`, `builder-initramfs.img`), keeping the installer lightweight.
- **Code & Surface Alignment**:
  - `ROADMAP.md`: Records the decision paragraph under Scope Decisions, updates M4 checklist, and adds #178 to the standing debt table for post-1.0.
  - `docs/user-guide.md`: Updates Section 5 to focus on Phase 1 Boot-in-VM as the risk-free trial path.
  - `docs/SPEC.md`: Annotates Launchpad button actions and §6.1 noting pre-install builder preview is deferred to post-1.0 offline bundles.
  - `app/vm_windows.go` & `app/frontend/src/screens/launchpad.js`: Capability checks (`GetFreshVMCapability`) remain intact and dark by default, hiding the affordance on standard builds while retaining the backend code for offline bundles or developer workflows.

Closes #231
Refs #178, #212

— hive: backend=agy model=gemini-3.7-flash-high effort=low
---
🐝 **Hive Agent**: `contributor` | **SHA:** `464dc9d`