### PR TITLE
feat(session): label session migration honestly across dashboard, done screen, and docs (fixes #228)

### DIFF
--- a/app/frontend/src/screens/done.js
+++ b/app/frontend/src/screens/done.js
@@ -41,6 +41,10 @@ export function renderDoneScreen() {
       <strong>Enroll MOK</strong> → <strong>Continue</strong> → <strong>Yes</strong>, and type the password
       <strong>${state.selected.mokEnroll}</strong>. Totally normal, and it never appears again.</span>
     </div>` : ''}
+    ${Object.values(state.config.sessionConsent || {}).some(Boolean) ? `
+    <div style="display:flex;gap:8px;align-items:flex-start;font-size:12px;color:var(--text-muted);margin-top:8px;background:var(--bg-card);border:1px solid var(--border);border-radius:6px;padding:9px 12px;text-align:left;max-width:460px">
+      <span>🔐</span><span><strong>Session keys staged:</strong> your opted-in session keys are safely staged. On Linux, you'll sign in once to connect your apps.</span>
+    </div>` : ''}
   `;
   screen.appendChild(hero);
   wrap.appendChild(screen);

--- a/app/frontend/src/screens/launchpad.js
+++ b/app/frontend/src/screens/launchpad.js
@@ -260,7 +260,7 @@ export function renderLaunchpad() {
   if (movableSessions.length) {
     sessionBox = el('div');
     sessionBox.style.cssText = 'margin-top:8px;padding:8px;border:1.5px solid var(--border);border-radius:6px';
-    sessionBox.innerHTML = `<div style="font-size:12px;font-weight:600">Signed-in app sessions</div><div style="font-size:11.5px;color:var(--text-muted);margin-top:2px">Optional: move these sessions while Windows is online. Off means you will sign in once on Linux.</div>`;
+    sessionBox.innerHTML = `<div style="font-size:12px;font-weight:600">App session staging (opt-in)</div><div style="font-size:11.5px;color:var(--text-muted);margin-top:2px">Optional: stage session keys while Windows is online. Staged — you'll sign in once on Linux until target import is verified.</div>`;
     movableSessions.forEach(candidate => {
       const row = el('label');
       row.style.cssText = 'display:flex;gap:8px;align-items:flex-start;cursor:pointer;font-size:12px;margin-top:7px';

--- a/app/frontend/src/screens/migrate.js
+++ b/app/frontend/src/screens/migrate.js
@@ -226,6 +226,7 @@ const APP_ICONS = {
 // The honest outcome badge, driven by the backend's session verdict.
 const SESSION_BADGE = {
   portable: { label: '✓ Signed in', cls: 'ok' },
+  staged:   { label: 'Staged — sign in once', cls: '' },
   signin:   { label: 'Sign in once', cls: '' },
   relink:   { label: 'Re-link needed (2 steps)', cls: '' },
   none:     { label: 'Re-link needed', cls: '' },
@@ -253,7 +254,7 @@ function renderAppRow(a) {
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.checked = !!a.consent;
-    checkbox.title = 'Allow session token copy when the Windows-online exporter supports this app';
+    checkbox.title = 'Allow session key staging when the Windows-online exporter supports this app';
     checkbox.onchange = async () => {
       checkbox.disabled = true;
       try { await SetSessionConsent(a.app, checkbox.checked); a.consent = checkbox.checked; }

--- a/app/migration_linux.go
+++ b/app/migration_linux.go
@@ -201,9 +201,23 @@ func appMigrations() ([]AppMigration, error) {
 		return nil, err
 	}
 	consents := readSessionConsents(filepath.Join(u.HomeDir, ".config", "wootc", "session-consent.json"))
+	exports := readSessionExports()
 	for i := range parsed.Apps {
-		parsed.Apps[i].ConsentAvailable = tokenConsentApps[parsed.Apps[i].App] && parsed.Apps[i].Session == "signin"
-		parsed.Apps[i].Consent = parsed.Apps[i].ConsentAvailable && consents[parsed.Apps[i].App]
+		appKey := parsed.Apps[i].App
+		if exp, ok := exports[appKey]; ok {
+			switch exp.State {
+			case "staged":
+				parsed.Apps[i].Session = "staged"
+				parsed.Apps[i].Copied = true
+				parsed.Apps[i].Note = "Session key staged — you'll sign in once on Linux until target import is verified."
+			case "imported":
+				parsed.Apps[i].Session = "portable"
+				parsed.Apps[i].Copied = true
+				parsed.Apps[i].Note = "Session imported — opens signed in."
+			}
+		}
+		parsed.Apps[i].ConsentAvailable = tokenConsentApps[appKey] && (parsed.Apps[i].Session == "signin" || parsed.Apps[i].Session == "staged")
+		parsed.Apps[i].Consent = parsed.Apps[i].ConsentAvailable && (consents[appKey] || exports[appKey].State == "staged")
 	}
 	return parsed.Apps, nil
 }
@@ -247,6 +261,36 @@ func readSessionConsents(path string) map[string]bool {
 		return map[string]bool{}
 	}
 	return consents
+}
+
+func readSessionExports() map[string]SessionExport {
+	candidates := []string{
+		"/run/wootc/host/wootc/install/slurp/session/exports.json",
+		filepath.Join(wootcDir(), "install", "slurp", "session", "exports.json"),
+	}
+	for _, p := range candidates {
+		exports := readSessionExportsFrom(p)
+		if len(exports) > 0 {
+			return exports
+		}
+	}
+	return map[string]SessionExport{}
+}
+
+func readSessionExportsFrom(path string) map[string]SessionExport {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return map[string]SessionExport{}
+	}
+	var exports []SessionExport
+	if unmarshalJSON(data, &exports) != nil || len(exports) == 0 {
+		return map[string]SessionExport{}
+	}
+	res := make(map[string]SessionExport, len(exports))
+	for _, exp := range exports {
+		res[exp.App] = exp
+	}
+	return res
 }
 
 func reinstallApps() error {

--- a/app/migration_linux_test.go
+++ b/app/migration_linux_test.go
@@ -96,3 +96,35 @@ func TestDirSizeMissingPath(t *testing.T) {
 		t.Errorf("dirSize(missing) = %d, want -1 (du fails, UI shows \"calculating…\")", got)
 	}
 }
+
+func TestReadSessionExportsFrom(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "exports.json")
+	payload := `[{"app":"chrome","state":"staged","reason":"protected envelope staged; Linux app import still required"},{"app":"spotify","state":"imported","reason":"imported"}]`
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exports := readSessionExportsFrom(path)
+	if len(exports) != 2 {
+		t.Fatalf("expected 2 exports, got %d", len(exports))
+	}
+	if exports["chrome"].State != "staged" {
+		t.Errorf("chrome state = %q, want staged", exports["chrome"].State)
+	}
+	if exports["spotify"].State != "imported" {
+		t.Errorf("spotify state = %q, want imported", exports["spotify"].State)
+	}
+}
+
+func TestReadSessionExportsFromFailClosed(t *testing.T) {
+	if got := readSessionExportsFrom(filepath.Join(t.TempDir(), "absent.json")); len(got) != 0 {
+		t.Errorf("absent exports file = %#v, want empty map", got)
+	}
+	malformed := filepath.Join(t.TempDir(), "malformed.json")
+	if err := os.WriteFile(malformed, []byte("bad-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := readSessionExportsFrom(malformed); len(got) != 0 {
+		t.Errorf("malformed exports file = %#v, want empty map", got)
+	}
+}

--- a/app/session_windows.go
+++ b/app/session_windows.go
@@ -66,7 +66,7 @@ func collectSessions() ([]SessionCandidate, error) {
 		note := "Sign in once — your data is in your account."
 		if portable {
 			rec = "copy"
-			note = "We can carry your signed-in session across (with your OK)."
+			note = "Stage session keys (with your OK) — you'll sign in once on Linux."
 		}
 		// Messengers that fingerprint devices: prefer re-link even if a
 		// token copy is technically possible.

--- a/docs/session-migration.md
+++ b/docs/session-migration.md
@@ -33,12 +33,12 @@ carry the login with no decryption. Done in the deployer.
 3. re-encrypts the payload under a key derived from the wootc vault
    secret (never written in clear to disk), stored in
    `install\slurp\session\<app>.enc`.
-On the Linux side, the app's equivalent store is written back and
-re-encrypted under the Linux `safeStorage` (libsecret/kwallet). Result:
-the app opens already signed in. **Gated behind explicit user consent per
-app** — this is moving auth tokens, so the dashboard asks first and
-defaults off. (Implemented incrementally; the collector scaffolding lands
-here, per-app LevelDB rewriting is the follow-up.)
+On the Linux side, once the app's equivalent store is written back,
+re-encrypted under the Linux `safeStorage` (libsecret/kwallet), and verified
+against real service invalidation, the app opens signed in. **Gated behind
+explicit user consent per app** — this is moving auth tokens, so the dashboard
+asks first and defaults off. Until the target consumer and test matrix prove
+a migration, the key remains staged and the UI honestly says so.
 
 ### Online rewrap contract
 
@@ -78,8 +78,9 @@ Chrome/Edge install and a Linux D-Bus session to verify against, neither
 of which this change had access to.
 
 Until that consumer completes and records `imported`, the dashboard must show
-re-link/sign-in guidance rather than a signed-in result. A staged key is an
-implementation artifact, not evidence that a token transplant succeeded.
+staged guidance ("staged — you'll sign in once on Linux") or re-link/sign-in
+guidance rather than a signed-in result. A staged key is an implementation
+artifact, not evidence that a token transplant succeeded.
 
 **Phone-linked apps → guided re-link, not token theft.** Signal, WhatsApp,
 and (when token copy is declined) any messenger: the safest, most durable
@@ -100,4 +101,5 @@ everything. The dashboard frames it that way ("your playlists are waiting
 - Prefer re-link over token copy when the service is known to invalidate
   transplanted sessions (avoids a broken-looking app on first launch).
 - Every app row in the dashboard states its real outcome: *signed in*,
-  *re-link needed (2 steps)*, or *sign in once*.
+  *staged — sign in once*, *re-link needed (2 steps)*, or *sign in once*.
+- No UI surface implies a migration that wasn't measured.

--- a/payload/migration/wootc-detect-apps
+++ b/payload/migration/wootc-detect-apps
@@ -39,6 +39,33 @@ add() {
     [[ -n "$2" ]] && flatpaks+=("$2")
 }
 
+# Check if any sessions were staged online during Windows install.
+EXPORTS_JSON=""
+for p in /run/wootc/host/wootc/install/slurp/session/exports.json /run/wootc/host/install/slurp/session/exports.json; do
+    if [[ -f "$p" ]]; then
+        EXPORTS_JSON="$p"
+        break
+    fi
+done
+
+session_state() {
+    local app="$1"
+    [[ -n "$EXPORTS_JSON" ]] || { echo "none"; return 0; }
+    python3 -c "
+import json, sys
+try:
+    with open('$EXPORTS_JSON') as f:
+        data = json.load(f)
+    for entry in data:
+        if entry.get('app') == '$app':
+            print(entry.get('state', 'none'))
+            sys.exit(0)
+except Exception:
+    pass
+print('none')
+" 2>/dev/null || echo "none"
+}
+
 # ── APP DATABASE ────────────────────────────────────────────────────────────
 
 # Firefox — whole profile is portable (wootc-import-browser owns the copy).
@@ -47,13 +74,28 @@ if [[ -f "$W/AppData/Roaming/Mozilla/Firefox/profiles.ini" ]]; then
         "Everything moves: bookmarks, history, passwords, extensions, open tabs."
 fi
 
-# Chrome / Edge — bookmarks+history copy; sessions are DPAPI-locked.
-[[ -d "$W/AppData/Local/Google/Chrome/User Data" ]] && \
-    add chrome com.google.Chrome signin true \
-        "Bookmarks and history move. Sign in once and sync brings the rest."
-[[ -d "$W/AppData/Local/Microsoft/Edge/User Data" ]] && \
-    add edge com.google.Chrome signin true \
-        "Bookmarks and history move into Chrome. Passwords need a fresh sign-in."
+# Chrome / Edge — bookmarks+history copy; sessions are DPAPI-locked unless staged.
+if [[ -d "$W/AppData/Local/Google/Chrome/User Data" ]]; then
+    c_state=$(session_state "chrome")
+    if [[ "$c_state" == "imported" ]]; then
+        add chrome com.google.Chrome portable true "Session imported — opens signed in."
+    elif [[ "$c_state" == "staged" ]]; then
+        add chrome com.google.Chrome staged true "Session key staged — you'll sign in once on Linux until target import is verified."
+    else
+        add chrome com.google.Chrome signin true "Bookmarks and history move. Sign in once and sync brings the rest."
+    fi
+fi
+
+if [[ -d "$W/AppData/Local/Microsoft/Edge/User Data" ]]; then
+    e_state=$(session_state "edge")
+    if [[ "$e_state" == "imported" ]]; then
+        add edge com.google.Chrome portable true "Session imported into Chrome — opens signed in."
+    elif [[ "$e_state" == "staged" ]]; then
+        add edge com.google.Chrome staged true "Session key staged — you'll sign in once on Linux until target import is verified."
+    else
+        add edge com.google.Chrome signin true "Bookmarks and history move into Chrome. Passwords need a fresh sign-in."
+    fi
+fi
 
 # VS Code — settings/keybindings/snippets + extension list are plain files.
 VSC="$W/AppData/Roaming/Code/User"
@@ -79,9 +121,16 @@ fi
         "Your servers and messages live in your account — sign in once and everything is back."
 
 # Spotify — credentials are machine-bound; library is cloud-side anyway.
-[[ -d "$W/AppData/Roaming/Spotify" || -d "$W/AppData/Local/Packages/SpotifyAB.SpotifyMusic_zpdnekdrzrea0" ]] && \
-    add spotify com.spotify.Client signin false \
-        "Playlists and library are in your account — sign in once."
+if [[ -d "$W/AppData/Roaming/Spotify" || -d "$W/AppData/Local/Packages/SpotifyAB.SpotifyMusic_zpdnekdrzrea0" ]]; then
+    s_state=$(session_state "spotify")
+    if [[ "$s_state" == "imported" ]]; then
+        add spotify com.spotify.Client portable true "Playlists and library are in your account — opens signed in."
+    elif [[ "$s_state" == "staged" ]]; then
+        add spotify com.spotify.Client staged true "Session key staged — you'll sign in once on Linux until target import is verified."
+    else
+        add spotify com.spotify.Client signin false "Playlists and library are in your account — sign in once."
+    fi
+fi
 
 # Slack / Teams — Electron, same story.
 [[ -d "$W/AppData/Roaming/Slack" ]] && \


### PR DESCRIPTION
Fixes #228
Refs: #211, #1

## Summary
Aligns session migration status across all UI surfaces, backend reporting, scripts, and documentation with the binding honesty rules specified in `docs/session-migration.md` and issue #228 (Path B):

- **Migration Dashboard**: Added `staged` outcome badge (`Staged — sign in once`) and wired the `exports.json` status ledger so apps with staged keys reflect their honest state rather than implying an unmeasured login transplant.
- **Done Screen**: Added an honest session staging note on the installation complete screen when opt-in session staging was selected.
- **Windows Installer / Launchpad**: Clarified session candidate notes and session box title/subtitle to describe session key staging and explicitly communicate that the user will sign in once on Linux until target import is verified.
- **App Detection (`wootc-detect-apps`)**: Updated to inspect `exports.json` and mark staged session envelopes honestly.
- **Documentation (`docs/session-migration.md`)**: Updated the binding honesty rules and rewrap contract to ensure no UI surface implies a migration that was not measured.
- **Unit Tests**: Added tests covering session export ledger parsing and fail-closed handling in `migration_linux_test.go`.

— hive: backend=agy model=gemini-3.7-flash-high effort=low
---
🐝 **Hive Agent**: `contributor` | **SHA:** `3ca4c58`