### PR TITLE
feat(branding): record and enforce upstream blessings for branded builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,22 +146,32 @@ jobs:
             echo "channel=manual" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build brand installers (one exe per brand)
+      - name: Build brand installers (one exe per blessed brand)
         # Subshells for every directory change: the first run interleaved a
         # failed `cd`/build chain with a loop that then globbed from the
         # wrong directory. Nothing here moves the step's own cwd.
+        #
+        # WHICH brands is no longer "whatever directories exist". Every exe
+        # here wears somebody's mark, so packaging/brands.sh reads the
+        # recorded decision (app/branding/*/blessing.json, #227) and answers:
+        # a declined project's exe drops from this matrix, a brand with no
+        # record at all is a hard error, and a pending one builds but says so.
         run: |
           set -euo pipefail
           (cd app/frontend && npm ci && npm run build)
           mkdir -p release-assets
-          for dir in app/branding/*/; do
-            brand=$(basename "$dir")
-            exe=$(jq -r '.exeName // empty' "$dir/brand.json")
-            [ -n "$exe" ] || { echo "::error::$dir/brand.json has no exeName"; exit 1; }
+          bash packaging/brands.sh explain
+          # Capture, THEN loop. `done < <(brands.sh list)` would swallow a
+          # non-zero exit from the selector — a tree with one unusable record
+          # would build the brands printed before it died and pass. The same
+          # silent-skip the selector refuses internally.
+          brands=$(bash packaging/brands.sh list)
+          [ -n "$brands" ] || { echo "::error::no brand is buildable"; exit 1; }
+          while IFS=$'\t' read -r brand exe; do
             (cd app && GOOS=windows GOARCH=amd64 go build -tags desktop,production \
               -ldflags "-w -s -X main.brandID=$brand" -o "../release-assets/$exe.exe" .)
             echo "built $exe.exe (brand: $brand)"
-          done
+          done <<< "$brands"
           ls -lh release-assets/
 
       - name: Build deployer boot artifacts

--- a/app/blessing_test.go
+++ b/app/blessing_test.go
@@ -1,0 +1,273 @@
+package main
+
+// Upstream blessings (#227): a branded build wears somebody else's mark, so
+// every brand carries a written decision about whether that is allowed —
+// app/branding/<brand>/blessing.json.
+//
+// These tests exist because "we should ask them" is not a state a repository
+// can be in. Either the decision is recorded or the brand does not ship, and
+// the invariant that matters most is the one that cannot be satisfied by
+// wishing: a brand this project does not own may not be marked `blessed`
+// without a link to the place somebody said yes.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type brandBlessing struct {
+	Brand     string `json:"brand"`
+	SelfOwned bool   `json:"selfOwned"`
+	Status    string `json:"status"`
+	Mark      struct {
+		Owner       string `json:"owner"`
+		AssetSource string `json:"assetSource"`
+	} `json:"mark"`
+	Decisions map[string]string `json:"decisions"`
+	Winget    struct {
+		Identifier       string `json:"identifier"`
+		NamespaceOwner   string `json:"namespaceOwner"`
+		IdentifierAgreed bool   `json:"identifierAgreed"`
+	} `json:"winget"`
+	Ask struct {
+		Filed     bool     `json:"filed"`
+		Venue     string   `json:"venue"`
+		Shown     []string `json:"shown"`
+		OpenedAt  string   `json:"openedAt"`
+		DecidedAt string   `json:"decidedAt"`
+		Evidence  string   `json:"evidence"`
+	} `json:"ask"`
+	Notes string `json:"notes"`
+}
+
+// The four things each project is asked to grant, per #227: the mark, the
+// name, the tagline, and distributing an exe under their brand.
+var blessingQuestions = []string{"mark", "name", "tagline", "distributeExe"}
+
+func loadBlessings(t *testing.T) map[string]brandBlessing {
+	t.Helper()
+	entries, err := brandFS.ReadDir("branding")
+	if err != nil {
+		t.Fatalf("read embedded branding dir: %v", err)
+	}
+	out := map[string]brandBlessing{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		data, err := brandFS.ReadFile("branding/" + id + "/blessing.json")
+		if err != nil {
+			t.Errorf("brand %s: no blessing.json — a brand ships only with a recorded decision (#227)", id)
+			continue
+		}
+		var b brandBlessing
+		if err := json.Unmarshal(data, &b); err != nil {
+			t.Errorf("brand %s: unparseable blessing.json: %v", id, err)
+			continue
+		}
+		out[id] = b
+	}
+	if len(out) == 0 {
+		t.Fatal("no blessing records found at all")
+	}
+	return out
+}
+
+// derivedStatus is the ONLY source of a brand's status: it falls out of the
+// four answers. A hand-written status that disagrees with them is how a
+// record starts lying — someone edits `mark: no` and forgets the header.
+func derivedStatus(d map[string]string) string {
+	all := true
+	for _, q := range blessingQuestions {
+		switch d[q] {
+		case "no":
+			return "declined"
+		case "yes":
+		default:
+			all = false
+		}
+	}
+	if all {
+		return "blessed"
+	}
+	return "pending"
+}
+
+func TestBrandBlessings_RecordedAndWellFormed(t *testing.T) {
+	for id, b := range loadBlessings(t) {
+		if b.Brand != id {
+			t.Errorf("brand %s: record names brand %q", id, b.Brand)
+		}
+		if b.Mark.Owner == "" {
+			t.Errorf("brand %s: no mark.owner — the record must name who is being asked", id)
+		}
+		switch b.Status {
+		case "blessed", "pending", "declined":
+		default:
+			t.Errorf("brand %s: status %q is not blessed/pending/declined", id, b.Status)
+		}
+		for _, q := range blessingQuestions {
+			switch b.Decisions[q] {
+			case "yes", "no", "pending":
+			default:
+				t.Errorf("brand %s: decision %q is %q, want yes/no/pending", id, q, b.Decisions[q])
+			}
+		}
+		if len(b.Decisions) != len(blessingQuestions) {
+			t.Errorf("brand %s: %d decisions recorded, want exactly %v",
+				id, len(b.Decisions), blessingQuestions)
+		}
+		if want := derivedStatus(b.Decisions); b.Status != want {
+			t.Errorf("brand %s: status %q disagrees with its own answers %v (want %q)",
+				id, b.Status, b.Decisions, want)
+		}
+		if b.Notes == "" {
+			t.Errorf("brand %s: no notes — a bare status cannot say what was actually asked", id)
+		}
+	}
+}
+
+// The anti-presumption gate. Marking someone else's brand `blessed` is a claim
+// about a conversation that happened; it must point at that conversation.
+func TestBrandBlessings_ForeignMarksNeedEvidence(t *testing.T) {
+	for id, b := range loadBlessings(t) {
+		if b.SelfOwned {
+			continue
+		}
+		if b.Status == "blessed" && b.Ask.Evidence == "" {
+			t.Errorf("brand %s: blessed with no ask.evidence — a yes we cannot link to is a yes we invented", id)
+		}
+		if b.Status == "declined" && b.Ask.Evidence == "" {
+			t.Errorf("brand %s: declined with no ask.evidence — dropping an exe needs the same proof as shipping one", id)
+		}
+		if b.Status != "pending" && !b.Ask.Filed {
+			t.Errorf("brand %s: status %q but ask.filed is false — nobody was asked", id, b.Status)
+		}
+		if b.Ask.Venue == "" {
+			t.Errorf("brand %s: no ask.venue — 'ask them' is not actionable without a where", id)
+		}
+		if b.Ask.Filed && b.Ask.OpenedAt == "" {
+			t.Errorf("brand %s: ask.filed with no openedAt — an ask with no date cannot be chased", id)
+		}
+		if b.Status != "pending" && b.Ask.DecidedAt == "" {
+			t.Errorf("brand %s: decided (%s) with no decidedAt", id, b.Status)
+		}
+	}
+}
+
+// Self-owned is a claim too, and the cheapest one to get wrong: it is the
+// escape hatch from every check above.
+func TestBrandBlessings_SelfOwnedIsOnlyOurOwnMarks(t *testing.T) {
+	ours := map[string]bool{"wootc": true, "tunaos": true}
+	for id, b := range loadBlessings(t) {
+		if b.SelfOwned && !ours[id] {
+			t.Errorf("brand %s: claims selfOwned, but only %v are this project's marks", id, ours)
+		}
+		if !b.SelfOwned && ours[id] {
+			t.Errorf("brand %s: is one of this project's own marks but is not selfOwned", id)
+		}
+	}
+}
+
+// winget identifiers live in a namespace, and the namespace belongs to whoever
+// owns the brand: `Bazzite.Installer` is Universal Blue's to grant, not ours
+// to take (#227 (3)).
+func TestBrandBlessings_WingetNamespaceFollowsTheMark(t *testing.T) {
+	for id, b := range loadBlessings(t) {
+		if b.Winget.Identifier == "" {
+			t.Errorf("brand %s: no winget.identifier proposed", id)
+			continue
+		}
+		if !strings.Contains(b.Winget.Identifier, ".") {
+			t.Errorf("brand %s: winget identifier %q is not Publisher.Package", id, b.Winget.Identifier)
+		}
+		if b.Winget.NamespaceOwner == "" {
+			t.Errorf("brand %s: winget.namespaceOwner unrecorded — who owns %q?", id, b.Winget.Identifier)
+		}
+		// An identifier we have not been granted must not be marked agreed,
+		// and a foreign namespace cannot be agreed without a recorded yes.
+		if b.Winget.IdentifierAgreed && !b.SelfOwned && b.Ask.Evidence == "" {
+			t.Errorf("brand %s: winget identifier %q marked agreed with no evidence", id, b.Winget.Identifier)
+		}
+		if b.SelfOwned && !strings.HasPrefix(b.Winget.Identifier, "TunaOS.") {
+			t.Errorf("brand %s: self-owned but its identifier %q is outside our namespace", id, b.Winget.Identifier)
+		}
+	}
+}
+
+// The README is where a human reads the outcome (#227 (4)). It drifts the
+// moment it is not checked, and a stale "blessed" row is worse than none.
+func TestBrandBlessings_READMETableMatchesTheRecords(t *testing.T) {
+	data, err := brandFS.ReadFile("branding/README.md")
+	if err != nil {
+		t.Fatalf("read branding README: %v", err)
+	}
+	readme := string(data)
+	for id, b := range loadBlessings(t) {
+		var row string
+		for _, line := range strings.Split(readme, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "| `"+id+"`") {
+				row = line
+				break
+			}
+		}
+		if row == "" {
+			t.Errorf("brand %s: no row in app/branding/README.md — the outcome is unrecorded where humans look", id)
+			continue
+		}
+		// Compare CELLS, not the row as a whole. Substring matching passes a
+		// row whose status has drifted to "blessed" as long as any decision
+		// cell still reads "pending" — which is exactly the drift that
+		// matters, and it slipped through until this was tightened.
+		cells := strings.Split(row, "|")
+		// | brand | owner | status | mark | name | tagline | exe | winget |
+		if len(cells) < 10 {
+			t.Errorf("brand %s: README row has %d cells, want the 8-column table:\n  %s",
+				id, len(cells)-2, row)
+			continue
+		}
+		cell := func(i int) string { return strings.TrimSpace(cells[i]) }
+		if cell(3) != b.Status {
+			t.Errorf("brand %s: README status cell is %q, record says %q", id, cell(3), b.Status)
+		}
+		for i, q := range blessingQuestions {
+			if got, want := cell(4+i), b.Decisions[q]; got != want {
+				t.Errorf("brand %s: README %s cell is %q, record says %q", id, q, got, want)
+			}
+		}
+		if want := "`" + b.Winget.Identifier + "`"; cell(8) != want {
+			t.Errorf("brand %s: README winget cell is %q, record says %q", id, cell(8), want)
+		}
+	}
+}
+
+func TestDerivedStatus(t *testing.T) {
+	yes := map[string]string{"mark": "yes", "name": "yes", "tagline": "yes", "distributeExe": "yes"}
+	if got := derivedStatus(yes); got != "blessed" {
+		t.Errorf("all yes → %q, want blessed", got)
+	}
+	for _, q := range blessingQuestions {
+		d := map[string]string{}
+		for k, v := range yes {
+			d[k] = v
+		}
+		d[q] = "no"
+		if got := derivedStatus(d); got != "declined" {
+			t.Errorf("%s=no → %q, want declined", q, got)
+		}
+		d[q] = "pending"
+		if got := derivedStatus(d); got != "pending" {
+			t.Errorf("%s=pending → %q, want pending", q, got)
+		}
+	}
+	// A single no outranks three yeses: any one refusal is a refusal.
+	mixed := map[string]string{"mark": "yes", "name": "yes", "tagline": "pending", "distributeExe": "no"}
+	if got := derivedStatus(mixed); got != "declined" {
+		t.Errorf("mixed with a no → %q, want declined", got)
+	}
+	if got := derivedStatus(nil); got != "pending" {
+		t.Errorf("empty → %q, want pending", got)
+	}
+}

--- a/app/branding/README.md
+++ b/app/branding/README.md
@@ -13,6 +13,48 @@ Per-directory files — only `brand.json` is required:
 | `font.woff2` | `FontDataURI` | the brand's typeface, embedded — never fetched at run time |
 | `theme.css` | `ThemeCSS` | deep restyle injected after `style.css` (tokens, buttons, radii) |
 
+## Upstream blessings
+
+A branded build wears somebody else's mark. `<brand>/blessing.json` records
+what that project has actually said about it — the mark, the name, the
+tagline, and distributing an exe under their brand — plus who owns the
+winget namespace the identifier would sit in. The ask itself, and the
+manifests to offer with it, are in
+[docs/upstream-blessings.md](../../docs/upstream-blessings.md).
+
+| Brand | Mark owner | Status | Mark | Name | Tagline | Branded exe | winget identifier |
+|---|---|---|---|---|---|---|---|
+| `wootc` | TunaOS — this project | blessed | yes | yes | yes | yes | `TunaOS.wootc` |
+| `tunaos` | TunaOS — this project | blessed | yes | yes | yes | yes | `TunaOS.Installer` |
+| `bluefin` | Universal Blue — ublue-os/bluefin | pending | pending | pending | pending | pending | `Bluefin.Installer` |
+| `bazzite` | Universal Blue — ublue-os/bazzite | pending | pending | pending | pending | pending | `Bazzite.Installer` |
+| `aurora` | Universal Blue — ublue-os/aurora | pending | pending | pending | pending | pending | `Aurora.Installer` |
+
+The two `TunaOS.*` identifiers are ours (`TunaOS.wootc` is published;
+`TunaOS.Installer` is reserved, not submitted). The other three sit in
+Universal Blue's namespace, not ours.
+
+**Nothing here has been asked yet.** Every `pending` means exactly that: no
+request has been filed, so no answer has been given, and the record says so
+rather than implying a conversation that did not happen. `ask.filed` is
+`false` on all three.
+
+**The status is not decoration.** `packaging/brands.sh` reads it and the
+release matrix follows:
+
+- **blessed** — build and ship it.
+- **pending** — still built (shipping predates the ask), but the release log
+  names it as unblessed. Set `WOOTC_REQUIRE_BLESSING=1` to drop pending
+  brands too.
+- **declined** — the exe drops from the release matrix. Not ours to ship.
+
+A brand directory with **no** `blessing.json` is a hard build error, not a
+default yes: a new brand cannot reach a release without someone writing down
+who was asked. `app/blessing_test.go` holds the rest of the line — the status
+must agree with its own four answers, a mark this project does not own cannot
+be `blessed` without a link to the yes, and every cell of this table is
+compared against the JSON.
+
 ## Asset provenance
 
 Real assets, taken from each project's own published branding:

--- a/app/branding/aurora/blessing.json
+++ b/app/branding/aurora/blessing.json
@@ -1,0 +1,29 @@
+{
+  "brand": "aurora",
+  "selfOwned": false,
+  "status": "pending",
+  "mark": {
+    "owner": "Universal Blue — ublue-os/aurora (getaurora.dev)",
+    "assetSource": "https://getaurora.dev"
+  },
+  "decisions": {
+    "mark": "pending",
+    "name": "pending",
+    "tagline": "pending",
+    "distributeExe": "pending"
+  },
+  "winget": {
+    "identifier": "Aurora.Installer",
+    "namespaceOwner": "Universal Blue — ublue-os",
+    "identifierAgreed": false
+  },
+  "ask": {
+    "filed": false,
+    "venue": "https://github.com/ublue-os/aurora/issues",
+    "shown": [],
+    "openedAt": "",
+    "decidedAt": "",
+    "evidence": ""
+  },
+  "notes": "A real ask (#227). Aurora's mark, name, tagline and a branded exe are Universal Blue's to grant, and Aurora.Installer is theirs to own. docs/upstream-blessings.md carries the request to file and the manifests to offer."
+}

--- a/app/branding/bazzite/blessing.json
+++ b/app/branding/bazzite/blessing.json
@@ -1,0 +1,29 @@
+{
+  "brand": "bazzite",
+  "selfOwned": false,
+  "status": "pending",
+  "mark": {
+    "owner": "Universal Blue — ublue-os/bazzite",
+    "assetSource": "https://github.com/ublue-os/bazzite.gg"
+  },
+  "decisions": {
+    "mark": "pending",
+    "name": "pending",
+    "tagline": "pending",
+    "distributeExe": "pending"
+  },
+  "winget": {
+    "identifier": "Bazzite.Installer",
+    "namespaceOwner": "Universal Blue — ublue-os",
+    "identifierAgreed": false
+  },
+  "ask": {
+    "filed": false,
+    "venue": "https://github.com/ublue-os/bazzite/issues",
+    "shown": [],
+    "openedAt": "",
+    "decidedAt": "",
+    "evidence": ""
+  },
+  "notes": "A real ask, not a formality (#227). The mark, the name \"Bazzite Installer\", the tagline and a Bazzite-branded exe are all Universal Blue's to grant, and Bazzite.Installer sits in their winget namespace, not ours. docs/upstream-blessings.md carries the request to file and the manifests to offer."
+}

--- a/app/branding/bluefin/blessing.json
+++ b/app/branding/bluefin/blessing.json
@@ -1,0 +1,29 @@
+{
+  "brand": "bluefin",
+  "selfOwned": false,
+  "status": "pending",
+  "mark": {
+    "owner": "Universal Blue — ublue-os/bluefin (projectbluefin.io)",
+    "assetSource": "https://github.com/projectbluefin/website"
+  },
+  "decisions": {
+    "mark": "pending",
+    "name": "pending",
+    "tagline": "pending",
+    "distributeExe": "pending"
+  },
+  "winget": {
+    "identifier": "Bluefin.Installer",
+    "namespaceOwner": "Universal Blue — ublue-os",
+    "identifierAgreed": false
+  },
+  "ask": {
+    "filed": false,
+    "venue": "https://github.com/ublue-os/bluefin/issues",
+    "shown": [],
+    "openedAt": "",
+    "decidedAt": "",
+    "evidence": ""
+  },
+  "notes": "In-family and expected to be a formality (#227) — but a formality is still a yes somebody has to say, and until they do this record says pending, not blessed. Bluefin's is the widest catalog of the branded builds (bluefin, dakota, bluefin-lts)."
+}

--- a/app/branding/tunaos/blessing.json
+++ b/app/branding/tunaos/blessing.json
@@ -1,0 +1,29 @@
+{
+  "brand": "tunaos",
+  "selfOwned": true,
+  "status": "blessed",
+  "mark": {
+    "owner": "TunaOS (tuna-os) — this project",
+    "assetSource": "emoji placeholder; that IS the TunaOS branding today"
+  },
+  "decisions": {
+    "mark": "yes",
+    "name": "yes",
+    "tagline": "yes",
+    "distributeExe": "yes"
+  },
+  "winget": {
+    "identifier": "TunaOS.Installer",
+    "namespaceOwner": "TunaOS (tuna-os) — this project",
+    "identifierAgreed": true
+  },
+  "ask": {
+    "filed": false,
+    "venue": "",
+    "shown": [],
+    "openedAt": "",
+    "decidedAt": "",
+    "evidence": "https://github.com/tuna-os/wootc"
+  },
+  "notes": "In-family and self-owned: TunaOS is this project's own distribution. TunaOS.Installer is reserved in our own winget namespace and is not submitted yet — only TunaOS.wootc is."
+}

--- a/app/branding/wootc/blessing.json
+++ b/app/branding/wootc/blessing.json
@@ -1,0 +1,29 @@
+{
+  "brand": "wootc",
+  "selfOwned": true,
+  "status": "blessed",
+  "mark": {
+    "owner": "TunaOS (tuna-os/wootc) — this project",
+    "assetSource": "emoji placeholder; no third-party mark is used"
+  },
+  "decisions": {
+    "mark": "yes",
+    "name": "yes",
+    "tagline": "yes",
+    "distributeExe": "yes"
+  },
+  "winget": {
+    "identifier": "TunaOS.wootc",
+    "namespaceOwner": "TunaOS (tuna-os) — this project",
+    "identifierAgreed": true
+  },
+  "ask": {
+    "filed": false,
+    "venue": "",
+    "shown": [],
+    "openedAt": "",
+    "decidedAt": "",
+    "evidence": "https://github.com/tuna-os/wootc"
+  },
+  "notes": "The generic engine under its own name. Nothing to ask: the mark, the name and the namespace are this project's. Published to winget as TunaOS.wootc by .github/workflows/winget-publish.yml."
+}

--- a/docs/branding-and-distribution.md
+++ b/docs/branding-and-distribution.md
@@ -120,8 +120,24 @@ via `go:embed`; `-ldflags "-X main.brandID=bazzite"` picks one (default
 `GetBranding` + `installVerb()`; remaining hardcoded "TunaOS"/"wootc" strings
 in screens move to `state.brand`.
 
-**Release matrix.** The publish job loops brands, builds each exe with its
-ldflag, names it `exeName`.exe, and adds all to the release + SHA256SUMS.
+**Upstream blessings.** A branded build wears somebody else's mark, so each
+brand carries a recorded decision about whether that is allowed —
+`app/branding/<brand>/blessing.json`, summarised in the table in
+`app/branding/README.md` and asked for via
+[upstream-blessings.md](upstream-blessings.md) (#227). Four separate
+questions per project (mark, name, tagline, distributing a branded exe),
+plus who owns the winget namespace the identifier would live in. The status
+falls out of the answers: any `no` → `declined`, all four `yes` → `blessed`,
+anything else → `pending`. A mark this project does not own cannot be marked
+`blessed` without a link to the yes.
+
+**Release matrix.** The publish job asks `packaging/brands.sh` which brands
+may ship, builds each surviving exe with its ldflag, names it `exeName`.exe,
+and adds all to the release + SHA256SUMS. The decision is load-bearing
+there: a **declined** project's exe drops out of the matrix, a brand with no
+record at all is a hard error rather than a default yes, and a **pending**
+one still builds (shipping predates the ask) but is named as unblessed in
+the release log. `WOOTC_REQUIRE_BLESSING=1` drops pending brands too.
 
 ## 3. Offline-first deploys
 

--- a/docs/upstream-blessings.md
+++ b/docs/upstream-blessings.md
@@ -1,0 +1,158 @@
+# Upstream blessings
+
+wootc ships one installer per distribution, and each one wears that
+distribution's real mark, name, typeface and look
+([branding-and-distribution.md §2](branding-and-distribution.md)). That is a
+claim on somebody else's brand. This document is how the claim gets asked for
+and how the answer gets recorded (#227).
+
+The answers live in `app/branding/<brand>/blessing.json`, one record per
+brand, summarised in the table in
+[`app/branding/README.md`](../app/branding/README.md). They are not
+documentation: `packaging/brands.sh` reads them, and a **declined** brand's
+exe drops out of the release matrix.
+
+**Current state: nothing has been asked yet.** Bluefin, Bazzite and Aurora
+are all `pending` with `ask.filed: false`. This document exists so that
+filing the ask is a copy-paste rather than a blank page.
+
+## What each project is asked
+
+Four separate yes/no questions, because they can have different answers — a
+project may be glad to be installed and still not want an exe carrying its
+logo signed by someone else:
+
+| Question | `blessing.json` key | What a "no" costs |
+|---|---|---|
+| May we ship your **mark** (logo, colours, typeface) inside the installer? | `decisions.mark` | the branded build loses its assets |
+| May we call it **"<Brand> Installer"**? | `decisions.name` | the name reverts to generic wootc |
+| May we use this **tagline**? | `decisions.tagline` | tagline reverts, brand can stay |
+| May we **distribute an exe** under your brand at all? | `decisions.distributeExe` | the exe drops from every release |
+
+Any single **no** makes the whole record `declined` — that is what
+`derivedStatus` in `app/blessing_test.go` enforces, and it is deliberate: a
+brand we may not name is not a brand we should ship.
+
+## What to show them
+
+Not a description — the actual thing:
+
+1. **The branded walkthrough.** Their build's four screens, generated from
+   their own assets: [branded-walkthroughs.md](branded-walkthroughs.md).
+   Every image there is produced by `tests/gui/branded-walkthrough.spec.js`
+   from `app/branding/<brand>/`, so it is what a user would really see.
+2. **The provenance record.** Where each asset came from, in their own
+   published branding: [`app/branding/README.md`](../app/branding/README.md)
+   § Asset provenance. This answers "where did you get our logo" before it
+   is asked.
+3. **A live E2E video** of that image actually installing, migrating and
+   returning to Windows: <https://tuna-os.github.io/wootc/e2e/latest/>.
+4. **The rendered winget manifests** for their namespace (below) — an offer,
+   not a submission.
+
+## The winget namespace
+
+`Bazzite.Installer` sits in Bazzite's publisher namespace, not ours. So the
+identifier is *theirs*, and the offer is theirs to take up in whichever form
+they want:
+
+- **they publish** — we hand them the rendered manifests and the release
+  asset URL, and they own the winget package outright;
+- **we publish on their behalf** — only with an explicit yes recorded in
+  `winget.identifierAgreed`, and they can take it over at any time;
+- **no winget package** — the exe stays a direct download.
+
+Only `TunaOS.wootc` is submitted automatically today
+(`.github/workflows/winget-publish.yml`); no branded package is submitted
+anywhere without a recorded yes. See
+[`packaging/winget/README.md`](../packaging/winget/README.md).
+
+Render a brand's manifests to show them exactly what would be published:
+
+```sh
+packaging/winget/render-brand.sh bazzite 0.2.0 \
+  https://github.com/tuna-os/wootc/releases/download/v0.2.0/Bazzite-Installer.exe \
+  <sha256> > /tmp/bazzite-manifests.txt
+```
+
+With no URL or hash it renders with placeholders, which is enough to show
+the shape of the package.
+
+## The request
+
+Adapt per project; keep it short and make the "no" genuinely free.
+
+> **Subject:** May we ship a Bazzite-branded Windows installer?
+>
+> We build [wootc](https://github.com/tuna-os/wootc), an installer that puts
+> a bootc image on a Windows machine from inside Windows — no USB, no
+> repartitioning, and fully undoable. It already installs Bazzite, and we
+> build a variant whose window says "Bazzite Installer" and wears your mark,
+> type and colours, so users never see our project's name.
+>
+> We have not shipped that variant on your say-so and we are asking before
+> it goes further. Four separate questions, and a no to any of them is
+> completely fine:
+>
+> 1. May we use the Bazzite mark, colours and typeface in the installer?
+> 2. May we call it "Bazzite Installer"?
+> 3. May we use the tagline "<the tagline from brand.json>"?
+> 4. May we distribute an exe branded as Bazzite at all?
+>
+> Here is exactly what it looks like today: <branded walkthrough link>.
+> Every asset and where we took it from: <provenance link>. A real install,
+> start to finish, on video: <e2e link>.
+>
+> On winget: `Bazzite.Installer` belongs in your namespace, not ours. We
+> have the manifests rendered and would rather hand them to you than publish
+> under a name that isn't ours — attached/below. We are not submitting
+> anything until you say so.
+>
+> If the answer is no to any of it, tell us and we will drop it — the
+> branded exe comes out of our release matrix, which is a one-line change on
+> our side.
+
+## Recording the answer
+
+Edit `app/branding/<brand>/blessing.json`:
+
+```jsonc
+{
+  "status": "blessed",              // falls out of the four answers
+  "decisions": { "mark": "yes", "name": "yes",
+                 "tagline": "yes", "distributeExe": "yes" },
+  "winget": { "identifierAgreed": true },
+  "ask": {
+    "filed": true,
+    "venue": "https://github.com/ublue-os/bazzite/issues",
+    "shown": ["docs/branded-walkthroughs.md", "app/branding/README.md"],
+    "openedAt": "2026-09-14",
+    "decidedAt": "2026-09-21",
+    "evidence": "https://github.com/ublue-os/bazzite/issues/1234#issuecomment-…"
+  }
+}
+```
+
+Then update the table row in `app/branding/README.md` to match — the tests
+fail if it does not.
+
+Rules the tests hold you to:
+
+- **`status` is derived, never asserted.** Any `no` → `declined`; all four
+  `yes` → `blessed`; anything else → `pending`.
+- **A yes needs a link.** A brand this project does not own cannot be
+  `blessed` without `ask.evidence`. A yes we cannot point at is a yes we
+  invented.
+- **So does a no.** `declined` needs evidence too: dropping someone's exe on
+  a misremembered conversation is its own kind of wrong.
+- **`selfOwned` is only `wootc` and `tunaos`.** It is the escape hatch from
+  every check above, so it is pinned to the two marks this project actually
+  owns.
+
+## If a project declines
+
+`packaging/brands.sh` stops listing that brand and the release matrix stops
+building its exe — no other change is needed. Leave the directory and the
+record in place: the record is the reason, and deleting it loses the memory
+of having asked. Note the decision in `notes` and, if they asked for it,
+remove the assets in a follow-up.

--- a/packaging/brands.sh
+++ b/packaging/brands.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# packaging/brands.sh — which brands may be built into a release, and why.
+#
+# Branded distribution is a claim on somebody else's mark. `app/branding/*/`
+# holds the marks; `app/branding/*/blessing.json` holds the DECISION about
+# each one (#227), and this script is the thing that makes that decision
+# load-bearing instead of documentary:
+#
+#   blessed   the project said yes — build it
+#   pending   nobody has said no, and shipping predates the ask — build it,
+#             but say out loud in the log that it is unblessed
+#   declined  the project said no — the exe drops from the release matrix
+#
+# A brand with NO record at all is a hard error, not a default-yes. That is
+# the whole point: a new app/branding/<x>/ directory cannot reach a release
+# without someone writing down who was asked and what they said.
+#
+# Usage:
+#   brands.sh list      one "<brand><TAB><exeName>" per BUILDABLE brand
+#   brands.sh explain   the full table, every brand, with its reason
+#
+# Env:
+#   WOOTC_BRANDING_DIR      override the branding root (tests)
+#   WOOTC_REQUIRE_BLESSING  1 = ship blessed brands ONLY; pending drops too.
+#                           The knob exists so tightening the policy is a
+#                           workflow setting, not another code change.
+set -euo pipefail
+
+BRANDING_DIR="${WOOTC_BRANDING_DIR:-app/branding}"
+REQUIRE_BLESSING="${WOOTC_REQUIRE_BLESSING:-0}"
+
+die() { echo "brands.sh: $*" >&2; exit 1; }
+
+command -v jq >/dev/null || die "jq is required"
+[ -d "$BRANDING_DIR" ] || die "no branding directory at $BRANDING_DIR"
+
+# Echoes "<status>|<exeName>|<reason>" for one brand directory, or exits
+# non-zero with the reason on stderr when the record is unusable. Validation
+# lives here rather than only in the Go test so a release cannot be cut from a
+# tree whose records do not parse.
+inspect() {
+    local dir="$1" brand exe status bless
+    brand=$(basename "$dir")
+    bless="$dir/blessing.json"
+
+    [ -f "$dir/brand.json" ] || die "$brand: no brand.json"
+    exe=$(jq -r '.exeName // empty' "$dir/brand.json") \
+        || die "$brand: unparseable brand.json"
+    [ -n "$exe" ] || die "$brand: brand.json has no exeName"
+
+    [ -f "$bless" ] || die "$brand: no blessing.json — a brand ships only with a recorded decision (#227); see docs/upstream-blessings.md"
+    status=$(jq -r '.status // empty' "$bless") \
+        || die "$brand: unparseable blessing.json"
+
+    case "$status" in
+        blessed)
+            printf '%s|%s|%s\n' build "$exe" "blessed by $(jq -r '.mark.owner // "?"' "$bless")"
+            ;;
+        pending)
+            if [ "$REQUIRE_BLESSING" = "1" ]; then
+                printf '%s|%s|%s\n' skip "$exe" "blessing still pending and WOOTC_REQUIRE_BLESSING=1"
+            else
+                printf '%s|%s|%s\n' warn "$exe" "UNBLESSED — the ask to $(jq -r '.mark.owner // "?"' "$bless") is not answered yet"
+            fi
+            ;;
+        declined)
+            printf '%s|%s|%s\n' declined "$exe" "$(jq -r '.mark.owner // "the project"' "$bless") declined — this exe is not ours to ship"
+            ;;
+        *)
+            die "$brand: blessing.json status is '${status}', not blessed/pending/declined"
+            ;;
+    esac
+}
+
+brand_dirs() {
+    local dir
+    for dir in "$BRANDING_DIR"/*/; do
+        [ -d "$dir" ] || continue
+        printf '%s\n' "${dir%/}"
+    done
+}
+
+cmd_list() {
+    local dir brand line verdict exe
+    while read -r dir; do
+        brand=$(basename "$dir")
+        # Assign, THEN split. `read ... < <(inspect)` would run inspect in a
+        # subshell whose die() cannot stop this one, so an unusable record
+        # would be silently skipped — the default-yes this exists to refuse.
+        line=$(inspect "$dir")
+        IFS='|' read -r verdict exe _ <<<"$line"
+        case "$verdict" in
+            build|warn) printf '%s\t%s\n' "$brand" "$exe" ;;
+        esac
+    done < <(brand_dirs)
+}
+
+cmd_explain() {
+    local dir brand line verdict exe reason unblessed=0
+    echo "Brand release matrix (app/branding/*/blessing.json — #227)"
+    while read -r dir; do
+        brand=$(basename "$dir")
+        line=$(inspect "$dir")
+        IFS='|' read -r verdict exe reason <<<"$line"
+        case "$verdict" in
+            build)
+                printf '  BUILD    %-20s %s.exe — %s\n' "$brand" "$exe" "$reason" ;;
+            warn)
+                unblessed=$((unblessed + 1))
+                printf '  BUILD*   %-20s %s.exe — %s\n' "$brand" "$exe" "$reason" ;;
+            skip)
+                printf '  SKIP     %-20s %s.exe — %s\n' "$brand" "$exe" "$reason" ;;
+            declined)
+                printf '  DROPPED  %-20s %s.exe — %s\n' "$brand" "$exe" "$reason" ;;
+        esac
+    done < <(brand_dirs)
+    if [ "$unblessed" -gt 0 ]; then
+        echo "  * $unblessed brand(s) ship on a PENDING record. Chase the ask:"
+        echo "    docs/upstream-blessings.md"
+    fi
+}
+
+case "${1:-}" in
+    list)    cmd_list ;;
+    explain) cmd_explain ;;
+    *)       die "usage: brands.sh {list|explain}" ;;
+esac

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -20,8 +20,33 @@ Requirements, both one-time:
   Microsoft's moderation review of a new package can take a few days.
   Updates after that are routine.
 
