### PR TITLE
fix(e2e): classify and retry QGA channel loss instead of blaming the product

### DIFF
--- a/docs/agent-lessons.md
+++ b/docs/agent-lessons.md
@@ -753,3 +753,44 @@ copy loop saw an unattributable vendor binary and refused, correctly.
 - The harness now drops the task once the app is up and then *counts*
   `wootc.exe` before writing the directive — no instance can install until the
   directive exists, so an extra killed at that point provably never installed.
+
+## 33. A deaf channel has no opinion about the product
+
+el10-gnome-win11pro (run 32556250889) reported "install stalled at *Finding
+your files*" after waiting out its full 30-minute drive deadline. Printed
+underneath that verdict, in the same block, was the fact that invalidated it:
+
+```
+[FAIL] GUI-driven install did not reach the done screen in 30m
+[FAIL]   QGA does NOT answer ping — the verdict above may be a lost channel
+```
+
+The QGA virtio-serial channel had gone deaf. A stalled installer and a dead
+channel produce the *same* observable — the drive-state file stops changing —
+and opposite causes, so the run had no standing to say anything about the
+install. It said it anyway, thirty minutes late, and a human had to read the
+log to find out the red was not real.
+
+- **Ask the discriminator first, not last.** `guest-ping` decides which verdict
+  is even available, so it runs *before* anything is written down. Appending
+  the channel state under a product verdict is the wrong order: the caveat does
+  not retract the claim, it just sits below it.
+- **Waiting longer cannot make a deaf socket talk.** The remaining ~28 minutes
+  bought nothing except the appearance of diligence. Once ping is dead, one
+  bounded reconnect cycle — reap the clients that may still hold the
+  single-client socket, drain what the killed one left queued (§20), reopen
+  with a delimited sync — and then a verdict either way.
+- **Say what you do not know.** The classification is `qga-channel-lost` and it
+  states that the run has *no* verdict on the product. The install may have
+  finished, stalled or failed; the harness cannot tell, so it does not guess.
+- **Name the class in the ledger.** `note_flake` writes the machine-readable
+  verdict the retry gate reads, and the ledger line names the same class, so
+  the re-dispatch decision needs no human in it.
+- **Exit 1 from a socket that will not open was the same mistake in miniature.**
+  `qga.py` connected outside its own error handler, so ENOENT on a dead channel
+  exited 1 — indistinguishable from a guest command that ran and returned 1,
+  which `qga_call_retry` must never replay (§#40). A transport failure has to
+  say so: it exits 42.
+
+Guarded by `tests/unit/qga-channel-lost.bats` and a synthetic channel kill
+against a real socket in `tests/unit/test_qga_reconnect.py`.

--- a/tests/e2e/qga.py
+++ b/tests/e2e/qga.py
@@ -24,12 +24,51 @@ SOCKET = "/run/shm/qga.sock"
 
 
 class GuestAgent:
-    def __init__(self, path=SOCKET, timeout=60.0):
+    def __init__(self, path=SOCKET, timeout=60.0, drain_grace=0.0):
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.timeout = timeout
         self.sock.settimeout(timeout)
         self.sock.connect(path)
+        # Drain BEFORE makefile(): the bytes a dead client left behind are raw
+        # socket data, and once a buffered reader has joined them onto the head
+        # of our first real response there is no un-joining them.
+        self.drained = self._drain(drain_grace)
         self.file = self.sock.makefile("rwb")
         self._sync()
+
+    def _drain(self, grace=0.0):
+        """Discard whatever a previous client left in the channel.
+
+        The QGA virtio-serial socket takes ONE client at a time, so a client
+        that was KILLED mid-request (our `timeout` wrapper does exactly that on
+        124) leaves its reply queued: the next connection reads that reply as
+        the answer to a question it never asked, and every subsequent response
+        is off by one — the channel is open and useless. guest-sync-delimited
+        re-anchors the stream, but only once the backlog ahead of it is gone.
+
+        `grace` is a bounded blocking window: 0 means "take only what has
+        already arrived" (the hot path, no added latency), and the recovery
+        path in reconnect() pays a fraction of a second to also catch bytes
+        still in flight. Bounded either way — a channel that streams forever
+        must not turn a drain into the hang it exists to prevent.
+        """
+        discarded = 0
+        deadline = time.monotonic() + max(grace, 0.0) + 1.0
+        self.sock.settimeout(grace if grace > 0 else 0.0)
+        try:
+            while time.monotonic() < deadline and discarded < 4 * 1024 * 1024:
+                try:
+                    chunk = self.sock.recv(65536)
+                except (BlockingIOError, socket.timeout):
+                    break
+                except OSError:
+                    break
+                if not chunk:
+                    break
+                discarded += len(chunk)
+        finally:
+            self.sock.settimeout(self.timeout)
+        return discarded
 
     def _sync(self):
         """Synchronize with QGA using guest-sync-delimited.
@@ -179,6 +218,47 @@ class GuestAgent:
         return written_total
 
 
+def reconnect(path=SOCKET, attempts=3, settle=3.0, timeout=10.0, log=None):
+    """One bounded reconnect cycle against a channel that stopped answering.
+
+    Returns True as soon as a freshly opened connection gets a guest-ping back,
+    False once the attempt budget is spent.  Each attempt is a full cycle:
+    open, drain what the previous client left, re-anchor with a 0xFF-delimited
+    sync, ping.
+
+    BOUNDED is the whole point.  A deaf virtio-serial channel does not heal by
+    being asked again for half an hour — el10-gnome-win11pro in run
+    32556250889 waited out its full 30-minute drive deadline and then reported
+    the product as broken on evidence it did not have (#220).  Either a small
+    number of clean reopens gets the channel back, or the caller must classify
+    the run `qga-channel-lost` and let the retry gate re-dispatch it.
+    """
+    def emit(message):
+        (log or (lambda m: print("QGA reconnect: %s" % m, file=sys.stderr)))(message)
+
+    for attempt in range(1, attempts + 1):
+        agent = None
+        try:
+            agent = GuestAgent(path, timeout=timeout, drain_grace=0.5)
+            agent.request("guest-ping")
+            emit(
+                "attempt %d/%d: channel answered guest-ping "
+                "(discarded %d stale bytes)" % (attempt, attempts, agent.drained)
+            )
+            return True
+        except (OSError, RuntimeError, ValueError) as error:
+            emit("attempt %d/%d: %s" % (attempt, attempts, error))
+        finally:
+            if agent is not None:
+                try:
+                    agent.close()
+                except OSError:
+                    pass
+        if attempt < attempts:
+            time.sleep(settle)
+    return False
+
+
 def powershell(agent, command):
     return agent.exec(
         r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
@@ -204,9 +284,38 @@ def main():
     write = sub.add_parser("write")
     write.add_argument("local_path")
     write.add_argument("guest_path")
+    recon = sub.add_parser("reconnect")
+    recon.add_argument("--attempts", type=int, default=3)
+    recon.add_argument("--settle", type=float, default=3.0)
+    recon.add_argument("--timeout", type=float, default=10.0)
     args = parser.parse_args()
 
-    agent = GuestAgent(args.socket)
+    if args.command == "reconnect":
+        if reconnect(
+            args.socket,
+            attempts=args.attempts,
+            settle=args.settle,
+            timeout=args.timeout,
+        ):
+            return 0
+        print(
+            "QGA: channel still deaf after %d reconnect attempts — qga-channel-lost"
+            % args.attempts,
+            file=sys.stderr,
+        )
+        return TRANSPORT_EXIT
+
+    # A socket that will not open is a TRANSPORT failure, and it used to exit
+    # 1: the connect() sat OUTSIDE this try, so ENOENT/ECONNREFUSED on a dead
+    # channel raised a bare traceback.  Exit 1 is indistinguishable from a
+    # guest command that ran and returned 1, so qga_call_retry refused to retry
+    # it (#40 forbids replaying guest exit codes) and every caller read a dead
+    # socket as a real, guest-side failure — the masquerade #220 is about.
+    try:
+        agent = GuestAgent(args.socket)
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"QGA: cannot open {args.socket}: {error}", file=sys.stderr)
+        return TRANSPORT_EXIT
     try:
         if args.command == "ping":
             agent.request("guest-ping")
@@ -241,7 +350,10 @@ def main():
         print(f"QGA: {error}", file=sys.stderr)
         return TRANSPORT_EXIT
     finally:
-        agent.close()
+        try:
+            agent.close()
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -609,6 +609,62 @@ qga_probe() {
     WOOTC_QGA_CALL_TIMEOUT=5 qga_call_retry ping >/dev/null 2>&1 || return 1
 }
 
+# ── the QGA-channel-loss failure class (#220) ────────────────────────────────
+# A deaf virtio-serial channel and a stalled installer produce the SAME
+# observable — the drive-state file stops changing — and opposite verdicts.
+# guest-ping is the discriminator, and these two helpers are what the harness
+# does with the answer.
+#
+# qga_reconnect_cycle runs ONE bounded recovery attempt. The socket takes a
+# single client at a time, so a client our `timeout` wrapper killed on 124 can
+# still own it, with its unread reply queued behind — the next connection then
+# reads that reply as the answer to a question it never asked (agent-lessons
+# §20: a retried command is a second command). Reaping the stale clients and
+# reopening with a drained, 0xFF-delimited sync is the whole recovery.
+#
+# It is one cycle and not a loop on purpose. If a few clean reopens cannot get
+# a ping back, the channel is gone, and grinding away at it just re-buys the
+# 30-minute false verdict this exists to delete.
+WOOTC_QGA_RECONNECT_ATTEMPTS="${WOOTC_QGA_RECONNECT_ATTEMPTS:-3}"
+WOOTC_QGA_RECONNECT_SETTLE_S="${WOOTC_QGA_RECONNECT_SETTLE_S:-3}"
+qga_reconnect_cycle() {
+    local out rc=0
+    warn "  QGA channel is not answering — ONE bounded reconnect cycle before any verdict"
+    # Clients that outlived their `timeout` may still hold the single-client
+    # socket. Reaping them is a prerequisite for the reopen, not an extra.
+    $DOCKER exec "$CONTAINER_NAME" pkill -f '/tmp/qga.py' >/dev/null 2>&1 || true
+    sleep 1
+    out=$(timeout 60 $DOCKER exec "$CONTAINER_NAME" python3 /tmp/qga.py reconnect \
+        --attempts "$WOOTC_QGA_RECONNECT_ATTEMPTS" \
+        --settle "$WOOTC_QGA_RECONNECT_SETTLE_S" 2>&1) || rc=$?
+    # An `x && y` tail would be the last status of this block under `set -e`,
+    # and an empty $out would abort the whole run from inside the recovery path.
+    if [ -n "$out" ]; then
+        printf '%s\n' "$out" | sed 's/^/    reconnect: /'
+    fi
+    if [ "$rc" -eq 0 ]; then
+        pass "  QGA channel RECOVERED — the stall was the channel, and it is back"
+        return 0
+    fi
+    return 1
+}
+
+# qga_channel_lost writes the verdict for a channel that did not come back.
+# The WORDING is the deliverable, not decoration: run 32556250889 led with
+# "install stalled at Finding your files" and appended the dead-ping caveat
+# underneath, so the run read as a product red for a failure the harness had
+# no evidence about. Once the channel is deaf the harness knows nothing about
+# the install and must say exactly that. The ledger line NAMES the class, so
+# the re-dispatch decision needs no human to read the log.
+qga_channel_lost() {
+    local where="$1"
+    fail "CLASSIFICATION: qga-channel-lost — the QGA channel died during $where"
+    fail "  QGA does NOT answer ping, and one bounded reconnect cycle did not bring the channel back."
+    fail "  This run has NO verdict on the product: the install may have finished, stalled or failed,"
+    fail "  and with the channel deaf the harness cannot tell — so it does not guess."
+    note_flake "qga-channel-lost"
+}
+
 qga_wait() {
     local label="$1" timeout="$2" elapsed=0
     step "Waiting for QGA: $label..."
@@ -2791,6 +2847,10 @@ if ($left.Count -ne 1) { Write-Output ("SINGLE-INSTANCE-UNPROVEN: " + $left.Coun
     local drive_deadline drive_state="" driven=false
     local last_good="" last_screen="" empty_reads=0 total_empty=0 blocked_reads=0
     local dead_app_checks=0
+    # One reconnect cycle per run, not per stall: the second time the channel
+    # goes deaf we already know reopening is on the table, and the answer is a
+    # verdict rather than another round of dialling.
+    local reconnect_tried=false
     local WOOTC_DRIVE_APP_DEAD_THRESHOLD="${WOOTC_DRIVE_APP_DEAD_THRESHOLD:-12}"
     drive_deadline=$(deadline_in 1800)
     while ! past_deadline "$drive_deadline"; do
@@ -2844,6 +2904,24 @@ if ($left.Count -ne 1) { Write-Output ("SINGLE-INSTANCE-UNPROVEN: " + $left.Coun
                     fi
                 else
                     warn "  drive state unreadable AND QGA does not answer ping — lost the channel to the guest"
+                    # Do not wait this out. The remaining ~28 minutes cannot
+                    # make a deaf channel talk, and spending them produces a
+                    # verdict about the PRODUCT from a run that stopped being
+                    # able to observe it (#220). One bounded reconnect cycle,
+                    # then classify and hand the run to the retry gate.
+                    if [ "$reconnect_tried" = false ]; then
+                        reconnect_tried=true
+                        if qga_reconnect_cycle; then
+                            empty_reads=0
+                            sleep 10
+                            continue
+                        fi
+                    fi
+                    qga_channel_lost "the GUI-driven install"
+                    fail "  last screen reached: ${last_screen:-<none>} (install clicked: $driven)"
+                    fail "  last readable state: ${last_good:-<never read one>}"
+                    capture_vm_diagnostics
+                    exit 1
                 fi
             fi
             sleep 10
@@ -2936,18 +3014,27 @@ if (Test-Path $cfg) { Write-Output "grub.cfg first line:"; Write-Output ("  " + 
         sleep 10
     done
     printf '%s' "$drive_state" | grep -q '"screen":"done"' || {
+        # WHICH failure this is depends on the channel, so ask BEFORE writing a
+        # verdict. This used to lead with "did not reach the done screen in 30m"
+        # and append the dead-ping caveat underneath — a product red on top of
+        # the one fact that says the run has no standing to judge the product.
+        # The discriminator keeps it honest in both directions: an installer
+        # that stalled with a LIVE channel writes no flake verdict and stays a
+        # real red, which is why the reconnect cycle must fail too before the
+        # class is claimed.
+        if ! qga_probe && ! qga_reconnect_cycle; then
+            qga_channel_lost "the GUI-driven install"
+            fail "  last screen reached: ${last_screen:-<none>} (install clicked: $driven)"
+            fail "  last readable state: ${last_good:-<never read one>}"
+            fail "  unreadable reads: $total_empty of ~180"
+            capture_vm_diagnostics
+            exit 1
+        fi
         fail "GUI-driven install did not reach the done screen in 30m"
         fail "  last screen reached: ${last_screen:-<none>} (install clicked: $driven)"
         fail "  last readable state: ${last_good:-<never read one>}"
         fail "  unreadable reads: $total_empty of ~180"
-        if qga_probe; then
-            fail "  QGA answers ping NOW — so this is the installer, not the channel"
-        else
-            fail "  QGA does NOT answer ping — the verdict above may be a lost channel, not a stalled install"
-            # The discriminator that keeps this honest: an installer that
-            # stalled with a LIVE channel writes no verdict and is a real red.
-            note_flake "qga-channel-lost"
-        fi
+        fail "  QGA answers ping — so this is the installer, not the channel"
         capture_vm_diagnostics
         exit 1
     }

--- a/tests/unit/qga-channel-lost.bats
+++ b/tests/unit/qga-channel-lost.bats
@@ -1,0 +1,225 @@
+#!/usr/bin/env bats
+# The QGA-channel-loss failure class (#220).
+#
+# The exemplar is el10-gnome-win11pro in run 32556250889: the drive-state file
+# stopped changing, the harness waited out its full 30-minute deadline, and
+# then reported "install stalled at Finding your files" — with the dead-ping
+# caveat printed underneath the verdict it invalidated. A deaf virtio-serial
+# channel and a stalled installer produce the SAME observable and opposite
+# causes, so the channel has to be asked before anything is written down, and
+# what gets written must name the class rather than the product.
+#
+# The recovery itself (drain, reopen, bounded give-up) is exercised against a
+# real killed socket in tests/unit/test_qga_reconnect.py. Here the two harness
+# helpers are sourced and RUN against a stubbed container, and the wiring that
+# reaches them is pinned statically.
+
+E2E=tests/e2e/run-e2e.sh
+QGA=tests/e2e/qga.py
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    ABS_E2E="$REPO_ROOT/$E2E"
+    # Source just the helpers — running the script would start a VM.
+    eval "$(sed -n '/^pass()/,/^info()/p' "$ABS_E2E")"
+    eval "$(sed -n '/^note_flake()/,/^}/p' "$ABS_E2E")"
+    eval "$(sed -n '/^WOOTC_QGA_RECONNECT_ATTEMPTS=/,/^}/p' "$ABS_E2E")"
+    eval "$(sed -n '/^qga_channel_lost()/,/^}/p' "$ABS_E2E")"
+
+    STORAGE_DIR="$BATS_TEST_TMPDIR/storage"; mkdir -p "$STORAGE_DIR"
+    WOOTC_FAILURE_LEDGER="$BATS_TEST_TMPDIR/ledger"; : > "$WOOTC_FAILURE_LEDGER"
+    CONTAINER_NAME="stub-ctr"
+    STUB_LOG="$BATS_TEST_TMPDIR/stub.log"; : > "$STUB_LOG"
+    export STORAGE_DIR WOOTC_FAILURE_LEDGER STUB_LOG
+    # A stand-in for podman/docker: records what it was asked to run and takes
+    # the reconnect exit code from the environment.
+    DOCKER="$BATS_TEST_TMPDIR/docker"
+    cat > "$DOCKER" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$STUB_LOG"
+case "$*" in
+    *pkill*)              exit "${STUB_PKILL_RC:-1}" ;;
+    *"qga.py reconnect"*) printf '%s' "${STUB_RECONNECT_OUT-}"
+                          exit "${STUB_RECONNECT_RC:-0}" ;;
+esac
+exit 0
+STUB
+    chmod +x "$DOCKER"
+    export DOCKER CONTAINER_NAME
+}
+
+@test "the reconnect cycle reports a channel that came back" {
+    eval "$(sed -n '/^qga_reconnect_cycle()/,/^}/p' "$ABS_E2E")"
+    STUB_RECONNECT_RC=0 STUB_RECONNECT_OUT="attempt 1/3: channel answered guest-ping"
+    export STUB_RECONNECT_RC STUB_RECONNECT_OUT
+    run qga_reconnect_cycle
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RECOVERED"* ]]
+    [[ "$output" == *"reconnect: attempt 1/3"* ]]
+    # Stale clients are reaped BEFORE the reopen, not after: while one holds
+    # the single-client socket the reopen cannot succeed.
+    run cat "$STUB_LOG"
+    [[ "${lines[0]}" == *pkill* ]]
+    [[ "${lines[1]}" == *"qga.py reconnect"* ]]
+    [[ "${lines[1]}" == *"--attempts 3"* ]]
+    [[ "${lines[1]}" == *"--settle 3"* ]]
+}
+
+@test "the reconnect cycle claims nothing when the channel stays deaf" {
+    eval "$(sed -n '/^qga_reconnect_cycle()/,/^}/p' "$ABS_E2E")"
+    STUB_RECONNECT_RC=42
+    STUB_RECONNECT_OUT="attempt 3/3: timed out"
+    export STUB_RECONNECT_RC STUB_RECONNECT_OUT
+    run qga_reconnect_cycle
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"RECOVERED"* ]]
+}
+
+@test "the recovery path cannot itself kill the run under set -e" {
+    # run-e2e.sh runs under `set -Eeuo pipefail`, so every non-zero step inside
+    # the recovery has to be absorbed deliberately. Both of the ordinary ones
+    # are: pkill exits 1 when there is nothing stale to reap (the common case),
+    # and a reconnect that fails is the whole reason this function exists. An
+    # unabsorbed either would abort the run from inside its own rescue, and
+    # bats `run` cannot see it — set -e is suspended in a tested call — so this
+    # invokes the function as a bare statement.
+    local probe="$BATS_TEST_TMPDIR/probe.sh"
+    {
+        echo 'set -Eeuo pipefail'
+        sed -n "/^RED='/,/^NC='/p" "$ABS_E2E"
+        sed -n '/^pass()/,/^info()/p' "$ABS_E2E"
+        sed -n '/^WOOTC_QGA_RECONNECT_ATTEMPTS=/,/^}/p' "$ABS_E2E"
+        # Bare, NOT `|| true`: set -e is suspended inside a tested call, which
+        # is exactly the leniency this test exists to deny itself.
+        echo 'qga_reconnect_cycle'
+        echo 'echo "SURVIVED"'
+    } > "$probe"
+    # Nothing stale to reap, channel comes back: runs to completion.
+    STUB_PKILL_RC=1 STUB_RECONNECT_RC=0 STUB_RECONNECT_OUT="attempt 1/3: ok" run bash "$probe"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SURVIVED"* ]]
+    # Channel stays deaf: the only non-zero the caller may see is the
+    # function's own verdict, reached AFTER the reconnect actually ran. An
+    # unabsorbed pkill or capture aborts before that line is ever printed.
+    STUB_PKILL_RC=1 STUB_RECONNECT_RC=42 STUB_RECONNECT_OUT="attempt 3/3: timed out" run bash "$probe"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"reconnect: attempt 3/3: timed out"* ]]
+    [[ "$output" != *"RECOVERED"* ]]
+}
+
+@test "the verdict lands in BOTH the ledger and the machine-readable file" {
+    run qga_channel_lost "the GUI-driven install"
+    [ "$status" -eq 0 ]
+    # The retry gate reads this file; nothing else re-dispatches a run.
+    [ "$(cat "$STORAGE_DIR/flake-verdict.txt")" = "qga-channel-lost" ]
+    # And the ledger NAMES the class, so the decision needs no log-reading.
+    grep -q 'CLASSIFICATION: qga-channel-lost' "$WOOTC_FAILURE_LEDGER"
+    grep -q 'NO verdict on the product' "$WOOTC_FAILURE_LEDGER"
+    # The product-failure wording must not ride along with it.
+    ! grep -qi 'did not reach the done screen' "$WOOTC_FAILURE_LEDGER"
+}
+
+@test "channel loss is classified, not waited out" {
+    # The drive loop's dead-ping branch must reach a verdict. Before #220 it
+    # only warn()ed and fell back into the poll, buying ~28 more minutes that
+    # cannot make a deaf channel talk.
+    run bash -c "grep -A20 'drive state unreadable AND QGA does not answer ping' $E2E"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"qga_reconnect_cycle"* ]]
+    [[ "$output" == *"qga_channel_lost"* ]]
+    [[ "$output" == *"exit 1"* ]]
+}
+
+@test "the reconnect cycle runs ONCE, and only before the verdict" {
+    # One cycle per run, not one per stall: a second deaf spell is answered
+    # with a classification, not another round of dialling.
+    grep -q 'local reconnect_tried=false' "$E2E"
+    # The in-loop call is fired behind the latch, and the latch is set BEFORE
+    # the attempt, so a cycle that dies mid-way cannot be retried either.
+    run bash -c "grep -B2 'if qga_reconnect_cycle; then' $E2E"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'if [ "$reconnect_tried" = false ]; then'* ]]
+    [[ "$output" == *"reconnect_tried=true"* ]]
+}
+
+@test "the reconnect cycle reaps stale clients before reopening" {
+    # The QGA socket takes ONE client at a time, so a client killed by the
+    # `timeout` wrapper can still own it with its reply queued behind — the
+    # poisoning caveat from agent-lessons §20. Reaping is part of the reopen.
+    run bash -c "sed -n '/^qga_reconnect_cycle()/,/^}/p' $E2E"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pkill"* ]]
+    [[ "$output" == *"qga.py reconnect"* ]]
+    # Bounded: an attempt budget and a settle delay, both overridable.
+    [[ "$output" == *'--attempts'* ]]
+    [[ "$output" == *'--settle'* ]]
+    grep -q 'WOOTC_QGA_RECONNECT_ATTEMPTS' "$E2E"
+    grep -q 'WOOTC_QGA_RECONNECT_SETTLE_S' "$E2E"
+}
+
+@test "the verdict names the class and claims nothing about the product" {
+    run bash -c "sed -n '/^qga_channel_lost()/,/^}/p' $E2E"
+    [ "$status" -eq 0 ]
+    # The ledger line NAMES the class, so re-dispatch needs no human to read
+    # the log — fail() is what appends to WOOTC_FAILURE_LEDGER.
+    [[ "$output" == *"CLASSIFICATION: qga-channel-lost"* ]]
+    [[ "$output" == *'note_flake "qga-channel-lost"'* ]]
+    # ...and it explicitly withholds a product verdict it cannot support.
+    [[ "$output" == *"NO verdict on the product"* ]]
+}
+
+@test "the 30-minute timeout leads with the channel, not with the product" {
+    # The old order printed "did not reach the done screen in 30m" first and
+    # appended "the verdict above may be a lost channel" underneath. The
+    # discriminator has to come FIRST because it decides which verdict is even
+    # available.
+    run bash -c "grep -A12 'GUI-driven install did not reach the done screen' $E2E"
+    [ "$status" -eq 0 ]
+    # A live channel is still a real product red, and writes no flake verdict.
+    [[ "$output" == *"QGA answers ping"* ]]
+    [[ "$output" != *"note_flake"* ]]
+    # The channel-lost arm is gated on BOTH a dead ping and a failed reconnect.
+    grep -q 'if ! qga_probe && ! qga_reconnect_cycle; then' "$E2E"
+}
+
+@test "a channel that comes back is not a failure" {
+    # The recovery path must resume the poll, not fall through to a verdict:
+    # a transient stall the reconnect fixes is a run that continues.
+    run bash -c "grep -A6 'if qga_reconnect_cycle; then' $E2E | head -8"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"continue"* ]]
+}
+
+@test "qga.py: a socket that will not open is TRANSPORT, not a guest exit code" {
+    # Exit 1 from a dead channel is indistinguishable from a guest command that
+    # ran and returned 1, so qga_call_retry refused to retry it (#40 forbids
+    # replaying guest exit codes) and callers read the dead channel as a real
+    # product failure — the masquerade this issue is about.
+    run bash -c "grep -A5 'agent = GuestAgent(args.socket)' $QGA"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"cannot open"* ]]
+    [[ "$output" == *"TRANSPORT_EXIT"* ]]
+}
+
+@test "qga.py: the reconnect cycle drains before it syncs" {
+    # guest-sync-delimited re-anchors the response stream, but only once the
+    # backlog ahead of it is gone — and the leftovers are raw socket bytes, so
+    # the drain must happen before makefile() joins them onto a real reply.
+    run bash -c "sed -n '/def __init__(self, path=SOCKET/,/self._sync()/p' $QGA"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"self._drain("* ]]
+    run bash -c "grep -n 'self._drain(drain_grace)' $QGA"
+    [ "$status" -eq 0 ]
+    drain_line=$(grep -n 'self.drained = self._drain' "$QGA" | cut -d: -f1)
+    makefile_line=$(grep -n 'self.file = self.sock.makefile' "$QGA" | cut -d: -f1)
+    [ "$drain_line" -lt "$makefile_line" ]
+}
+
+@test "the synthetic channel-kill test exists and runs in the fast tier" {
+    [ -f tests/unit/test_qga_reconnect.py ]
+    # tests/run.sh globs tests/unit/test_*.py, so the name is the wiring.
+    grep -q 'tests/unit/test_\*\.py' tests/run.sh
+    run python3 tests/unit/test_qga_reconnect.py
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+}

--- a/tests/unit/test_qga_reconnect.py
+++ b/tests/unit/test_qga_reconnect.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Synthetic channel-kill test for the QGA-channel-loss failure class (#220).
+
+A deaf virtio-serial channel and a stalled installer look identical from the
+harness: the guest stops answering and the drive-state file stops changing.
+They have opposite causes, and until the channel is asked directly, a run that
+lost the channel reports a verdict on a product it can no longer observe —
+el10-gnome-win11pro in run 32556250889 spent its full 30-minute drive deadline
+doing exactly that.
+
+These tests kill a REAL AF_UNIX channel underneath the client rather than
+faking the client's own methods, because the two things #220 turns on both
+live below the protocol: whether a reopen drains what a killed client left
+behind, and whether a socket that will not open is reported as a TRANSPORT
+failure or masquerades as a guest exit code.
+
+Run: python3 tests/unit/test_qga_reconnect.py
+"""
+
+import importlib.util
+import json
+import os
+import pathlib
+import socket
+import sys
+import tempfile
+import threading
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+QGA = HERE.parent / "e2e" / "qga.py"
+
+spec = importlib.util.spec_from_file_location("qga", QGA)
+qga = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(qga)
+
+
+class FakeQGA(threading.Thread):
+    """A real Unix socket that speaks just enough QGA to be killed credibly.
+
+    `script` gives the behaviour of each accepted connection in turn; the last
+    entry repeats forever, so ["deaf", "deaf", "healthy"] is a channel that
+    comes back on the third reopen.
+
+      healthy  answers guest-sync-delimited and guest-ping
+      deaf     accepts and answers NOTHING (the #220 signature: the socket is
+               there, the agent behind it is not)
+      poison   writes a dead client's leftovers — including a half line with
+               no terminator — the instant it accepts, then serves normally
+    """
+
+    daemon = True
+
+    def __init__(self, path, script):
+        super().__init__()
+        self.path = path
+        self.script = list(script)
+        self.connections = 0
+        self.stop = threading.Event()
+        self.listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.listener.bind(path)
+        self.listener.listen(8)
+        self.listener.settimeout(0.2)
+
+    def behaviour_for(self, index):
+        return self.script[min(index, len(self.script) - 1)]
+
+    def run(self):
+        while not self.stop.is_set():
+            try:
+                conn, _ = self.listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            behaviour = self.behaviour_for(self.connections)
+            self.connections += 1
+            threading.Thread(
+                target=self._serve, args=(conn, behaviour), daemon=True
+            ).start()
+
+    def shutdown(self):
+        self.stop.set()
+        try:
+            self.listener.close()
+        except OSError:
+            pass
+        self.join(timeout=2)
+        try:
+            os.unlink(self.path)
+        except OSError:
+            pass
+
+    def _serve(self, conn, behaviour):
+        try:
+            if behaviour == "poison":
+                # Exactly what a client killed mid-request leaves behind: a
+                # complete reply nobody is waiting for, then a truncated one.
+                conn.sendall(
+                    b'{"return": {"pid": 4321}}\n'
+                    b'{"return": "half a line from a client that was killed'
+                )
+                time.sleep(0.05)
+            if behaviour == "deaf":
+                self.stop.wait(5)
+                return
+            stream = conn.makefile("rwb")
+            while not self.stop.is_set():
+                line = stream.readline()
+                if not line:
+                    return
+                delimited = line[0:1] == b"\xff"
+                message = json.loads(line[1:] if delimited else line)
+                execute = message.get("execute")
+                if execute == "guest-sync-delimited":
+                    reply = {"return": message["arguments"]["id"]}
+                    stream.write(b"\xff" + json.dumps(reply).encode() + b"\n")
+                elif execute == "guest-ping":
+                    stream.write(json.dumps({"return": {}}).encode() + b"\n")
+                else:
+                    stream.write(
+                        json.dumps(
+                            {"error": {"class": "CommandNotFound", "desc": execute}}
+                        ).encode()
+                        + b"\n"
+                    )
+                stream.flush()
+        except (OSError, ValueError):
+            return
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+
+def _sock_path(tmp, name):
+    return os.path.join(tmp, name)
+
+
+def _quiet(_message):
+    """reconnect() logs to stderr by default; the tests do not need the noise."""
+
+
+def main():
+    failures = []
+    checks = 0
+
+    def check(ok, message):
+        nonlocal checks
+        checks += 1
+        if not ok:
+            failures.append(message)
+
+    tmp = tempfile.mkdtemp(prefix="qga-channel-kill-")
+
+    # 1. A live channel is recovered on the FIRST attempt — the cycle must not
+    #    charge a healthy channel for the settle delays it budgeted.
+    path = _sock_path(tmp, "healthy.sock")
+    server = FakeQGA(path, ["healthy"])
+    server.start()
+    try:
+        ok = qga.reconnect(path, attempts=3, settle=5.0, timeout=2.0, log=_quiet)
+        check(ok, "healthy channel: reconnect() did not recover it")
+        check(
+            server.connections == 1,
+            "healthy channel: took %d connections, expected 1" % server.connections,
+        )
+    finally:
+        server.shutdown()
+
+    # 2. THE CHANNEL KILL. A socket that accepts and then answers nothing is
+    #    the #220 signature. reconnect() must give up inside its budget rather
+    #    than hand the caller another half hour of waiting.
+    path = _sock_path(tmp, "deaf.sock")
+    server = FakeQGA(path, ["deaf"])
+    server.start()
+    try:
+        started = time.monotonic()
+        ok = qga.reconnect(path, attempts=3, settle=0.0, timeout=0.5, log=_quiet)
+        elapsed = time.monotonic() - started
+        check(not ok, "killed channel: reconnect() claimed a recovery it never got")
+        check(
+            elapsed < 15,
+            "killed channel: reconnect() took %.1fs — it is not bounded" % elapsed,
+        )
+        check(
+            server.connections == 3,
+            "killed channel: %d attempts, expected the 3 it was given"
+            % server.connections,
+        )
+    finally:
+        server.shutdown()
+
+    # 3. A channel that comes back WITHIN the budget is recovered, and the run
+    #    continues. This is the case that must not become a red: one bounded
+    #    cycle, then the install goes on.
+    path = _sock_path(tmp, "revives.sock")
+    server = FakeQGA(path, ["deaf", "deaf", "healthy"])
+    server.start()
+    try:
+        ok = qga.reconnect(path, attempts=3, settle=0.0, timeout=0.5, log=_quiet)
+        check(ok, "revived channel: reconnect() gave up on a channel that came back")
+    finally:
+        server.shutdown()
+
+    # 4. Socket poisoning: the single-client socket hands the next connection
+    #    whatever the killed client never read. Without a drain the leftovers
+    #    are joined onto the head of the sync reply and the reopen is useless.
+    path = _sock_path(tmp, "poisoned.sock")
+    server = FakeQGA(path, ["poison"])
+    server.start()
+    try:
+        agent = None
+        drained = -1
+        pinged = False
+        try:
+            agent = qga.GuestAgent(path, timeout=2.0, drain_grace=0.5)
+            drained = agent.drained
+            agent.request("guest-ping")
+            pinged = True
+        except (OSError, RuntimeError, ValueError) as error:
+            failures.append("poisoned socket: reopen failed (%s)" % error)
+        finally:
+            if agent is not None:
+                agent.close()
+        check(pinged, "poisoned socket: the reopened channel never answered ping")
+        check(
+            drained > 0,
+            "poisoned socket: %d bytes drained — the sync only got lucky, and "
+            "the leftovers are still ahead of the next reply" % drained,
+        )
+    finally:
+        server.shutdown()
+
+    # 5. THE MASQUERADE. A socket that will not open is a transport failure. It
+    #    used to exit 1, which is indistinguishable from a guest command that
+    #    ran and returned 1 — so qga_call_retry would not retry it (#40 forbids
+    #    replaying guest exit codes) and callers read a dead channel as a real,
+    #    guest-side failure.
+    missing = _sock_path(tmp, "not-here.sock")
+    argv = sys.argv
+    try:
+        sys.argv = ["qga.py", "--socket", missing, "ping"]
+        rc = qga.main()
+        check(
+            rc == qga.TRANSPORT_EXIT,
+            "dead socket: qga.py ping exited %r, expected TRANSPORT_EXIT (%d)"
+            % (rc, qga.TRANSPORT_EXIT),
+        )
+    finally:
+        sys.argv = argv
+
+    # 6. And the CLI the harness calls reports a spent budget the same way, so
+    #    a failed reconnect is retryable transport, never a product verdict.
+    path = _sock_path(tmp, "deaf-cli.sock")
+    server = FakeQGA(path, ["deaf"])
+    server.start()
+    try:
+        sys.argv = [
+            "qga.py", "--socket", path, "reconnect",
+            "--attempts", "2", "--settle", "0", "--timeout", "0.5",
+        ]
+        rc = qga.main()
+        check(
+            rc == qga.TRANSPORT_EXIT,
+            "reconnect CLI: exited %r on a deaf channel, expected TRANSPORT_EXIT "
+            "(%d)" % (rc, qga.TRANSPORT_EXIT),
+        )
+    finally:
+        sys.argv = argv
+        server.shutdown()
+
+    try:
+        os.rmdir(tmp)
+    except OSError:
+        pass
+
+    for failure in failures:
+        print("FAIL: %s" % failure)
+    print("%s (%d checks)" % ("FAIL" if failures else "PASS", checks))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #220.

## The failure class

A deaf QGA virtio-serial channel and a stalled installer produce the **same** observable — the drive-state file stops changing — and opposite causes. The exemplar is el10-gnome-win11pro in run 32556250889, which waited out its full 30-minute drive deadline and then printed:

```
[FAIL] GUI-driven install did not reach the done screen in 30m
[FAIL]   QGA does NOT answer ping — the verdict above may be a lost channel
```

The product verdict came first and the fact that invalidated it came second. A run that has lost the channel has no standing to judge the install, and a caveat under a claim does not retract it.

## What changes

**The discriminator runs before anything is written down.** `guest-ping` decides which verdict is even available, so it is asked first, in the drive loop and at the deadline alike.

**One bounded reconnect cycle** (`qga_reconnect_cycle`). The QGA socket takes a single client at a time, so a client the `timeout` wrapper killed on 124 can still own it with its unread reply queued behind — the poisoning caveat from agent-lessons §20. The cycle reaps those clients, then reopens with a drained, `0xFF`-delimited sync. Bounded and not a loop: attempts and settle are `WOOTC_QGA_RECONNECT_ATTEMPTS` / `WOOTC_QGA_RECONNECT_SETTLE_S`. A channel that comes back resumes the poll and the run continues; grinding at one that does not just re-buys the 30-minute false verdict.

**The verdict names the class** (`qga_channel_lost`). It leads with `CLASSIFICATION: qga-channel-lost`, states that the run has **no** verdict on the product, and drops the product-failure wording. `fail()` puts that line in the failure ledger, so the re-dispatch decision needs no human to read the log, and `note_flake` still writes `flake-verdict.txt` for the existing single automated re-run.

**Channel loss is no longer waited out.** Three empty reads plus a dead ping now gets the reconnect cycle; if that fails, the run classifies and exits there rather than at the 30-minute mark.

**A live channel is still a real red.** The channel-lost arm requires *both* a dead ping and a failed reconnect. An installer that stalled with a working channel writes no flake verdict and is never retried — the existing `e2e-failure-ledger.bats` gate on that is unchanged and still green.

### `qga.py`

- `_drain()` discards what a killed client left in the channel **before** `makefile()` can join those bytes onto the head of a real reply. Zero grace on the hot path (take only what has already arrived, no added latency); the recovery path pays a fraction of a second to also catch bytes still in flight. Bounded either way.
- `reconnect()` is the open → drain → sync → ping cycle, exposed as a `reconnect` subcommand.
- A socket that will not open now exits `TRANSPORT_EXIT` (42) instead of 1. The `connect()` sat outside the error handler, so ENOENT on a dead channel raised a bare traceback and exited 1 — indistinguishable from a guest command that ran and returned 1, which `qga_call_retry` must never replay (#40). Every caller therefore read a dead channel as a real guest-side failure. Same masquerade, smaller scale.

## Tests

`tests/unit/test_qga_reconnect.py` is the synthetic channel-kill test the issue asks for. It kills a **real** AF_UNIX channel underneath the client rather than faking the client's own methods, because both things this turns on live below the protocol:

| case | asserts |
|---|---|
| healthy | recovered on the first attempt — a live channel is not charged the settle delays |
| **deaf** (accepts, answers nothing) | gives up inside its budget, spends exactly its attempts, does not hand back another half hour |
| **revived mid-budget** | one bounded cycle recovers it, so a transient stall does not become a red |
| **poisoned** (a killed client's leftovers, including a half line with no terminator) | the drain discards them and the reopen answers ping |
| **absent socket** | `TRANSPORT_EXIT`, not 1 |
| `reconnect` CLI on a deaf channel | `TRANSPORT_EXIT` |

`tests/unit/qga-channel-lost.bats` sources both harness helpers and runs them against a stubbed container: the reconnect reports a recovered channel, claims nothing when it stays deaf, reaps before it reopens, and the verdict lands in **both** the ledger and `flake-verdict.txt` without the product wording. One test invokes the helper as a bare statement under `set -Eeuo pipefail` — bats `run` suspends `set -e` inside a tested call — to prove the recovery path cannot abort the run it is rescuing.

Both suites were mutation-checked: removing the drain turns the poison case and two bats gates red; removing `|| true` from the reap or `|| rc=$?` from the capture turns the `set -e` gate red.

Both are auto-discovered by `tests/run.sh fast` (`tests/unit/*.bats`, `tests/unit/test_*.py`). Local: full bats suite green except `userdata-persistence.bats`, which fails on an uninitialized `fisherman` submodule in this checkout and is untouched here; `shellcheck -S error tests/e2e/run-e2e.sh` clean.

Also adds agent-lessons §33, since this is exactly the class of trap that file exists for.

## Done when

> A synthetic channel-kill test (or the next natural occurrence) produces the `qga-channel-lost` classification and a clean single retry instead of a 30-minute false verdict.

The synthetic kill is in the fast tier. The classification and the single bounded retry are pinned by the bats suite. The 30-minute wait is gone from the dead-ping path.

— hive: backend=claude model=claude-haiku-4-5-20251001
