### PR TITLE
feat(uninstall): make the restoration proof collectable, and fix the path it would have failed on

### DIFF
--- a/app/power_state.go
+++ b/app/power_state.go
@@ -1,0 +1,33 @@
+package main
+
+import "strings"
+
+// Pre-install power state, parsed here rather than in the Windows-only prober
+// so it builds — and is tested — everywhere. The install turns hibernation and
+// Fast Startup off; uninstall's promise is to put back exactly what was there,
+// which means the recorded values have to survive the uninstall and be read
+// back unambiguously.
+
+// parsePriorPower reads the `hibernate=<n>\nhiberboot=<n>` record written by
+// recordPriorPowerState. Unknown keys and blank lines are ignored; a missing
+// key yields "" so callers can tell "was off" (0) from "never recorded" ("").
+//
+// The previous reader was `strings.Contains(content, "hibernate=1")`, which
+// cannot make that distinction and matches "hibernate=10" as well. Restoration
+// is a promise about the user's machine, so it reads the value rather than
+// looking for a substring of it.
+func parsePriorPower(content string) (hibernate, hiberboot string) {
+	for _, line := range strings.Split(content, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "hibernate":
+			hibernate = strings.TrimSpace(value)
+		case "hiberboot":
+			hiberboot = strings.TrimSpace(value)
+		}
+	}
+	return hibernate, hiberboot
+}

--- a/app/power_state_test.go
+++ b/app/power_state_test.go
@@ -1,0 +1,69 @@
+package main
+
+import "testing"
+
+// Uninstall restoration (#238, v1.0 criterion 2). "One uninstall puts
+// everything back" includes hibernation and Fast Startup, which the install
+// turns off — so the pre-install values have to be read back exactly, and
+// "never recorded" has to be distinguishable from "was off".
+
+func TestParsePriorPower(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		content              string
+		hibernate, hiberboot string
+	}{
+		{"both on", "hibernate=1\nhiberboot=1\n", "1", "1"},
+		{"both off", "hibernate=0\nhiberboot=0\n", "0", "0"},
+		{"mixed", "hibernate=1\nhiberboot=0\n", "1", "0"},
+		{"crlf", "hibernate=1\r\nhiberboot=1\r\n", "1", "1"},
+		{"whitespace", "  hibernate = 1 \n hiberboot=0\n", "1", "0"},
+		{"empty file", "", "", ""},
+		// The installer writes empty values when it could not read the
+		// registry. That is "unknown", not "was off" — restoring a machine to
+		// 0 because we failed to look is exactly the silent change uninstall
+		// promises not to make.
+		{"unreadable at install time", "hibernate=\nhiberboot=\n", "", ""},
+		{"partial record", "hibernate=1\n", "1", ""},
+		{"unknown keys ignored", "colour=blue\nhibernate=1\n", "1", ""},
+		{"no separator", "hibernate\n", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hib, hbb := parsePriorPower(tc.content)
+			if hib != tc.hibernate || hbb != tc.hiberboot {
+				t.Errorf("parsePriorPower(%q) = (%q, %q), want (%q, %q)",
+					tc.content, hib, hbb, tc.hibernate, tc.hiberboot)
+			}
+		})
+	}
+}
+
+// The old reader was strings.Contains(content, "hibernate=1"), which cannot
+// tell 1 from 10 and would re-enable hibernation on a machine whose recorded
+// value was neither.
+func TestParsePriorPower_DoesNotSubstringMatch(t *testing.T) {
+	hib, _ := parsePriorPower("hibernate=10\nhiberboot=0\n")
+	if hib == "1" {
+		t.Errorf("hibernate=10 must not read as 1 (got %q)", hib)
+	}
+	if hib != "10" {
+		t.Errorf("hibernate = %q, want the recorded value 10", hib)
+	}
+}
+
+// A value that was OFF before the install must stay off. restorePriorPowerState
+// only ever re-enables, so this pins the input side of that: only an exact "1"
+// may trigger a restore.
+func TestParsePriorPower_OnlyExactOneMeansRestore(t *testing.T) {
+	for _, content := range []string{
+		"hibernate=0\nhiberboot=0\n",
+		"hibernate=\nhiberboot=\n",
+		"",
+		"hibernate=true\nhiberboot=yes\n",
+	} {
+		hib, hbb := parsePriorPower(content)
+		if hib == "1" || hbb == "1" {
+			t.Errorf("parsePriorPower(%q) = (%q, %q) — must not ask for a restore", content, hib, hbb)
+		}
+	}
+}