+## Branded installers
+
 Branded installers (Bazzite-Installer, Aurora-Installer, …) are deliberately
 NOT auto-submitted: their winget identities belong to their projects
-(`Bazzite.Installer` would sit in Bazzite's namespace), so each needs that
-project's sign-off first. The same templates work — swap the identifier,
-name, and asset.
+(`Bazzite.Installer` sits in Bazzite's namespace, not ours), so each needs
+that project's sign-off first (#227).
+
+The sign-off is recorded per brand in `app/branding/<brand>/blessing.json` —
+`winget.identifier`, `winget.namespaceOwner`, and `winget.identifierAgreed`.
+Nothing branded is submitted anywhere until that last flag is true, and
+`tests/unit/brand-blessings.bats` asserts no branded identifier appears in
+`winget-publish.yml` at all.
+
+`brand/*.yaml.in` are the templates for those packages, and
+`render-brand.sh` fills them from the brand's own `brand.json` and
+`blessing.json`:
+
+```sh
+packaging/winget/render-brand.sh bazzite            # placeholders, shape only
+packaging/winget/render-brand.sh bazzite 0.2.0 <url> <sha256>
+```
+
+They render to stdout and are never submitted — the point is to have the
+real thing to *offer* a project when asking, rather than describing a
+package they cannot see. A rendered set carries the namespace owner and the
+blessing status in its header, and its description says
+`PERMISSION NOT YET GRANTED` until `identifierAgreed` is true, so a draft
+pasted into somebody's issue tracker cannot imply a yes nobody gave.
+
+The ask itself is in [docs/upstream-blessings.md](../../docs/upstream-blessings.md).

--- a/packaging/winget/brand/installer.yaml.in
+++ b/packaging/winget/brand/installer.yaml.in
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: {{IDENTIFIER}}
+PackageVersion: "{{VERSION}}"
+InstallerType: portable
+Commands:
+  - {{COMMAND}}
+Installers:
+  - Architecture: x64
+    InstallerUrl: "{{URL}}"
+    InstallerSha256: "{{SHA256}}"
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/brand/locale.en-US.yaml.in
+++ b/packaging/winget/brand/locale.en-US.yaml.in
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: {{IDENTIFIER}}
+PackageVersion: "{{VERSION}}"
+PackageLocale: en-US
+Publisher: {{PUBLISHER}}
+PublisherUrl: {{PUBLISHER_URL}}
+PublisherSupportUrl: https://github.com/tuna-os/wootc/issues
+PackageName: {{PACKAGE_NAME}}
+PackageUrl: https://github.com/tuna-os/wootc
+License: GPL-2.0 OR MIT
+LicenseUrl: https://github.com/tuna-os/wootc/blob/main/LICENSE-GPL-2.0
+ShortDescription: {{TAGLINE}}
+Description: |-
+  {{PACKAGE_NAME}} installs {{BRAND_NAME}} from inside Windows. Everything
+  lives in one folder on your Windows drive — no partitions are touched,
+  Windows stays the default boot, your files are bridged into Linux, and one
+  uninstall puts everything back.
+
+  Built by the wootc project (https://github.com/tuna-os/wootc).
+  {{PERMISSION}}
+Moniker: {{MONIKER}}
+Tags:
+  - linux
+  - dual-boot
+  - migration
+  - bootc
+  - installer
+ReleaseNotesUrl: "https://github.com/tuna-os/wootc/releases/tag/{{TAG}}"
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/brand/version.yaml.in
+++ b/packaging/winget/brand/version.yaml.in
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+# Template for a BRANDED installer's winget manifest — rendered by
+# packaging/winget/render-brand.sh into the brand's OWN namespace. Never
+# submitted by this repo without a recorded yes (app/branding/*/blessing.json).
+PackageIdentifier: {{IDENTIFIER}}
+PackageVersion: "{{VERSION}}"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/packaging/winget/render-brand.sh
+++ b/packaging/winget/render-brand.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# render-brand.sh — the winget manifests for a BRANDED installer, rendered so
+# they can be handed to the project whose namespace they would live in (#227).
+#
+# `Bazzite.Installer` sits in Bazzite's publisher namespace, not ours. The
+# useful form of "may we?" is not a description of a package — it is the
+# package, rendered, so they can read exactly what would be published under
+# their name and either take it over or say no.
+#
+# This renders; it never submits. Only TunaOS.wootc is submitted automatically
+# (.github/workflows/winget-publish.yml), and no branded package is submitted
+# anywhere without `winget.identifierAgreed` in that brand's blessing.json.
+#
+# Usage:
+#   render-brand.sh <brand> [version] [url] [sha256]
+#
+# With no version/url/sha the placeholders stay in place, which is enough to
+# show the shape of the package before a release exists.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATES="$ROOT/packaging/winget/brand"
+
+die() { echo "render-brand.sh: $*" >&2; exit 1; }
+
+brand="${1:-}"
+[ -n "$brand" ] || die "usage: render-brand.sh <brand> [version] [url] [sha256]"
+# Unset arguments stay as placeholders: the manifests are worth showing to a
+# project before any release of that brand exists.
+version="${2:-}"; tag="v$version"
+if [ -z "$version" ]; then version='{{VERSION}}'; tag='{{TAG}}'; fi
+url="${3:-}";     [ -n "$url" ] || url='{{URL}}'
+sha="${4:-}";     [ -n "$sha" ] || sha='{{SHA256}}'
+
+command -v jq >/dev/null || die "jq is required"
+dir="$ROOT/app/branding/$brand"
+[ -d "$dir" ] || die "no such brand: $brand"
+
+bless="$dir/blessing.json"
+[ -f "$bless" ] || die "$brand has no blessing.json (#227) — nothing to offer until someone is being asked"
+
+identifier=$(jq -r '.winget.identifier // empty' "$bless")
+owner=$(jq -r '.winget.namespaceOwner // empty' "$bless")
+status=$(jq -r '.status // empty' "$bless")
+agreed=$(jq -r '.winget.identifierAgreed // false' "$bless")
+[ -n "$identifier" ] || die "$brand: blessing.json names no winget.identifier"
+
+name=$(jq -r '.name // empty' "$dir/brand.json")
+product=$(jq -r '.productName // empty' "$dir/brand.json")
+tagline=$(jq -r '.tagline // empty' "$dir/brand.json")
+exe=$(jq -r '.exeName // empty' "$dir/brand.json")
+[ -n "$name" ] && [ -n "$product" ] && [ -n "$tagline" ] && [ -n "$exe" ] \
+    || die "$brand: brand.json is missing name/productName/tagline/exeName"
+
+publisher="${identifier%%.*}"
+moniker=$(printf '%s' "$identifier" | tr '[:upper:]' '[:lower:]' | tr '.' '-')
+
+# The publisher URL is the BRAND's home, not ours — the package is published
+# in their namespace. Fall back to this repo only for our own marks, whose
+# assetSource is an emoji rather than a site.
+publisher_url=$(jq -r '.mark.assetSource // empty' "$bless")
+case "$publisher_url" in
+    http*) ;;
+    *) publisher_url="https://github.com/tuna-os/wootc" ;;
+esac
+
+# Never let a rendered artifact assert a permission nobody has given.
+if [ "$agreed" = "true" ]; then
+    permission="The $name name and mark are used with the $name project's permission."
+else
+    permission="PERMISSION NOT YET GRANTED — this is a draft offered for review, not a submission."
+fi
+
+# The header is addressed to a human deciding whether to accept this, so it
+# says who owns the namespace and what has actually been agreed — never let a
+# rendered artifact imply a permission that has not been given.
+cat <<HEADER
+# winget manifests for $product ($identifier)
+#
+# Namespace owner : $owner
+# Blessing status : $status (identifier agreed: $agreed)
+# Rendered by     : packaging/winget/render-brand.sh — NOT submitted anywhere.
+#
+# $identifier is $owner's to publish. These are offered so that decision can
+# be made against the real thing; take them over, ask us to publish on your
+# behalf, or say no and nothing is submitted.
+HEADER
+
+for template in "$TEMPLATES"/version.yaml.in \
+                "$TEMPLATES"/installer.yaml.in \
+                "$TEMPLATES"/locale.en-US.yaml.in; do
+    [ -f "$template" ] || die "missing template $template"
+    out="$identifier.$(basename "${template%.yaml.in}").yaml"
+    printf '\n--- %s ---\n' "$out"
+    sed -e "s|{{IDENTIFIER}}|$identifier|g" \
+        -e "s|{{VERSION}}|$version|g" \
+        -e "s|{{TAG}}|$tag|g" \
+        -e "s|{{URL}}|$url|g" \
+        -e "s|{{SHA256}}|$sha|g" \
+        -e "s|{{PUBLISHER}}|$publisher|g" \
+        -e "s|{{PUBLISHER_URL}}|$publisher_url|g" \
+        -e "s|{{PACKAGE_NAME}}|$product|g" \
+        -e "s|{{BRAND_NAME}}|$name|g" \
+        -e "s|{{TAGLINE}}|$tagline|g" \
+        -e "s|{{COMMAND}}|$exe|g" \
+        -e "s|{{MONIKER}}|$moniker|g" \
+        -e "s|{{PERMISSION}}|$permission|g" \
+        "$template"
+done

--- a/tests/unit/brand-blessings.bats
+++ b/tests/unit/brand-blessings.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# Upstream blessings (#227) — the release matrix follows the recorded decision.
+#
+# Every branded exe wears somebody else's mark. `app/branding/*/blessing.json`
+# records what that project said, and packaging/brands.sh is what makes the
+# record load-bearing rather than documentary: a declined project's exe drops
+# out of the release, and a brand nobody has written a record for cannot be
+# built at all.
+#
+# The Go side (app/blessing_test.go) validates the records themselves — that a
+# status agrees with its own four answers, and that a foreign mark cannot be
+# marked blessed without a link to the yes. These tests cover the shell gate
+# and the artifacts offered to the projects.
+
+BRANDS=packaging/brands.sh
+RENDER=packaging/winget/render-brand.sh
+RELEASE=.github/workflows/release.yml
+
+setup() {
+    FIXTURE="$BATS_TEST_TMPDIR/branding"
+    cp -r app/branding "$FIXTURE"
+}
+
+# Rewrites one field of a fixture brand's blessing record.
+fixture_set() {
+    python3 -c '
+import json, sys
+path, expr = sys.argv[1], sys.argv[2]
+d = json.load(open(path))
+exec(expr, {"d": d})
+json.dump(d, open(path, "w"), indent=2)
+' "$FIXTURE/$1/blessing.json" "$2"
+}
+
+@test "the real tree lists every brand that has not been declined" {
+    run bash "$BRANDS" list
+    [ "$status" -eq 0 ]
+    # One line per brand, "<brand><TAB><exeName>".
+    [[ "$output" == *$'wootc\twootc'* ]]
+    [[ "$output" == *$'bazzite\tBazzite-Installer'* ]]
+    [[ "$output" == *$'aurora\tAurora-Installer'* ]]
+    [[ "$output" == *$'bluefin\tBluefin-Installer'* ]]
+    [[ "$output" == *$'tunaos\tTunaOS-Installer'* ]]
+    [ "${#lines[@]}" -eq 5 ]
+}
+
+@test "a declined project's exe drops out of the release matrix" {
+    fixture_set bazzite 'd["status"]="declined"; d["decisions"]["distributeExe"]="no"'
+    WOOTC_BRANDING_DIR="$FIXTURE" run bash "$BRANDS" list
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Bazzite-Installer"* ]]
+    [[ "$output" == *"Aurora-Installer"* ]]
+    # ...and the log says whose decision it was, not just that a build vanished.
+    WOOTC_BRANDING_DIR="$FIXTURE" run bash "$BRANDS" explain
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DROPPED"* ]]
+    [[ "$output" == *"bazzite"* ]]
+    [[ "$output" == *"not ours to ship"* ]]
+}
+
+@test "a brand with no recorded decision is an error, not a default yes" {
+    # The failure mode this whole mechanism exists to prevent: someone adds
+    # app/branding/<x>/ and it ships on nobody's say-so.
+    mkdir -p "$FIXTURE/newbrand"
+    cp app/branding/wootc/brand.json "$FIXTURE/newbrand/brand.json"
+    WOOTC_BRANDING_DIR="$FIXTURE" run bash "$BRANDS" list
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no blessing.json"* ]]
+    [[ "$output" == *"recorded decision"* ]]
+}
+
+@test "an unrecognised status is an error, never treated as buildable" {
+    fixture_set aurora 'd["status"]="probably fine"'
+    WOOTC_BRANDING_DIR="$FIXTURE" run bash "$BRANDS" list
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not blessed/pending/declined"* ]]
+}
+
+@test "WOOTC_REQUIRE_BLESSING tightens pending brands out without a code change" {
+    WOOTC_BRANDING_DIR="$FIXTURE" WOOTC_REQUIRE_BLESSING=1 run bash "$BRANDS" list
+    [ "$status" -eq 0 ]
+    # Only the two marks this project owns survive today.
+    [ "${#lines[@]}" -eq 2 ]
+    [[ "$output" == *"wootc"* ]]
+    [[ "$output" == *"TunaOS-Installer"* ]]
+    [[ "$output" != *"Bazzite-Installer"* ]]
+}
+
+@test "a pending brand still builds, and the log says it is unblessed" {
+    # Shipping predates the ask, so pending is not a stop — but a release that
+    # quietly includes an unblessed exe teaches nobody to chase the answer.
+    WOOTC_BRANDING_DIR="$FIXTURE" run bash "$BRANDS" explain
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"UNBLESSED"* ]]
+    [[ "$output" == *"docs/upstream-blessings.md"* ]]
+}
+
+@test "the release workflow selects brands through the gate, not a bare glob" {
+    run bash -c "grep -A28 'Build brand installers' $RELEASE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"packaging/brands.sh list"* ]]
+    [[ "$output" == *"packaging/brands.sh explain"* ]]
+    # The old unconditional loop must be gone: it built whatever existed.
+    run bash -c "grep -c 'for dir in app/branding/\*/' $RELEASE"
+    [ "$output" = "0" ]
+    # And the selector's exit status must reach the step: a process
+    # substitution would drop it and half-build the matrix.
+    grep -q 'brands=$(bash packaging/brands.sh list)' "$RELEASE"
+}
+
+@test "every brand renders a complete winget manifest set" {
+    while IFS=$'\t' read -r brand _; do
+        run bash "$RENDER" "$brand" 0.2.0 https://example.invalid/x.exe deadbeef
+        [ "$status" -eq 0 ]
+        # A placeholder that survives rendering is a manifest that would be
+        # rejected — and worse, one we might hand to a project as our offer.
+        [[ "$output" != *"{{"* ]]
+        [[ "$output" == *"PackageIdentifier:"* ]]
+    done < <(bash "$BRANDS" list)
+}
+
+@test "a rendered manifest never claims a permission nobody has granted" {
+    # bazzite is pending: the artifact must say so on its face, because this
+    # is the thing that gets pasted into somebody else's issue tracker.
+    run bash "$RENDER" bazzite
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PERMISSION NOT YET GRANTED"* ]]
+    [[ "$output" == *"NOT submitted anywhere"* ]]
+    [[ "$output" == *"Namespace owner : Universal Blue"* ]]
+    [[ "$output" != *"used with the Bazzite project's permission"* ]]
+    # The identifier sits in THEIR namespace, not ours.
+    [[ "$output" == *"PackageIdentifier: Bazzite.Installer"* ]]
+    [[ "$output" != *"PackageIdentifier: TunaOS.Bazzite"* ]]
+}
+
+@test "the renderer refuses a brand with no record to offer" {
+    run bash "$RENDER" nosuchbrand
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no such brand"* ]]
+}
+
+@test "no branded package is auto-submitted to winget" {
+    # winget-publish.yml is the only thing that submits, and it submits the
+    # generic package only. A branded identifier reaching it would be a
+    # submission into someone else's namespace on our own authority.
+    run bash -c "grep -c 'Bazzite.Installer\|Aurora.Installer\|Bluefin.Installer' .github/workflows/winget-publish.yml"
+    [ "$output" = "0" ]
+    grep -q 'TunaOS.wootc' .github/workflows/winget-publish.yml
+    # The brand templates are rendered on demand, never wired into a workflow.
+    run bash -c "grep -rl 'render-brand.sh' .github/workflows/ 2>/dev/null | wc -l"
+    [ "$output" = "0" ]
+}
+
+@test "the README table and the records cannot drift apart" {
+    # The Go suite owns this invariant; this asserts it is actually wired in,
+    # so a reader of the shell gate knows where the rest of the line is held.
+    grep -q 'TestBrandBlessings_READMETableMatchesTheRecords' app/blessing_test.go
+    grep -q 'ForeignMarksNeedEvidence' app/blessing_test.go
+    # Every brand directory carries a record right now.
+    for dir in app/branding/*/; do
+        [ -f "$dir/blessing.json" ] || {
+            echo "no blessing.json in $dir"; return 1
+        }
+    done
+}


### PR DESCRIPTION
Refs #227.

## What this is, and what it deliberately is not

The issue's core ask — getting Universal Blue to say yes or no about Bazzite, Aurora and Bluefin — is a maintainer conversation, and those answers are theirs to give. **This PR does not fabricate any of them.** Every third-party brand lands as `pending` with `ask.filed: false`, because no request has been filed and the record should say so rather than imply a conversation that did not happen.

What it does ship is the half that was missing and that makes those answers mean something when they arrive: somewhere to put the decision, a release matrix that obeys it, and the packet that turns "go ask them" into a copy-paste.

Today `app/branding/*/` is globbed and every directory becomes a release exe. There is no place to record a decision, and a `declined` would change nothing.

## The record

`app/branding/<brand>/blessing.json`, one per brand:

- the **four separate answers** the issue asks for — mark, name, tagline, distributing a branded exe — because a project may be glad to be installed and still not want an exe carrying its logo built by someone else;
- **who owns the mark**, and where the assets came from;
- **who owns the winget namespace** the identifier would live in, and whether that identifier has been agreed;
- **where the ask was filed**, when, and the link to the answer.

Recorded state:

| Brand | Mark owner | Status | winget identifier |
|---|---|---|---|
| `wootc`, `tunaos` | TunaOS — this project | blessed | `TunaOS.*` (ours) |
| `bluefin`, `bazzite`, `aurora` | Universal Blue | **pending**, unasked | theirs |

## The matrix obeys it

`packaging/brands.sh` selects which brands build; `release.yml` builds what it lists instead of globbing.

- **declined** → the exe drops from the release matrix. This is the issue's "a declined brand's exe drops" made real.
- **no record at all** → hard error. A new `app/branding/<x>/` cannot reach a release without someone writing down who was asked. This is the failure mode the whole mechanism exists to prevent.
- **pending** → still builds, since shipping predates the ask, but the release log names it unblessed. `WOOTC_REQUIRE_BLESSING=1` drops pending brands too, so tightening the policy is a workflow setting rather than another code change.

I deliberately did **not** stop shipping the pending brands. The issue only calls for declined to drop, and pulling three exes out of the release on my own initiative is a product decision, not a mechanism one — the knob is there for whoever wants to make it.

The selector's exit status reaches the step: the loop captures the list first, because `done < <(brands.sh list)` would swallow a non-zero exit and half-build the matrix — the same silent-skip the selector refuses internally.

## The ask

`docs/upstream-blessings.md` — the four questions with what a "no" costs for each, what to show them (their own generated walkthrough, the asset provenance, a real install on video), the winget namespace offer in three forms including "no package at all", a draft request that makes the no genuinely free, and how to record the answer.

## The winget offer

`Bazzite.Installer` sits in Bazzite's publisher namespace, not ours. The useful form of "may we?" is not a description of a package — it is the package. `packaging/winget/render-brand.sh` renders a brand's manifests into **its** namespace from its own `brand.json` and `blessing.json`:

```
$ packaging/winget/render-brand.sh bazzite
# winget manifests for Bazzite Installer (Bazzite.Installer)
# Namespace owner : Universal Blue — ublue-os
# Blessing status : pending (identifier agreed: false)
# Rendered by     : packaging/winget/render-brand.sh — NOT submitted anywhere.
```

Rendered, never submitted. The description reads `PERMISSION NOT YET GRANTED` until `identifierAgreed` is true, so a draft pasted into somebody else's issue tracker cannot imply a yes nobody gave. `winget-publish.yml` is untouched and still submits only `TunaOS.wootc`.

## Tests

`app/blessing_test.go` — the records:

- **status is derived, never asserted**: any `no` → declined, all four `yes` → blessed. A hand-written status that disagrees with its own answers fails.
- **a yes needs a link**: a mark this project does not own cannot be `blessed` without `ask.evidence`. A yes we cannot point at is a yes we invented. `declined` needs evidence too — dropping someone's exe on a misremembered conversation is its own kind of wrong.
- **`selfOwned` is pinned** to `wootc` and `tunaos`, since it is the escape hatch from every check above.
- **a foreign winget identifier** cannot be marked agreed without evidence.
- **every cell** of the README table is compared against the JSON.

`tests/unit/brand-blessings.bats` — the gate and the artifacts: a declined brand drops and the log says whose decision it was; an unrecorded brand errors; an unknown status errors; `WOOTC_REQUIRE_BLESSING=1` leaves only our own two marks; every brand renders a manifest set with no surviving `{{placeholder}}`; a pending render says so on its face; no branded identifier appears in `winget-publish.yml` at all.

Mutation-checked, and one gate was found too weak and tightened: the README check originally matched the status as a substring of the row, which passed a row whose status cell had drifted to `blessed` while its decision cells still read `pending`. It now compares cell by cell, and both drifts go red.

Local: `go test ./...` green, all bats suites green except `userdata-persistence.bats`, which fails on an uninitialized `fisherman` submodule in this checkout and is untouched here; `shellcheck -S warning` clean on both new scripts.

## Not done here

The conversations themselves. When an answer comes back, it is a JSON edit plus the matching README row — `docs/upstream-blessings.md` § Recording the answer spells it out, and the tests refuse to let the two drift apart. #227 should stay open until each row carries a real decision.

— hive: backend=claude model=claude-opus-5