--- a/app/sysprobe_windows.go
+++ b/app/sysprobe_windows.go
@@ -187,25 +187,65 @@ func recordPriorPowerState() {
 	if err1 != nil && err2 != nil {
 		return
 	}
-	content := fmt.Sprintf("hibernate=%s\nhiberboot=%s\n",
-		strings.TrimSpace(hibernate), strings.TrimSpace(hiberboot))
+	hib, hbb := strings.TrimSpace(hibernate), strings.TrimSpace(hiberboot)
+	content := fmt.Sprintf("hibernate=%s\nhiberboot=%s\n", hib, hbb)
 	_ = os.MkdirAll(filepath.Dir(priorPowerPath()), 0o755)
 	_ = os.WriteFile(priorPowerPath(), []byte(content), 0o644)
+	// Mirror into the Add/Remove key, which survives what the file cannot.
+	// The file lives under C:\wootc\install — so a user who deletes C:\wootc
+	// by hand and THEN uninstalls (the orphaned-leftovers path, and a case
+	// #238 tests explicitly) destroys the only record of what to restore, and
+	// restorePriorPowerState() silently returns having changed nothing:
+	// hibernation stays off forever on a machine we promised to leave
+	// unchanged. The registry key is removed by unregisterUninstallEntry(),
+	// which runs immediately AFTER the restore, so the mirror outlives exactly
+	// the window it is needed for.
+	_ = runPowerShell(fmt.Sprintf(
+		`New-Item -Path %q -Force | Out-Null; `+
+			`Set-ItemProperty -Path %q -Name WootcPriorHibernate -Value %q; `+
+			`Set-ItemProperty -Path %q -Name WootcPriorHiberboot -Value %q`,
+		uninstallRegKey, uninstallRegKey, hib, uninstallRegKey, hbb))
+}
+
+// readPriorPowerMirror reads the registry copy of the pre-install power state.
+// Returns ("", "") when no mirror exists — an install that predates the mirror,
+// or a machine wootc never touched.
+func readPriorPowerMirror() (hibernate, hiberboot string) {
+	h, err1 := runPowerShellOutput(fmt.Sprintf(
+		`(Get-ItemProperty -Path %q -Name WootcPriorHibernate -ErrorAction SilentlyContinue).WootcPriorHibernate`,
+		uninstallRegKey))
+	b, err2 := runPowerShellOutput(fmt.Sprintf(
+		`(Get-ItemProperty -Path %q -Name WootcPriorHiberboot -ErrorAction SilentlyContinue).WootcPriorHiberboot`,
+		uninstallRegKey))
+	if err1 != nil {
+		h = ""
+	}
+	if err2 != nil {
+		b = ""
+	}
+	return strings.TrimSpace(h), strings.TrimSpace(b)
 }
 
 // restorePriorPowerState re-enables hibernation / Fast Startup if — and only
 // if — they were on before wootc touched them. Best-effort by design.
 func restorePriorPowerState() {
-	b, err := os.ReadFile(priorPowerPath())
-	if err != nil {
-		return
-	}
-	content := string(b)
-	if strings.Contains(content, "hibernate=1") {
+	hibernate, hiberboot := priorPowerValues()
+	if hibernate == "1" {
 		_ = runPowerShell(`powercfg.exe /h on`)
 	}
-	if strings.Contains(content, "hiberboot=1") {
+	if hiberboot == "1" {
 		_ = runPowerShell(`Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power" ` +
 			`-Name "HiberbootEnabled" -Value 1 -Type DWord -Force`)
 	}
+}
+
+// priorPowerValues resolves the recorded pre-install state, file first and
+// registry mirror second. The file is authoritative when present; the mirror
+// is what makes the orphaned-leftovers path restorable at all, because that
+// path begins by deleting the file.
+func priorPowerValues() (hibernate, hiberboot string) {
+	if b, err := os.ReadFile(priorPowerPath()); err == nil {
+		return parsePriorPower(string(b))
+	}
+	return readPriorPowerMirror()
 }

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -72,6 +72,70 @@ Then run the uninstaller (Windows ▸ Settings ▸ Apps ▸ "TunaOS (wootc)", or
 your Fast Startup/hibernation settings, and keeps `root.disk` unless you
 tick otherwise — so a fixed build can retry without re-downloading.
 
+## Proving the uninstall put everything back
+
+"One uninstall puts everything back" is a v1.0 criterion ([#238]), and on
+real hardware it is where machines differ most: firmware boot entries are
+per-vendor, and a dual-boot machine has files on the ESP that are nobody's
+business but their owner's.
+
+The failures worth catching here are **silent** — an entry that survives,
+hibernation left off, someone else's ESP file gone — and the baseline you
+would need to notice them is **deleted by the uninstall itself**. So capture
+it first:
+
+```powershell
+# After the install completes, BEFORE uninstalling (run as Administrator):
+.\tests\field\verify-uninstall.ps1 capture -Out C:\uninstall-proof
+```
+
+That snapshots the firmware boot entries, every ESP file with its SHA-256,
+the ESP ownership manifest, your live power settings, `C:\wootc`, the
+Add/Remove entry — and copies out `C:\wootc\install\prior-power.txt`, the
+installer's record of what hibernation and Fast Startup were *before* it
+touched them.
+
+Uninstall, reboot **twice**, then:
+
+```powershell
+.\tests\field\verify-uninstall.ps1 verify -Baseline C:\uninstall-proof -RootDisk keep
+```
+
+It prints — and writes to `C:\uninstall-proof\checklist.md` — a checklist with
+every box ticked or not *and the evidence for it*, and **exits non-zero if
+any box failed**. Attach that file to your report; it is the artifact [#238]
+asks for. Nothing on the machine under test is modified: the script writes
+only its own two files into the folder you name, and the one thing it changes
+system-side is a temporary drive letter for the ESP, which it removes again
+before returning.
+
+What it checks:
+
+| Box | How it is decided |
+|---|---|
+| Firmware boot entries clean | `bcdedit /enum firmware` no longer lists any wootc entry (the captured identifiers are named, so you can see what went) |
+| ESP: every wootc-claimed file gone | each path in `EFI\wootc\wootc-owned.txt` is absent |
+| ESP: nothing else touched | every other file is still there **and byte-identical** — a name-only diff would miss a rewrite |
+| Hibernation / Fast Startup restored | current values match the recorded pre-install ones. A value that was *off* must still be off; restore is not "turn on" |
+| `C:\wootc` state | judged against the choice you made — see below |
+| Add/Remove Programs entry gone | the `Uninstall\wootc` key is unregistered |
+| Windows booted clean twice | boot events since the capture, with no bugcheck or unexpected shutdown |
+
+**`C:\wootc` is not always meant to disappear.** With the default keep
+choice — what the Apps entry and bare `wootc.exe uninstall` both do — the
+folder stays, holding `disks\root.disk` and your logs, and only `install\`
+is removed. Pass `-RootDisk delete` only if you ticked *"Also delete my
+Linux data"*. Grading a correct keep run against "the folder is gone" is the
+easiest way to record a ✘ that isn't one.
+
+**The orphaned-leftovers variant.** One machine should also test the path
+where `C:\wootc` was deleted by hand *before* uninstalling. Capture first
+anyway — that is the only way the power box can be graded, because the
+record lives in the folder you are about to delete — then add `-Orphaned` to
+the verify run.
+
+[#238]: https://github.com/tuna-os/wootc/issues/238
+
 ## Debug mode
 
 Add `wootc.debug` to the deployer's GRUB entry (press `e` in the boot menu)

--- a/tests/field/verify-uninstall.ps1
+++ b/tests/field/verify-uninstall.ps1
@@ -1,0 +1,526 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Proof that "one uninstall puts everything back", collected on the machine.
+
+.DESCRIPTION
+    v1.0 criterion 2 (#238) asks for uninstall restoration proven on real
+    hardware with "every box ticked". A box a human ticks from memory is not
+    proof — the interesting failures here are silent (a firmware entry that
+    survives, an ESP file that was not ours, hibernation left off), and the
+    baseline they must be compared against is DELETED BY THE UNINSTALL ITSELF.
+
+    So this runs in two phases:
+
+      capture   BEFORE the uninstall. Snapshots the firmware boot entries, the
+                whole ESP with per-file hashes, the ESP ownership manifest, the
+                live power settings, C:\wootc, the Add/Remove entry — and
+                copies out C:\wootc\install\prior-power.txt, the installer's
+                record of what hibernation/Fast Startup were before it touched
+                them. That file lives inside the directory uninstall removes,
+                so without this copy the "restored to the recorded pre-install
+                values" check is unverifiable after the fact.
+
+      verify    AFTER the uninstall and the reboots. Re-reads everything,
+                diffs it against the capture, prints the checklist with each
+                box ticked or not AND the evidence for it, and exits non-zero
+                if any box fails. The exit code is the point: a report can be
+                pasted, but it cannot be talked into passing.
+
+    Nothing on the machine under test is modified. The script writes only its
+    own baseline.json and checklist.md into the directory it is given, and the
+    one thing it changes system-side is a temporary drive letter for the ESP,
+    removed again before it returns.
+
+.EXAMPLE
+    # On the test machine, after the install completed and before uninstalling:
+    .\verify-uninstall.ps1 capture -Out C:\wootc-proof
+
+    # ...uninstall (Apps entry or `wootc.exe uninstall`), reboot twice, then:
+    .\verify-uninstall.ps1 verify -Baseline C:\wootc-proof -RootDisk keep
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('capture', 'verify')]
+    [string]$Mode,
+
+    # capture: where to write the baseline. verify: where to read it from.
+    [string]$Out,
+    [string]$Baseline,
+
+    # Which uninstall was performed. "keep" is the default the Apps entry and
+    # `wootc.exe uninstall` both use; "delete" is the Also-delete-my-Linux-data
+    # tick. They have DIFFERENT correct end states, and grading one against the
+    # other is the easiest way to record a false ✘.
+    [ValidateSet('keep', 'delete')]
+    [string]$RootDisk = 'keep',
+
+    # The orphaned-leftovers variant: C:\wootc was deleted by hand before
+    # uninstalling. Documents the run; also relaxes the checks that reference
+    # files that variant destroys.
+    [switch]$Orphaned
+)
+
+$ErrorActionPreference = 'Stop'
+
+$EspGptType = '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'
+
+# ── pure logic ───────────────────────────────────────────────────────────────
+# Everything below this line down to "collection" is deliberately free of
+# Windows APIs so tests/unit/test-verify-uninstall.ps1 can exercise the grading
+# on any platform. A checklist generator that is only testable on the hardware
+# it grades would be trusted exactly as much as the memory it replaces.
+
+function ConvertTo-EspRelative {
+    # ESPs are FAT32: case-insensitive, and written by tools that disagree
+    # about slashes. Matches normalizeESPPath in app/esp_ownership.go.
+    param([string]$Path)
+    $p = $Path -replace '\\', '/'
+    return $p.Trim('/').ToLowerInvariant()
+}
+
+function Read-OwnershipManifest {
+    # The manifest is one ESP-relative path per line; blanks and # comments are
+    # skipped. Written one line at a time as each file is created, so it can
+    # only ever name a destination wootc was in the act of writing.
+    param([string[]]$Lines)
+    $owned = @()
+    foreach ($line in @($Lines)) {
+        $t = "$line".Trim()
+        if (-not $t -or $t.StartsWith('#')) { continue }
+        $owned += (ConvertTo-EspRelative $t)
+    }
+    # No unary comma: `return , @()` unrolls to $null in the pipeline, so an
+    # EMPTY result would reach `@($x).Count` as 1. Callers wrap in @() instead,
+    # which is correct for zero, one and many. The grader reported a phantom
+    # firmware entry on a perfectly clean machine until this was fixed.
+    return $owned
+}
+
+function Compare-EspTrees {
+    <#
+        The spec's ESP check is two-sided, and the second side is the one that
+        matters for a v1.0 data-safety criterion: it is not enough that wootc's
+        files are gone, nothing ELSE may have been touched. A dual-boot user's
+        Fedora or vendor recovery entry disappearing during our uninstall is
+        precisely the failure this criterion exists to rule out.
+    #>
+    param(
+        [hashtable]$Before,        # esp-relative path -> sha256
+        [hashtable]$After,
+        [string[]]$Owned
+    )
+    $ownedSet = @{}
+    foreach ($o in @($Owned)) { $ownedSet[$o] = $true }
+
+    $ownedRemaining = @()
+    $foreignRemoved = @()
+    $foreignChanged = @()
+
+    foreach ($path in $Before.Keys) {
+        $isOwned = $ownedSet.ContainsKey($path)
+        # EFI/wootc is ours by definition — nothing else writes there — so it
+        # counts as claimed even when the manifest predates a given file.
+        if (-not $isOwned -and $path.StartsWith('efi/wootc/')) { $isOwned = $true }
+
+        if ($isOwned) {
+            if ($After.ContainsKey($path)) { $ownedRemaining += $path }
+            continue
+        }
+        if (-not $After.ContainsKey($path)) { $foreignRemoved += $path; continue }
+        if ($After[$path] -ne $Before[$path]) { $foreignChanged += $path }
+    }
+
+    $added = @()
+    foreach ($path in $After.Keys) {
+        if (-not $Before.ContainsKey($path)) { $added += $path }
+    }
+
+    return [pscustomobject]@{
+        OwnedRemaining = @($ownedRemaining | Sort-Object)
+        ForeignRemoved = @($foreignRemoved | Sort-Object)
+        ForeignChanged = @($foreignChanged | Sort-Object)
+        Added          = @($added | Sort-Object)
+        Pass           = (@($ownedRemaining).Count -eq 0 -and
+                          @($foreignRemoved).Count -eq 0 -and
+                          @($foreignChanged).Count -eq 0)
+    }
+}
+
+function Get-WootcFirmwareEntries {
+    <#
+        `bcdedit /enum firmware` prints blank-line-separated blocks. An entry is
+        wootc's if its description names us or its device/path points into
+        EFI\wootc. Returns the identifier of each match, so "no wootc residue"
+        is a list a reader can check rather than an assertion.
+    #>
+    param([string]$BcdText)
+    $hits = @()
+    $blocks = ($BcdText -split "(\r?\n){2,}") | Where-Object { "$_".Trim() }
+    foreach ($block in $blocks) {
+        if ($block -notmatch '(?i)wootc|tunaos') { continue }
+        $id = '<unidentified entry>'
+        foreach ($line in ($block -split "\r?\n")) {
+            if ($line -match '(?i)^\s*identifier\s+(\S+)') { $id = $Matches[1]; break }
+        }
+        $hits += $id
+    }
+    return $hits   # see Read-OwnershipManifest: no unary comma, callers use @()
+}
+
+function Test-PowerRestored {
+    <#
+        The installer records the pre-install values in
+        C:\wootc\install\prior-power.txt and restorePriorPowerState() puts them
+        back — but ONLY re-enables, never disables: a value that was 0 before
+        must still be 0, and a value that was 1 must be 1 again.
+
+        Missing baseline is NOT a pass. On the orphaned-leftovers run the record
+        is destroyed with the folder, and restorePriorPowerState() returns
+        early — so hibernation stays off forever and nothing says so. That is a
+        real finding, not an excuse to skip the box.
+    #>
+    param([hashtable]$Prior, [hashtable]$Current)
+
+    if ($null -eq $Prior -or $Prior.Count -eq 0) {
+        return [pscustomobject]@{
+            Pass    = $false
+            Detail  = 'no pre-install record was captured (C:\wootc\install\prior-power.txt) — restoration cannot be verified, and on the orphaned-leftovers path it also cannot happen'
+        }
+    }
+    $problems = @()
+    foreach ($key in @('hibernate', 'hiberboot')) {
+        $was = "$($Prior[$key])".Trim()
+        $now = "$($Current[$key])".Trim()
+        if ($was -eq '') { continue }   # installer could not read it either
+        if ($was -ne $now) {
+            $problems += "$key was '$was' before the install and is '$now' now"
+        }
+    }
+    return [pscustomobject]@{
+        Pass   = (@($problems).Count -eq 0)
+        Detail = if (@($problems).Count -eq 0) {
+            "hibernate=$($Prior['hibernate']) hiberboot=$($Prior['hiberboot']) — both back to their pre-install values"
+        } else { $problems -join '; ' }
+    }
+}
+
+function Test-WootcDirState {
+    <#
+        `C:\wootc` removed" is only the right expectation for the DELETE
+        choice. On the default keep-root.disk uninstall the code removes
+        install\ and leaves the folder with disks\root.disk in it, on purpose,
+        so a fixed build can retry without re-downloading. Grading a correct
+        keep run against "the folder is gone" is how a good machine gets a ✘.
+    #>
+    param(
+        [ValidateSet('keep', 'delete')][string]$Choice,
+        [bool]$WootcDirExists,
+        [bool]$InstallDirExists,
+        [bool]$RootDiskExists
+    )
+    $problems = @()
+    if ($InstallDirExists) { $problems += 'C:\wootc\install still exists' }
+    if ($Choice -eq 'delete') {
+        if ($WootcDirExists) { $problems += 'C:\wootc still exists after a delete-my-Linux-data uninstall' }
+        if ($RootDiskExists) { $problems += 'root.disk still exists after a delete-my-Linux-data uninstall' }
+    } else {
+        if (-not $RootDiskExists) { $problems += 'root.disk is GONE after a keep uninstall — the keep choice was not honoured' }
+    }
+    return [pscustomobject]@{
+        Pass   = (@($problems).Count -eq 0)
+        Detail = if (@($problems).Count -eq 0) {
+            if ($Choice -eq 'delete') { 'C:\wootc and root.disk removed, as chosen' }
+            else { 'install\ removed; root.disk kept, as chosen' }
+        } else { $problems -join '; ' }
+    }
+}
+
+function Test-CleanBoots {
+    <#
+        "Windows boots clean twice" — counted from the event log rather than
+        attested. Boot events since the uninstall, minus any bugcheck or
+        unexpected-shutdown in the same window.
+    #>
+    param([int]$BootCount, [int]$BugCheckCount, [int]$DirtyShutdownCount, [int]$Required = 2)
+    $problems = @()
+    if ($BootCount -lt $Required) { $problems += "only $BootCount clean boot(s) recorded since the uninstall, need $Required" }
+    if ($BugCheckCount -gt 0) { $problems += "$BugCheckCount bugcheck(s) since the uninstall" }
+    if ($DirtyShutdownCount -gt 0) { $problems += "$DirtyShutdownCount unexpected shutdown(s) since the uninstall" }
+    return [pscustomobject]@{
+        Pass   = (@($problems).Count -eq 0)
+        Detail = if (@($problems).Count -eq 0) { "$BootCount boots, no bugchecks, no unexpected shutdowns" } else { $problems -join '; ' }
+    }
+}
+
+function Format-Checklist {
+    <#
+        The output is the artifact that gets attached to #238, so it is written
+        to be pasted whole: every box carries the evidence that ticked it, and
+        a ✘ says what was found instead of just failing.
+    #>
+    param([System.Collections.IEnumerable]$Results, [hashtable]$Meta)
+    $lines = @()
+    $lines += '## Uninstall restoration checklist (#238)'
+    $lines += ''
+    foreach ($k in @($Meta.Keys | Sort-Object)) { $lines += "- **$k**: $($Meta[$k])" }
+    $lines += ''
+    foreach ($r in $Results) {
+        $box = if ($r.Pass) { '[x]' } else { '[ ]' }
+        $mark = if ($r.Pass) { '✔' } else { '✘' }
+        $lines += "- $box $mark **$($r.Name)** — $($r.Detail)"
+    }
+    $lines += ''
+    $failed = @($Results | Where-Object { -not $_.Pass })
+    if (@($failed).Count -eq 0) {
+        $lines += '**RESULT: PASS** — every box ticked from collected evidence.'
+    } else {
+        $lines += "**RESULT: FAIL** — $(@($failed).Count) unticked: $((@($failed).Name) -join ', ')."
+    }
+    return ($lines -join "`n")
+}
+
+# ── collection (Windows) ─────────────────────────────────────────────────────
+
+function Get-EspAccess {
+    # Returns @{ Letter; Temporary }. Assigns a temporary letter only when the
+    # ESP has none, and the caller always releases it.
+    $sysDisk = (Get-Partition -DriveLetter C -ErrorAction Stop).DiskNumber
+    $esp = Get-Partition -DiskNumber $sysDisk -ErrorAction Stop |
+        Where-Object { $_.GptType -eq $EspGptType } | Select-Object -First 1
+    if (-not $esp) { throw "no EFI system partition found on disk $sysDisk" }
+
+    foreach ($ap in @($esp.AccessPaths)) {
+        if ($ap -match '^([A-Za-z]):\\$') {
+            return @{ Letter = $Matches[1]; Temporary = $false }
+        }
+    }
+    foreach ($candidate in @('S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z')) {
+        if (Test-Path "${candidate}:\") { continue }
+        Add-PartitionAccessPath -DiskNumber $esp.DiskNumber `
+            -PartitionNumber $esp.PartitionNumber -AccessPath "${candidate}:\" -ErrorAction Stop
+        return @{ Letter = $candidate; Temporary = $true; Partition = $esp }
+    }
+    throw 'no free drive letter to mount the ESP'
+}
+
+function Remove-EspAccess {
+    param($Access)
+    if (-not $Access.Temporary) { return }
+    Remove-PartitionAccessPath -DiskNumber $Access.Partition.DiskNumber `
+        -PartitionNumber $Access.Partition.PartitionNumber `
+        -AccessPath "$($Access.Letter):\" -ErrorAction SilentlyContinue
+}
+
+function Get-EspFileMap {
+    # esp-relative path -> sha256. Hashes, not just names: "nothing else was
+    # touched" has to mean the bytes too.
+    param([string]$Letter)
+    $root = "${Letter}:\"
+    $map = @{}
+    Get-ChildItem -Path $root -Recurse -File -Force -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $rel = ConvertTo-EspRelative ($_.FullName.Substring($root.Length))
+            $map[$rel] = (Get-FileHash -Path $_.FullName -Algorithm SHA256 -ErrorAction SilentlyContinue).Hash
+        }
+    return $map
+}
+
+function Get-PowerSettings {
+    $hibernate = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Power' `
+        -Name HibernateEnabled -ErrorAction SilentlyContinue).HibernateEnabled
+    $hiberboot = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' `
+        -Name HiberbootEnabled -ErrorAction SilentlyContinue).HiberbootEnabled
+    return @{ hibernate = "$hibernate"; hiberboot = "$hiberboot" }
+}
+
+function Read-PriorPowerFile {
+    # hibernate=<n>\nhiberboot=<n>\n, written by recordPriorPowerState().
+    param([string]$Path)
+    $prior = @{}
+    if (-not (Test-Path $Path)) { return $prior }
+    foreach ($line in (Get-Content -Path $Path -ErrorAction SilentlyContinue)) {
+        if ("$line" -match '^\s*(hibernate|hiberboot)\s*=\s*(.*)$') {
+            $prior[$Matches[1]] = $Matches[2].Trim()
+        }
+    }
+    return $prior
+}
+
+function Invoke-Capture {
+    param([string]$OutDir)
+    New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+    $access = Get-EspAccess
+    try {
+        $espMap = Get-EspFileMap -Letter $access.Letter
+        $manifestPath = "$($access.Letter):\EFI\wootc\wootc-owned.txt"
+        $manifestLines = if (Test-Path $manifestPath) { Get-Content -Path $manifestPath } else { @() }
+    } finally {
+        Remove-EspAccess -Access $access
+    }
+
+    $bcd = (& bcdedit /enum firmware 2>&1 | Out-String)
+
+    # The one file that MUST be copied out: uninstall deletes C:\wootc\install.
+    $prior = Read-PriorPowerFile -Path 'C:\wootc\install\prior-power.txt'
+
+    $snapshot = [ordered]@{
+        capturedAt     = (Get-Date).ToUniversalTime().ToString('o')
+        computer       = $env:COMPUTERNAME
+        windows        = (Get-CimInstance Win32_OperatingSystem).Caption
+        windowsVersion = (Get-CimInstance Win32_OperatingSystem).Version
+        machine        = "$((Get-CimInstance Win32_ComputerSystem).Manufacturer) $((Get-CimInstance Win32_ComputerSystem).Model)"
+        firmwareBcd    = $bcd
+        wootcEntries   = @(Get-WootcFirmwareEntries -BcdText $bcd)
+        espFiles       = $espMap
+        espOwned       = @(Read-OwnershipManifest -Lines $manifestLines)
+        priorPower     = $prior
+        powerNow       = Get-PowerSettings
+        wootcDir       = (Test-Path 'C:\wootc')
+        installDir     = (Test-Path 'C:\wootc\install')
+        rootDisk       = ((Test-Path 'C:\wootc\disks\root.disk') -or (Test-Path 'C:\wootc\disks\root.vhdx'))
+        uninstallKey   = (Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\wootc')
+    }
+    $file = Join-Path $OutDir 'baseline.json'
+    $snapshot | ConvertTo-Json -Depth 6 | Set-Content -Path $file -Encoding UTF8
+
+    Write-Host "Baseline captured to $file"
+    Write-Host "  ESP files hashed : $($espMap.Count)"
+    Write-Host "  wootc-claimed    : $(@($snapshot.espOwned).Count)"
+    Write-Host "  firmware entries : $(@($snapshot.wootcEntries).Count) ($((@($snapshot.wootcEntries)) -join ', '))"
+    if (@($prior.Keys).Count -eq 0) {
+        Write-Warning 'C:\wootc\install\prior-power.txt is missing — the power-restore box CANNOT pass. Capture before deleting C:\wootc by hand.'
+    } else {
+        Write-Host "  prior power      : hibernate=$($prior['hibernate']) hiberboot=$($prior['hiberboot'])"
+    }
+    Write-Host ''
+    Write-Host 'Now uninstall, reboot twice, and run: verify -Baseline ' -NoNewline
+    Write-Host $OutDir
+}
+
+function Invoke-Verify {
+    param([string]$BaselineDir, [string]$Choice, [bool]$WasOrphaned)
+    $file = Join-Path $BaselineDir 'baseline.json'
+    if (-not (Test-Path $file)) { throw "no baseline at $file — run 'capture' before uninstalling" }
+    $base = Get-Content -Path $file -Raw | ConvertFrom-Json
+
+    $access = Get-EspAccess
+    try { $espAfter = Get-EspFileMap -Letter $access.Letter }
+    finally { Remove-EspAccess -Access $access }
+
+    $bcdNow = (& bcdedit /enum firmware 2>&1 | Out-String)
+    $entriesNow = @(Get-WootcFirmwareEntries -BcdText $bcdNow)
+
+    # PSCustomObject -> hashtable for the pure comparators.
+    $espBefore = @{}
+    foreach ($p in $base.espFiles.PSObject.Properties) { $espBefore[$p.Name] = $p.Value }
+    $prior = @{}
+    if ($base.priorPower) {
+        foreach ($p in $base.priorPower.PSObject.Properties) { $prior[$p.Name] = $p.Value }
+    }
+
+    $espResult = Compare-EspTrees -Before $espBefore -After $espAfter -Owned @($base.espOwned)
+    $power = Test-PowerRestored -Prior $prior -Current (Get-PowerSettings)
+    $dirs = Test-WootcDirState -Choice $Choice `
+        -WootcDirExists (Test-Path 'C:\wootc') `
+        -InstallDirExists (Test-Path 'C:\wootc\install') `
+        -RootDiskExists ((Test-Path 'C:\wootc\disks\root.disk') -or (Test-Path 'C:\wootc\disks\root.vhdx'))
+
+    $since = [datetime]::Parse($base.capturedAt).ToUniversalTime()
+    $boots = @(Get-WinEvent -FilterHashtable @{ LogName = 'System'; ProviderName = 'Microsoft-Windows-Kernel-Boot'; Id = 20; StartTime = $since } -ErrorAction SilentlyContinue).Count
+    if ($boots -eq 0) {
+        $boots = @(Get-WinEvent -FilterHashtable @{ LogName = 'System'; Id = 6005; StartTime = $since } -ErrorAction SilentlyContinue).Count
+    }
+    $bugchecks = @(Get-WinEvent -FilterHashtable @{ LogName = 'System'; Id = 1001; ProviderName = 'Microsoft-Windows-WER-SystemErrorReporting'; StartTime = $since } -ErrorAction SilentlyContinue).Count
+    $dirty = @(Get-WinEvent -FilterHashtable @{ LogName = 'System'; Id = 41; StartTime = $since } -ErrorAction SilentlyContinue).Count
+    $bootRes = Test-CleanBoots -BootCount $boots -BugCheckCount $bugchecks -DirtyShutdownCount $dirty
+
+    $results = @(
+        [pscustomobject]@{
+            Name = 'Firmware boot entries clean'
+            Pass = (@($entriesNow).Count -eq 0)
+            Detail = if (@($entriesNow).Count -eq 0) {
+                "bcdedit /enum firmware shows no wootc entry (was: $((@($base.wootcEntries)) -join ', '))"
+            } else { "still present: $((@($entriesNow)) -join ', ')" }
+        }
+        [pscustomobject]@{
+            Name = 'ESP: every wootc-claimed file gone'
+            Pass = (@($espResult.OwnedRemaining).Count -eq 0)
+            Detail = if (@($espResult.OwnedRemaining).Count -eq 0) {
+                "all $(@($base.espOwned).Count) claimed path(s) removed"
+            } else { "left behind: $((@($espResult.OwnedRemaining)) -join ', ')" }
+        }
+        [pscustomobject]@{
+            Name = 'ESP: nothing else touched'
+            Pass = (@($espResult.ForeignRemoved).Count -eq 0 -and @($espResult.ForeignChanged).Count -eq 0)
+            Detail = if (@($espResult.ForeignRemoved).Count -eq 0 -and @($espResult.ForeignChanged).Count -eq 0) {
+                "$($espAfter.Count) file(s) remain, all byte-identical to the capture"
+            } else {
+                "removed: $((@($espResult.ForeignRemoved)) -join ', '); changed: $((@($espResult.ForeignChanged)) -join ', ')"
+            }
+        }
+        [pscustomobject]@{
+            Name = 'Hibernation / Fast Startup restored'
+            Pass = $power.Pass
+            Detail = $power.Detail
+        }
+        [pscustomobject]@{
+            Name = "C:\wootc state (choice: $Choice)"
+            Pass = $dirs.Pass
+            Detail = $dirs.Detail
+        }
+        [pscustomobject]@{
+            Name = 'Add/Remove Programs entry gone'
+            Pass = (-not (Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\wootc'))
+            Detail = if (Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\wootc') {
+                'the Uninstall registry key is still registered'
+            } else { 'unregistered' }
+        }
+        [pscustomobject]@{
+            Name = 'Windows booted clean twice'
+            Pass = $bootRes.Pass
+            Detail = $bootRes.Detail
+        }
+    )
+
+    $meta = @{
+        'Machine'   = $base.machine
+        'Windows'   = "$($base.windows) ($($base.windowsVersion))"
+        'Captured'  = $base.capturedAt
+        'Verified'  = (Get-Date).ToUniversalTime().ToString('o')
+        'root.disk' = $Choice
+        'Variant'   = if ($WasOrphaned) { 'orphaned leftovers (C:\wootc deleted by hand before uninstall)' } else { 'normal' }
+    }
+
+    $report = Format-Checklist -Results $results -Meta $meta
+    $reportPath = Join-Path $BaselineDir 'checklist.md'
+    Set-Content -Path $reportPath -Value $report -Encoding UTF8
+    Write-Host $report
+    Write-Host ''
+    Write-Host "Checklist written to $reportPath — attach it to the field report."
+
+    if (@($results | Where-Object { -not $_.Pass }).Count -gt 0) { exit 1 }
+    exit 0
+}
+
+# Dot-sourcing (". ./verify-uninstall.ps1") loads the functions without running
+# anything, which is how the unit tests reach the grading logic off-Windows.
+if ($MyInvocation.InvocationName -ne '.') {
+    switch ($Mode) {
+        'capture' {
+            if (-not $Out) { throw 'capture needs -Out <dir>' }
+            Invoke-Capture -OutDir $Out
+        }
+        'verify' {
+            if (-not $Baseline) { throw 'verify needs -Baseline <dir>' }
+            Invoke-Verify -BaselineDir $Baseline -Choice $RootDisk -WasOrphaned:$Orphaned.IsPresent
+        }
+        default {
+            Write-Host 'usage: verify-uninstall.ps1 capture -Out <dir>'
+            Write-Host '       verify-uninstall.ps1 verify -Baseline <dir> [-RootDisk keep|delete] [-Orphaned]'
+            exit 2
+        }
+    }
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -65,8 +65,21 @@ run_fast() {
     if command -v pwsh >/dev/null; then
         echo "── powershell lint (tests/lint-ps1.ps1) ──"
         pwsh -NoProfile -File tests/lint-ps1.ps1 || rc=1
+
+        # PowerShell unit tests. tests/field/verify-uninstall.ps1 grades the
+        # uninstall restoration proof (#238) on machines no runner has, so its
+        # comparators are dot-sourced and driven from synthetic snapshots here.
+        # A grader nothing exercises is a rubber stamp — and the first run of
+        # these found one: an empty-array return collapsing to $null made a
+        # perfectly clean machine report a phantom firmware entry.
+        echo "── powershell unit tests (tests/unit/test-*.ps1) ──"
+        for t in tests/unit/test-*.ps1; do
+            [ -e "$t" ] || continue
+            echo "   $t"
+            pwsh -NoProfile -File "$t" || rc=1
+        done
     else
-        echo "!! pwsh not installed — skipping PowerShell lint" >&2
+        echo "!! pwsh not installed — skipping PowerShell lint + unit tests" >&2
     fi
 
     if command -v go >/dev/null; then

--- a/tests/unit/test-verify-uninstall.ps1
+++ b/tests/unit/test-verify-uninstall.ps1
@@ -1,0 +1,198 @@
+#!/usr/bin/env pwsh
+# Grading logic for the uninstall restoration proof (#238).
+#
+# tests/field/verify-uninstall.ps1 decides whether a real machine's uninstall
+# put everything back. It runs once per test machine, by hand, on hardware
+# nobody in CI has — so the grading itself has to be proven somewhere else, or
+# the report it produces is only as trustworthy as an untested script.
+#
+# The pure comparators are dot-sourced and driven from synthetic snapshots
+# here, on any platform. Each case below is a way the real check has to be able
+# to fail; a grader that cannot produce a ✘ is a rubber stamp.
+#
+# Run: pwsh -NoProfile -File tests/unit/test-verify-uninstall.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $PSCommandPath
+. (Join-Path (Split-Path -Parent $here) 'field/verify-uninstall.ps1')
+
+$script:failures = @()
+$script:checks = 0
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    $script:checks++
+    if (-not $Condition) { $script:failures += $Message }
+}
+
+function Assert-Equal {
+    param($Expected, $Actual, [string]$Message)
+    $script:checks++
+    if ("$Expected" -ne "$Actual") { $script:failures += "$Message (expected '$Expected', got '$Actual')" }
+}
+
+# ── the ESP diff ─────────────────────────────────────────────────────────────
+
+$before = @{
+    'efi/wootc/shimx64.efi'      = 'AAA'
+    'efi/wootc/grubx64.efi'      = 'BBB'
+    'efi/fedora/grub.cfg'        = 'CCC'
+    'efi/microsoft/boot/bcd'     = 'DDD'   # Windows' own — must survive untouched
+    'efi/boot/bootx64.efi'       = 'EEE'
+}
+$owned = @('EFI\wootc\shimx64.efi', 'EFI\wootc\grubx64.efi', 'EFI/fedora/grub.cfg')
+
+# A clean uninstall: ours gone, everyone else's byte-identical.
+$clean = @{ 'efi/microsoft/boot/bcd' = 'DDD'; 'efi/boot/bootx64.efi' = 'EEE' }
+$r = Compare-EspTrees -Before $before -After $clean -Owned $owned
+Assert-True $r.Pass 'clean uninstall should pass the ESP diff'
+Assert-Equal 0 @($r.OwnedRemaining).Count 'clean uninstall leaves no claimed file'
+
+# Ours left behind — the "residue" half of the check.
+$residue = @{
+    'efi/wootc/shimx64.efi'  = 'AAA'
+    'efi/microsoft/boot/bcd' = 'DDD'
+    'efi/boot/bootx64.efi'   = 'EEE'
+}
+$r = Compare-EspTrees -Before $before -After $residue -Owned $owned
+Assert-True (-not $r.Pass) 'a wootc file left on the ESP must fail'
+Assert-Equal 'efi/wootc/shimx64.efi' (@($r.OwnedRemaining) -join ',') 'the residue must be named'
+
+# Somebody ELSE's file removed. This is the one that matters for a data-safety
+# criterion: a dual-boot user's entry disappearing during our uninstall.
+$collateral = @{ 'efi/boot/bootx64.efi' = 'EEE' }
+$r = Compare-EspTrees -Before $before -After $collateral -Owned $owned
+Assert-True (-not $r.Pass) 'removing a file we never claimed must fail'
+Assert-Equal 'efi/microsoft/boot/bcd' (@($r.ForeignRemoved) -join ',') 'the collateral damage must be named'
+
+# Somebody else's file rewritten in place — same name, different bytes. A
+# name-only diff would call this clean.
+$rewritten = @{ 'efi/microsoft/boot/bcd' = 'XXX'; 'efi/boot/bootx64.efi' = 'EEE' }
+$r = Compare-EspTrees -Before $before -After $rewritten -Owned $owned
+Assert-True (-not $r.Pass) 'rewriting a foreign file must fail'
+Assert-Equal 'efi/microsoft/boot/bcd' (@($r.ForeignChanged) -join ',') 'the modified file must be named'
+
+# EFI\wootc is ours by definition, even for a path the manifest never listed.
+$unlisted = @{ 'efi/wootc/extra.efi' = 'ZZZ'; 'efi/boot/bootx64.efi' = 'EEE' }
+$r = Compare-EspTrees -Before (@{ 'efi/wootc/extra.efi' = 'ZZZ'; 'efi/boot/bootx64.efi' = 'EEE' }) `
+    -After $unlisted -Owned @()
+Assert-True (-not $r.Pass) 'an unlisted file under EFI\wootc still counts as ours and must be gone'
+
+# ── manifest parsing ─────────────────────────────────────────────────────────
+
+$parsed = Read-OwnershipManifest -Lines @(
+    '# written one line at a time',
+    'EFI\wootc\shimx64.efi',
+    '',
+    'EFI/Fedora/GRUB.CFG',
+    '   '
+)
+Assert-Equal 2 @($parsed).Count 'comments and blanks are skipped'
+Assert-True ($parsed -contains 'efi/fedora/grub.cfg') 'separators and case are normalised'
+
+# ── firmware entries ─────────────────────────────────────────────────────────
+
+$bcdWithWootc = @'
+Firmware Boot Manager
+---------------------
+identifier              {fwbootmgr}
+displayorder            {bootmgr}
+                        {b3b1a1d0-0000-0000-0000-000000000001}
+
+Windows Boot Manager
+--------------------
+identifier              {bootmgr}
+description             Windows Boot Manager
+
+Firmware Application (101fffff)
+-------------------------------
+identifier              {b3b1a1d0-0000-0000-0000-000000000001}
+description             wootc
+path                    \EFI\wootc\shimx64.efi
+'@
+$hits = Get-WootcFirmwareEntries -BcdText $bcdWithWootc
+Assert-Equal 1 @($hits).Count 'the wootc firmware entry is found'
+Assert-Equal '{b3b1a1d0-0000-0000-0000-000000000001}' (@($hits)[0]) 'the entry identifier is reported'
+
+$bcdClean = @'
+Windows Boot Manager
+--------------------
+identifier              {bootmgr}
+description             Windows Boot Manager
+
+Firmware Application (101fffff)
+-------------------------------
+identifier              {c0000001-0000-0000-0000-000000000002}
+description             Fedora
+path                    \EFI\fedora\shimx64.efi
+'@
+Assert-Equal 0 @(Get-WootcFirmwareEntries -BcdText $bcdClean).Count `
+    'a clean firmware list reports nothing — and a real Fedora entry is not ours'
+
+# ── power restoration ────────────────────────────────────────────────────────
+
+$r = Test-PowerRestored -Prior @{ hibernate = '1'; hiberboot = '1' } -Current @{ hibernate = '1'; hiberboot = '1' }
+Assert-True $r.Pass 'both values back on = restored'
+
+$r = Test-PowerRestored -Prior @{ hibernate = '0'; hiberboot = '0' } -Current @{ hibernate = '0'; hiberboot = '0' }
+Assert-True $r.Pass 'a machine that had them off must stay off — restore is not "turn on"'
+
+$r = Test-PowerRestored -Prior @{ hibernate = '1'; hiberboot = '1' } -Current @{ hibernate = '0'; hiberboot = '0' }
+Assert-True (-not $r.Pass) 'hibernation left off after uninstall must fail'
+Assert-True ($r.Detail -match 'hibernate') 'the failing value is named'
+
+# The orphaned-leftovers path destroys the record. Missing baseline is a ✘,
+# never a silent skip: on that path the restore provably does not happen.
+$r = Test-PowerRestored -Prior @{} -Current @{ hibernate = '0'; hiberboot = '0' }
+Assert-True (-not $r.Pass) 'no pre-install record must fail, not pass by default'
+Assert-True ($r.Detail -match 'orphaned') 'the reason names the orphaned path'
+
+# ── C:\wootc end state, which differs by choice ──────────────────────────────
+
+$r = Test-WootcDirState -Choice keep -WootcDirExists $true -InstallDirExists $false -RootDiskExists $true
+Assert-True $r.Pass 'keep: folder and root.disk remain, install\ gone — this is CORRECT'
+
+$r = Test-WootcDirState -Choice keep -WootcDirExists $true -InstallDirExists $false -RootDiskExists $false
+Assert-True (-not $r.Pass) 'keep: a deleted root.disk means the choice was not honoured'
+
+$r = Test-WootcDirState -Choice delete -WootcDirExists $false -InstallDirExists $false -RootDiskExists $false
+Assert-True $r.Pass 'delete: everything gone'
+
+$r = Test-WootcDirState -Choice delete -WootcDirExists $true -InstallDirExists $false -RootDiskExists $true
+Assert-True (-not $r.Pass) 'delete: a surviving root.disk must fail'
+
+$r = Test-WootcDirState -Choice keep -WootcDirExists $true -InstallDirExists $true -RootDiskExists $true
+Assert-True (-not $r.Pass) 'install\ surviving either choice must fail'
+
+# ── clean boots ──────────────────────────────────────────────────────────────
+
+Assert-True (Test-CleanBoots -BootCount 2 -BugCheckCount 0 -DirtyShutdownCount 0).Pass 'two clean boots pass'
+Assert-True (-not (Test-CleanBoots -BootCount 1 -BugCheckCount 0 -DirtyShutdownCount 0).Pass) 'one boot is not two'
+Assert-True (-not (Test-CleanBoots -BootCount 2 -BugCheckCount 1 -DirtyShutdownCount 0).Pass) 'a bugcheck is not a clean boot'
+Assert-True (-not (Test-CleanBoots -BootCount 3 -BugCheckCount 0 -DirtyShutdownCount 1).Pass) 'an unexpected shutdown is not clean'
+
+# ── the rendered checklist ───────────────────────────────────────────────────
+
+$report = Format-Checklist -Results @(
+    [pscustomobject]@{ Name = 'Alpha'; Pass = $true;  Detail = 'all good' }
+    [pscustomobject]@{ Name = 'Beta';  Pass = $false; Detail = 'left behind: x' }
+) -Meta @{ Machine = 'ACME 1'; Variant = 'normal' }
+Assert-True ($report -match '\[x\] ✔ \*\*Alpha\*\*') 'a passing box is ticked'
+Assert-True ($report -match '\[ \] ✘ \*\*Beta\*\*') 'a failing box is NOT ticked'
+Assert-True ($report -match 'RESULT: FAIL') 'one failure fails the whole report'
+Assert-True ($report -match 'Beta') 'the failing box is named in the result line'
+
+$allPass = Format-Checklist -Results @(
+    [pscustomobject]@{ Name = 'Alpha'; Pass = $true; Detail = 'ok' }
+) -Meta @{ Machine = 'ACME 1' }
+Assert-True ($allPass -match 'RESULT: PASS') 'all boxes ticked passes'
+
+# ── report ───────────────────────────────────────────────────────────────────
+
+foreach ($f in $script:failures) { Write-Host "FAIL: $f" }
+if (@($script:failures).Count -gt 0) {
+    Write-Host "FAIL ($($script:checks) checks, $(@($script:failures).Count) failed)"
+    exit 1
+}
+Write-Host "PASS ($($script:checks) checks)"
+exit 0

--- a/tests/unit/uninstall-restoration.bats
+++ b/tests/unit/uninstall-restoration.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# Uninstall restoration proof (#238, v1.0 criterion 2).
+#
+# The proof itself is collected by hand on real machines — nothing in CI has a
+# firmware boot menu or a vendor ESP. What CI *can* hold is the contract that
+# makes the proof collectable and honest:
+#
+#   * the ordering that lets the restore happen at all (read the record before
+#     deleting the folder it lives in),
+#   * the mirror that makes it happen on the orphaned-leftovers path, which the
+#     issue tests explicitly and which silently did nothing before,
+#   * a grader that is actually run somewhere, so its ✘ means something,
+#   * and a documented procedure that grades the keep and delete choices
+#     against their own correct end states.
+#
+# The PowerShell grading logic is exercised for real in
+# tests/unit/test-verify-uninstall.ps1; these are the wiring gates.
+
+E2E_APP=app/installer_windows.go
+PROBE=app/sysprobe_windows.go
+FIELD=tests/field/verify-uninstall.ps1
+
+@test "the power record is read BEFORE the folder holding it is removed" {
+    # restorePriorPowerState() reads C:\wootc\install\prior-power.txt, and step
+    # 3 of the same function removes C:\wootc\install. Reverse them and the
+    # restore silently becomes a no-op on every uninstall.
+    local restore_line remove_line
+    restore_line=$(grep -n 'restorePriorPowerState()' "$E2E_APP" | grep -v 'func ' | head -1 | cut -d: -f1)
+    remove_line=$(grep -n 'os.RemoveAll(filepath.Join(wootcDir(), "install"))' "$E2E_APP" | head -1 | cut -d: -f1)
+    [ -n "$restore_line" ]
+    [ -n "$remove_line" ]
+    [ "$restore_line" -lt "$remove_line" ]
+}
+
+@test "the pre-install power state is mirrored where a hand-deleted folder cannot take it" {
+    # The orphaned-leftovers path (#238: "delete C:\wootc by hand first, then
+    # uninstall") destroys prior-power.txt, so the file alone can never restore
+    # that machine. The Add/Remove key survives it and is deleted immediately
+    # AFTER the restore runs.
+    grep -q 'WootcPriorHibernate' "$PROBE"
+    grep -q 'WootcPriorHiberboot' "$PROBE"
+    grep -q 'func readPriorPowerMirror' "$PROBE"
+    # File first, registry second — the file is authoritative when present.
+    run bash -c "sed -n '/func priorPowerValues/,/^}/p' $PROBE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"os.ReadFile(priorPowerPath())"* ]]
+    [[ "$output" == *"readPriorPowerMirror()"* ]]
+    # And the mirror must outlive the restore that reads it.
+    local restore_line unregister_line
+    restore_line=$(grep -n 'restorePriorPowerState()' "$E2E_APP" | grep -v 'func ' | head -1 | cut -d: -f1)
+    unregister_line=$(grep -n 'unregisterUninstallEntry()' "$E2E_APP" | grep -v 'func ' | head -1 | cut -d: -f1)
+    [ "$restore_line" -lt "$unregister_line" ]
+}
+
+@test "restoration re-enables only what was on, and reads values not substrings" {
+    # A machine that had hibernation off must still have it off afterwards.
+    run bash -c "sed -n '/^func restorePriorPowerState/,/^}/p' $PROBE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'hibernate == "1"'* ]]
+    [[ "$output" == *'hiberboot == "1"'* ]]
+    # The old reader could not tell 1 from 10, nor "was off" from "never read".
+    [[ "$output" != *'strings.Contains'* ]]
+    grep -q 'func parsePriorPower' app/power_state.go
+}
+
+@test "only the FIRST install defines what 'prior' means" {
+    # A reinstall after wootc already turned hibernation off must not record
+    # the off state as the thing to restore to.
+    run bash -c "sed -n '/^func recordPriorPowerState/,/^}/p' $PROBE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'os.Stat(priorPowerPath())'* ]]
+    [[ "$output" == *"return"* ]]
+}
+
+@test "the field verifier exists and refuses to grade without a baseline" {
+    [ -f "$FIELD" ]
+    grep -q "run 'capture' before uninstalling" "$FIELD"
+    # Capture must copy out the record the uninstall is about to destroy.
+    grep -q 'prior-power.txt' "$FIELD"
+    # Read-only on the machine under test, apart from the temporary ESP letter.
+    grep -q 'Remove-PartitionAccessPath' "$FIELD"
+}
+
+@test "the verifier grades keep and delete against different end states" {
+    # C:\wootc surviving a keep uninstall is CORRECT; grading it as residue
+    # would fail a good machine.
+    run bash -c "sed -n '/function Test-WootcDirState/,/^}/p' $FIELD"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"root.disk is GONE after a keep uninstall"* ]]
+    [[ "$output" == *"still exists after a delete-my-Linux-data uninstall"* ]]
+}
+
+@test "a missing power baseline fails the box instead of skipping it" {
+    # The orphaned path destroys the record. Passing by default there would
+    # hide the exact regression this issue exists to catch.
+    run bash -c "sed -n '/function Test-PowerRestored/,/^}/p' $FIELD"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'Pass    = $false'* ]]
+    [[ "$output" == *"orphaned"* ]]
+}
+
+@test "the ESP check is two-sided: ours gone AND nothing else touched" {
+    grep -q 'ForeignRemoved' "$FIELD"
+    grep -q 'ForeignChanged' "$FIELD"
+    # Hashes, not just names — a rewritten foreign file must not read as clean.
+    grep -q 'Get-FileHash' "$FIELD"
+    grep -q 'ESP: nothing else touched' "$FIELD"
+}
+
+@test "the checklist cannot be talked into passing" {
+    # Any unticked box exits non-zero, so an attached checklist claiming PASS
+    # is a claim the script itself made.
+    grep -q 'RESULT: PASS' "$FIELD"
+    grep -q 'RESULT: FAIL' "$FIELD"
+    run bash -c "grep -A3 'Where-Object { -not \$_.Pass }' $FIELD | tail -5"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"exit 1"* ]]
+}
+
+@test "the PowerShell grading logic is actually run by the fast tier" {
+    # A grader nothing exercises is a rubber stamp. The first run of these
+    # tests found an empty-array return that made a clean machine report a
+    # phantom firmware entry.
+    [ -f tests/unit/test-verify-uninstall.ps1 ]
+    grep -q 'tests/unit/test-\*\.ps1' tests/run.sh
+    grep -q 'powershell unit tests' tests/run.sh
+}
+
+@test "manual-testing documents the procedure the issue asks for" {
+    grep -q 'Proving the uninstall put everything back' docs/manual-testing.md
+    grep -q 'verify-uninstall.ps1 capture' docs/manual-testing.md
+    grep -q 'verify-uninstall.ps1 verify' docs/manual-testing.md
+    # The two traps a tester would otherwise fall into.
+    grep -q 'RootDisk delete' docs/manual-testing.md
+    grep -q 'Orphaned' docs/manual-testing.md
+    grep -q 'is not always meant to disappear' docs/manual-testing.md
+}


### PR DESCRIPTION
Refs #238.

## What was actually blocking this

#238 asks for "one uninstall puts everything back" proven on two real machines with every box ticked. Nobody in CI has a firmware boot menu, so the two runs stay open — but the reason they hadn't happened isn't access to hardware. **The proof could not be collected, and one of the two variants the issue names does not actually restore.**

## The gap, found while working out how to verify it

`restorePriorPowerState()` reads the pre-install hibernation / Fast Startup values from `C:\wootc\install\prior-power.txt`. The spec requires testing the orphaned-leftovers path — *"delete `C:\wootc` by hand first, then uninstall"* — which destroys that file before the uninstaller ever runs. The restore then returns having changed nothing, and **hibernation stays off forever on a machine we promised to leave unchanged.** Silently: nothing reports it, and the record that would prove it is gone too.

Fix: mirror the two values into the Add/Remove registry key. It survives a hand-deleted folder, and `unregisterUninstallEntry()` removes it immediately *after* the restore reads it — so the mirror outlives exactly the window it's needed for. File first, registry second; the file stays authoritative when present.

While there: the reader was `strings.Contains(content, "hibernate=1")`, which can't tell `1` from `10`, nor "was off" from "we failed to read it at install time". Restoration is a promise about someone's machine, so it now parses the value (`parsePriorPower`, cross-platform and table-tested).

## The proof

`tests/field/verify-uninstall.ps1`, two phases on the test machine:

```powershell
# after the install, BEFORE uninstalling
.\tests\field\verify-uninstall.ps1 capture -Out C:\uninstall-proof
# ...uninstall, reboot twice...
.\tests\field\verify-uninstall.ps1 verify -Baseline C:\uninstall-proof -RootDisk keep
```

`capture` snapshots the firmware boot entries, every ESP file with its SHA-256, the ownership manifest, the live power settings, `C:\wootc`, the Add/Remove entry — and copies out `prior-power.txt`, **without which the power box is unverifiable after the fact**, because the uninstall deletes it.

`verify` diffs it all and writes `checklist.md` with each box ticked or not *and the evidence for it*, then **exits non-zero if any box failed**. That exit code is the whole point: an attached checklist claiming PASS is a claim the script made, not one a tester remembered.

Three things it gets right that a hand-written checklist would not:

- **The ESP check is two-sided and hash-based.** Not just "our files are gone" but "nothing else moved". A dual-boot user's entry vanishing during our uninstall is exactly what a data-safety criterion exists to rule out — and a name-only diff would miss a foreign file rewritten in place.
- **keep and delete are graded against different correct end states.** With the default keep choice `C:\wootc` is *supposed* to survive, holding `root.disk`; only `install\` goes. Grading that against "the folder is gone" records a ✘ on a good machine, and the issue's own checklist wording (*"`C:\wootc` removed"*) would have done exactly that.
- **A missing power baseline fails the box rather than skipping it** — so the orphan regression above cannot hide inside a green report.

## Tests

The grading comparators are dot-sourceable and driven from synthetic snapshots in `tests/unit/test-verify-uninstall.ps1` (34 checks), wired into the fast tier next to the existing ps1 lint. A grader nothing exercises is a rubber stamp — and the first run of these found one: an empty-array return collapsing to `$null` made a **perfectly clean machine report a phantom firmware entry**, i.e. a false ✘ on a passing run.

`tests/unit/uninstall-restoration.bats` (11 tests) holds the wiring: the restore must read the record before the folder holding it is deleted, the mirror must outlive the restore, only an exact `"1"` may trigger a re-enable, and only the *first* install may define what "prior" means. Mutation-checked — reordering the restore, removing the mirror, and making a missing baseline pass each turn the suite red.

Verified locally: `go test ./...` green, `GOOS=windows go vet ./...` clean (the changed files are Windows-tagged, so this is the real type-check), `GOOS=windows go build` produces a binary, ps1 lint passes on both new scripts. Full bats suite green except `userdata-persistence.bats`, which fails on an uninitialized `fisherman` submodule in this checkout and is untouched here.

## Still open

The two machine runs. `docs/manual-testing.md` gains the procedure, including the two traps a tester would otherwise hit — `C:\wootc` is not always meant to disappear, and the orphan run still has to capture first. **#238 should stay open** until both checklists are attached; this PR is what makes them collectable and their results worth trusting.

Note the field-report template itself belongs to #215 (`.github/ISSUE_TEMPLATE/manual-test-report.yml`) and is deliberately untouched here — the checklist is designed to be attached to whatever that template becomes.

— hive: backend=claude model=claude-opus-5
