### PR TITLE
feat(secure-boot): refuse before the reboot when the firmware cannot launch our shim (#322)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,67 @@ jobs:
             echo "channel=manual" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Build deployer boot artifacts
+        # The same builds the E2E harness performs (tests/e2e/run-e2e.sh):
+        # deployer kernel+initramfs out of the deployer image, signed
+        # shim+GRUB out of a Fedora container, wubildr best-effort.
+        run: |
+          set -euo pipefail
+          podman build -t wootc-deployer -f payload/deployer/Containerfile .
+          for artifact in deployer-vmlinuz deployer-initramfs.img; do
+            podman run --rm --entrypoint /bin/cat wootc-deployer "/out/$artifact" \
+              > "release-assets/$artifact"
+            [ -s "release-assets/$artifact" ] || { echo "::error::empty $artifact"; exit 1; }
+          done
+          # The shim must be signed by a Microsoft UEFI CA the user's firmware
+          # actually holds, or the reboot ends at "bad shim signature" with
+          # nothing said beforehand (#322). Fedora 44 ships shim-x64-16.1-5,
+          # signed ONLY by the 2011 authority whose certificate expired
+          # 2026-06-27; 16.1-7 is dual-signed (2011 AND 2023), which boots on
+          # old and new firmware alike. Pinned by exact NVR because "latest"
+          # is how a single-signed build silently comes back. Drop the pin
+          # when a numbered Fedora ships a dual-signed shim of its own — the
+          # --require check below holds the line either way.
+          SHIM_NVR="shim-x64-16.1-7.x86_64"
+          SHIM_RPM="https://kojipkgs.fedoraproject.org/packages/shim/16.1/7/x86_64/${SHIM_NVR}.rpm"
+          # Copy out of /usr/lib/efi/shim/<ver>/ (where the package owns the
+          # files at every version seen so far), with the /boot/efi path the
+          # post-install scriptlet populates as the fallback.
+          CID=$(podman create quay.io/fedora/fedora:44 \
+            bash -c "dnf install -y -q '$SHIM_RPM' grub2-efi-x64 2>/dev/null && \
+              for f in shimx64.efi mmx64.efi; do \
+                cp /usr/lib/efi/shim/*/EFI/fedora/\$f /tmp/ 2>/dev/null || \
+                cp /boot/efi/EFI/fedora/\$f /tmp/; done && \
+              cp /boot/efi/EFI/fedora/grubx64.efi /tmp/ && echo DONE")
+          podman start -a "$CID"
+          podman cp "$CID:/tmp/shimx64.efi" release-assets/shimx64.efi
+          podman cp "$CID:/tmp/grubx64.efi" release-assets/grubx64.efi
+          # MokManager: shim launches it for the MOK enrollment that
+          # custom-kernel images (Bazzite, #248) queue during deploy. Signed
+          # by Fedora's own key and verified by shim, not by the firmware —
+          # so it is deliberately NOT graded against the Microsoft CAs.
+          podman cp "$CID:/tmp/mmx64.efi" release-assets/mmx64.efi
+          podman rm "$CID"
+          [ -s release-assets/shimx64.efi ] && [ -s release-assets/grubx64.efi ] \
+            && [ -s release-assets/mmx64.efi ] || {
+            echo "::error::signed shim/GRUB extraction failed"; exit 1; }
+          # Record which Microsoft CA generations signed what we are shipping,
+          # and refuse to publish a shim that cannot boot on 2023-only
+          # firmware. The installer reads this file (or the value stamped into
+          # the exe below) to refuse BEFORE arming rather than after the
+          # reboot.
+          python3 packaging/shim-authorities.py --require 2023 --json \
+            release-assets/shimx64.efi > release-assets/shim-authorities.json
+          cat release-assets/shim-authorities.json
+          # wubildr is best-effort in the harness too — the signed shim chain
+          # is the fallback path.
+          if podman build -t wootc-wubildr -f payload/wubildr/Containerfile .; then
+            podman run --rm --entrypoint /bin/cat wootc-wubildr /out/wubildr.efi \
+              > release-assets/wubildr.efi || rm -f release-assets/wubildr.efi
+          fi
+          ls -lh release-assets/
+        working-directory: ${{ github.workspace }}
+
       - name: Build brand installers (one exe per blessed brand)
         # Subshells for every directory change: the first run interleaved a
         # failed `cd`/build chain with a loop that then globbed from the
@@ -167,48 +228,22 @@ jobs:
           # silent-skip the selector refuses internally.
           brands=$(bash packaging/brands.sh list)
           [ -n "$brands" ] || { echo "::error::no brand is buildable"; exit 1; }
+          # Each exe carries which Microsoft UEFI CA generations signed the
+          # shim this release stages, so the preflight can refuse a machine
+          # whose firmware trusts neither (#322) without a network round trip.
+          # Read from the shim that was actually extracted a step earlier —
+          # never a second copy of the pin, which is how a stamp starts
+          # describing a binary nobody is shipping.
+          SHIM_AUTHORITIES=$(python3 -c "import json;print(','.join(json.load(open('release-assets/shim-authorities.json'))['shimx64.efi']))")
+          [ -n "$SHIM_AUTHORITIES" ] || { echo "::error::the staged shim carries no Microsoft UEFI CA"; exit 1; }
+          echo "staging a shim signed by the Microsoft UEFI CA(s): $SHIM_AUTHORITIES"
           while IFS=$'\t' read -r brand exe; do
             (cd app && GOOS=windows GOARCH=amd64 go build -tags desktop,production \
-              -ldflags "-w -s -X main.brandID=$brand" -o "../release-assets/$exe.exe" .)
+              -ldflags "-w -s -X main.brandID=$brand -X main.shimAuthorities=$SHIM_AUTHORITIES" \
+              -o "../release-assets/$exe.exe" .)
             echo "built $exe.exe (brand: $brand)"
           done <<< "$brands"
           ls -lh release-assets/
-
-      - name: Build deployer boot artifacts
-        # The same builds the E2E harness performs (tests/e2e/run-e2e.sh):
-        # deployer kernel+initramfs out of the deployer image, signed
-        # shim+GRUB out of a Fedora container, wubildr best-effort.
-        run: |
-          set -euo pipefail
-          podman build -t wootc-deployer -f payload/deployer/Containerfile .
-          for artifact in deployer-vmlinuz deployer-initramfs.img; do
-            podman run --rm --entrypoint /bin/cat wootc-deployer "/out/$artifact" \
-              > "release-assets/$artifact"
-            [ -s "release-assets/$artifact" ] || { echo "::error::empty $artifact"; exit 1; }
-          done
-          CID=$(podman create quay.io/fedora/fedora:44 \
-            bash -c "dnf install -y -q shim-x64 grub2-efi-x64 2>/dev/null && \
-              cp /boot/efi/EFI/fedora/shimx64.efi /tmp/ && \
-              cp /boot/efi/EFI/fedora/grubx64.efi /tmp/ && \
-              cp /boot/efi/EFI/fedora/mmx64.efi /tmp/ && echo DONE")
-          podman start -a "$CID"
-          podman cp "$CID:/tmp/shimx64.efi" release-assets/shimx64.efi
-          podman cp "$CID:/tmp/grubx64.efi" release-assets/grubx64.efi
-          # MokManager: shim launches it for the MOK enrollment that
-          # custom-kernel images (Bazzite, #248) queue during deploy.
-          podman cp "$CID:/tmp/mmx64.efi" release-assets/mmx64.efi
-          podman rm "$CID"
-          [ -s release-assets/shimx64.efi ] && [ -s release-assets/grubx64.efi ] \
-            && [ -s release-assets/mmx64.efi ] || {
-            echo "::error::signed shim/GRUB extraction failed"; exit 1; }
-          # wubildr is best-effort in the harness too — the signed shim chain
-          # is the fallback path.
-          if podman build -t wootc-wubildr -f payload/wubildr/Containerfile .; then
-            podman run --rm --entrypoint /bin/cat wootc-wubildr /out/wubildr.efi \
-              > release-assets/wubildr.efi || rm -f release-assets/wubildr.efi
-          fi
-          ls -lh release-assets/
-        working-directory: ${{ github.workspace }}
 
       - name: Checksums for the release assets
         # The installer's fail-closed verification (#53/#194) and the

--- a/app/app.go
+++ b/app/app.go
@@ -152,6 +152,16 @@ type SystemInfo struct {
 	// user already has. Empty when unreadable or when nothing usable
 	// survives; the GUI then leaves the field for the user to fill.
 	SuggestedUsername string `json:"suggestedUsername"`
+	// TrustedUefiAuthorities lists the Microsoft UEFI CA generations this
+	// machine's firmware holds in its db variable ("2011", "2023"), so the
+	// preflight can tell before the reboot whether the signed shim this
+	// build stages will be launched at all (#322). Empty means the db could
+	// not be read, which warns rather than refusing.
+	TrustedUefiAuthorities []string `json:"trustedUefiAuthorities"`
+	// SecureBootChainWarning is set when Secure Boot is on but the db could
+	// not be read: honest disclosure that one check could not be made,
+	// shown before the user commits rather than after the restart.
+	SecureBootChainWarning string `json:"secureBootChainWarning"`
 }
 
 // sanitizeUsername converts a Windows account name into a legal Linux
@@ -380,12 +390,20 @@ func (a *App) gateScenario(cfg InstallConfig) error {
 	pol := a.GetSupportPolicy()
 	// BitLocker/FDE path is not green yet (#34).
 	if !pol.BitLockerSupported {
-		si := getSystemInfo()
-		if si.BitLockerOn {
+		if getSystemInfo().BitLockerOn {
 			return fmt.Errorf("BitLocker drive encryption isn't supported in the %s yet — "+
 				"we're finishing testing so your files stay safe. It's coming soon; "+
 				"for now, wootc works on PCs where drive encryption is off", pol.Channel)
 		}
+	}
+	// Secure Boot: can this firmware launch the shim we stage? (#322)
+	// Checked here, before a single byte is written, because the failure it
+	// prevents ("bad shim signature") happens after the reboot, where the
+	// user has no way to find out why Windows came back.
+	si := getSystemInfo()
+	if v := checkSecureBootChain(si.SecureBootOn, si.SecureBootKnown,
+		si.TrustedUefiAuthorities, stagedShimAuthorities()); v.Blocked {
+		return fmt.Errorf("%s", v.Message)
 	}
 	// Only offer images the channel permits. Enterprise images.json override
 	// (custom refs) is trusted; a custom ref typed by the user is gated.

--- a/app/frontend/src/screens/launchpad.js
+++ b/app/frontend/src/screens/launchpad.js
@@ -58,6 +58,14 @@ export function renderLaunchpad() {
     // Recovery-key warning (#63): tell the user to record their key before
     // proceeding, regardless of whether we unlock C: or carve a separate
     // volume. This is honest disclosure — independent of #61.
+    // Secure Boot is on but we could not read which certificates the
+    // firmware trusts (#322). Say so before the user commits: the check we
+    // could not make is the one that decides whether the restart reaches
+    // Linux at all.
+    if (state.sysinfo?.secureBootChainWarning) {
+      screen.appendChild(warningBanner(
+        '<b>⚠ One check we could not make:</b> ' + state.sysinfo.secureBootChainWarning));
+    }
     if (state.sysinfo?.bitLockerRecoveryKeyWarning) {
       screen.appendChild(warningBanner(
         '<b>⚠ Before you continue:</b> Make sure you have your BitLocker recovery key. ' +

--- a/app/installer_windows.go
+++ b/app/installer_windows.go
@@ -64,6 +64,18 @@ func getSystemInfo() SystemInfo {
 	// Secure Boot
 	info.SecureBootOn, info.SecureBootKnown = secureBootState()
 
+	// Which Microsoft UEFI CA generation does this firmware trust? (#322)
+	// Only worth asking when Secure Boot is actually on — with it off the
+	// firmware launches an unsigned loader too, and the db read costs a
+	// PowerShell spawn on a screen the user is waiting for.
+	if info.SecureBootOn {
+		info.TrustedUefiAuthorities = trustedUefiAuthorities()
+		if v := checkSecureBootChain(info.SecureBootOn, info.SecureBootKnown,
+			info.TrustedUefiAuthorities, stagedShimAuthorities()); v.Warn {
+			info.SecureBootChainWarning = v.Message
+		}
+	}
+
 	// Advisory NTFS fragmentation analysis (SPEC §3.6). Failure to analyze
 	// must not block installation.
 	info.DefragRecommended = defragRecommended(`C:`)

--- a/app/secureboot.go
+++ b/app/secureboot.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// ── Secure Boot: which Microsoft UEFI CA does this machine trust? (#322) ──────
+//
+// Under Secure Boot the firmware will only launch a loader signed by a CA in
+// its `db` variable. Microsoft's third-party authority exists in two
+// generations: "Microsoft Corporation UEFI CA 2011" (certificate expired
+// 2026-06-27) and "Microsoft UEFI CA 2023", which signs everything issued
+// now. Firmware does not check expiry, so a machine holding the 2011 CA still
+// boots a 2011-signed shim — but new machines increasingly ship the 2023 CA
+// alone, and Microsoft's certificate rollout is adding it to existing ones.
+//
+// wootc stages a signed shim on the ESP and points the one-shot boot entry at
+// it. If that shim is signed only by an authority this firmware does not hold,
+// the reboot ends at "bad shim signature", the firmware falls back to Windows,
+// and the user is told nothing. Asking BEFORE arming turns a silent failure
+// after a reboot into a sentence on screen while Windows is still running.
+
+// shimAuthorities is set at build time with
+// -ldflags "-X main.shimAuthorities=2011,2023", from the signatures actually
+// present on the shim that release stages (packaging/shim-authorities.py).
+// Empty in a local build, which means "unknown" and gates nothing: a
+// developer build must not refuse to install because the release pipeline
+// did not stamp it.
+var shimAuthorities = ""
+
+// microsoftUefiCAPatterns maps a certificate issuer common name to the
+// generation name the preflight and the release pipeline both speak. Matched
+// on the ISSUER: the leaf is a per-publisher certificate, and it is the CA
+// above it that has to be in the firmware's db.
+var microsoftUefiCAPatterns = []struct {
+	re  *regexp.Regexp
+	gen string
+}{
+	{regexp.MustCompile(`Microsoft Corporation UEFI CA 2011`), "2011"},
+	{regexp.MustCompile(`Microsoft (?:Corporation )?UEFI CA 2023`), "2023"},
+}
+
+// efiCertX509GUID is EFI_CERT_X509_GUID (a5c059a1-94e4-4aa7-87b5-ab155c2bf072)
+// in the mixed-endian form UEFI writes into a signature list header.
+var efiCertX509GUID = [16]byte{
+	0xa1, 0x59, 0xc0, 0xa5, 0xe4, 0x94, 0xa7, 0x4a,
+	0x87, 0xb5, 0xab, 0x15, 0x5c, 0x2b, 0xf0, 0x72,
+}
+
+// parseUEFISignatureListCAs walks an EFI_SIGNATURE_LIST chain (the raw
+// contents of the `db` variable) and returns the Microsoft UEFI CA
+// generations it contains, sorted and deduplicated.
+//
+// Layout per list: EFI_GUID SignatureType (16) | UINT32 SignatureListSize |
+// UINT32 SignatureHeaderSize | UINT32 SignatureSize | SignatureHeader[] |
+// EFI_SIGNATURE_DATA[] where each entry is EFI_GUID SignatureOwner (16)
+// followed by the signature itself. For an X509 list the signature is a DER
+// certificate. Non-X509 lists (SHA-256 hashes of individual binaries) carry
+// no CA and are skipped.
+//
+// Malformed input yields what could be read rather than an error: a db we
+// cannot fully parse still tells us about the entries we did understand, and
+// "unknown" is the safe answer for the rest.
+func parseUEFISignatureListCAs(db []byte) []string {
+	seen := map[string]bool{}
+	for off := 0; off+28 <= len(db); {
+		var sigType [16]byte
+		copy(sigType[:], db[off:off+16])
+		listSize := le32(db, off+16)
+		headerSize := le32(db, off+20)
+		sigSize := le32(db, off+24)
+
+		// A list that does not advance, overruns the buffer, or claims a
+		// signature bigger than itself is corrupt; stop rather than loop.
+		if listSize < 28 || sigSize <= 16 || off+int(listSize) > len(db) {
+			break
+		}
+		if sigType == efiCertX509GUID {
+			entries := off + 28 + int(headerSize)
+			for entries+int(sigSize) <= off+int(listSize) {
+				// Skip the 16-byte SignatureOwner GUID; the rest is DER.
+				der := db[entries+16 : entries+int(sigSize)]
+				if cert, err := x509.ParseCertificate(der); err == nil {
+					for _, gen := range matchMicrosoftUefiCA(cert.Subject.CommonName) {
+						seen[gen] = true
+					}
+				}
+				entries += int(sigSize)
+			}
+		}
+		off += int(listSize)
+	}
+	return sortedKeys(seen)
+}
+
+func le32(b []byte, off int) uint32 {
+	if off < 0 || off+4 > len(b) {
+		return 0
+	}
+	return uint32(b[off]) | uint32(b[off+1])<<8 | uint32(b[off+2])<<16 | uint32(b[off+3])<<24
+}
+
+// matchMicrosoftUefiCA returns the generation names a certificate subject or
+// issuer string identifies. A single string can only be one generation, but
+// returning a slice keeps the callers uniform.
+func matchMicrosoftUefiCA(name string) []string {
+	var out []string
+	for _, p := range microsoftUefiCAPatterns {
+		if p.re.MatchString(name) {
+			out = append(out, p.gen)
+		}
+	}
+	return out
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// stagedShimAuthorities returns the Microsoft CA generations that signed the
+// shim this build stages, or nil when the build did not record them.
+//
+// A pre-staged shim-authorities.json under the install directory wins over
+// the compiled-in value: the E2E harness and the offline bundle both assemble
+// their own boot artifacts, and grading them against the release's stamp
+// would be a lie in either direction.
+func stagedShimAuthorities() []string {
+	path := filepath.Join(wootcDir(), "install", "shim-authorities.json")
+	if data, err := os.ReadFile(path); err == nil {
+		var m map[string][]string
+		if json.Unmarshal(data, &m) == nil {
+			if gens, ok := m["shimx64.efi"]; ok {
+				return normalizeAuthorities(gens)
+			}
+		}
+	}
+	if shimAuthorities == "" {
+		return nil
+	}
+	return normalizeAuthorities(strings.Split(shimAuthorities, ","))
+}
+
+func normalizeAuthorities(in []string) []string {
+	seen := map[string]bool{}
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s != "" {
+			seen[s] = true
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func intersects(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// secureBootChainCheck is the preflight verdict on whether the shim this
+// build stages can be launched by this machine's firmware.
+type secureBootChainCheck struct {
+	// Blocked is set only when BOTH sides are known AND they do not
+	// intersect — the one case where we can say the reboot will fail.
+	Blocked bool
+	// Warn is set when Secure Boot is on but the firmware's db could not be
+	// read. The install still proceeds: "bad shim signature" costs the user
+	// a reboot back into Windows, not their data, and refusing every machine
+	// whose SecureBoot module is unavailable would block PCs that work today.
+	Warn    bool
+	Message string
+}
+
+// checkSecureBootChain compares what the firmware trusts against what this
+// build stages. secureBootOn/secureBootKnown come from the firmware probe;
+// trusted is what parseUEFISignatureListCAs found in db; staged is
+// stagedShimAuthorities().
+func checkSecureBootChain(secureBootOn, secureBootKnown bool, trusted, staged []string) secureBootChainCheck {
+	// Secure Boot off (or unknowable): the firmware launches whatever it is
+	// pointed at, so the signing authority is not what stands in the way.
+	if !secureBootKnown || !secureBootOn {
+		return secureBootChainCheck{}
+	}
+	// A build that did not record what it stages cannot grade anything.
+	if len(staged) == 0 {
+		return secureBootChainCheck{}
+	}
+	if len(trusted) == 0 {
+		return secureBootChainCheck{
+			Warn: true,
+			Message: "We could not read which certificates your PC's Secure Boot trusts, " +
+				"so we cannot check the startup file in advance. If the restart ends up " +
+				"back in Windows, that is why — nothing will be damaged, and you can " +
+				"turn Secure Boot off temporarily and try again.",
+		}
+	}
+	if intersects(trusted, staged) {
+		return secureBootChainCheck{}
+	}
+	return secureBootChainCheck{
+		Blocked: true,
+		Message: fmt.Sprintf(
+			"Your PC's Secure Boot trusts Microsoft's %s certificate, but this "+
+				"version's startup file is signed with %s. Starting Linux would stop "+
+				"at a \"bad shim signature\" message. Nothing has been changed. "+
+				"Please update %s to a newer version, or turn Secure Boot off in your "+
+				"PC's firmware settings and try again.",
+			humanAuthorities(trusted), humanAuthorities(staged), productNameForMessages()),
+	}
+}
+
+// humanAuthorities renders {"2011","2023"} as "2011 and 2023" for a sentence
+// a non-technical reader can parse.
+func humanAuthorities(gens []string) string {
+	switch len(gens) {
+	case 0:
+		return "no known"
+	case 1:
+		return gens[0]
+	case 2:
+		return gens[0] + " and " + gens[1]
+	default:
+		return strings.Join(gens[:len(gens)-1], ", ") + " and " + gens[len(gens)-1]
+	}
+}
+
+// productNameForMessages is the brand's product name, so a Bluefin user is
+// told to update Bluefin rather than something called wootc.
+func productNameForMessages() string {
+	if n := effectiveBranding().ProductName; n != "" {
+		return n
+	}
+	return "wootc"
+}

--- a/app/secureboot_other.go
+++ b/app/secureboot_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// trustedUefiAuthorities is Windows-only: reading the firmware's db variable
+// goes through the SecureBoot PowerShell module. The dev stub reports
+// "unknown", which gates nothing.
+func trustedUefiAuthorities() []string { return nil }

--- a/app/secureboot_test.go
+++ b/app/secureboot_test.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── Building a real db blob to parse ──────────────────────────────────────
+// Hand-written hex would only prove the parser matches whatever the test
+// author believed the layout was. Generating actual X.509 certificates and
+// wrapping them in a real EFI_SIGNATURE_LIST means a parser bug shows up as
+// a failing test rather than as "bad shim signature" on somebody's PC.
+
+func selfSigned(t *testing.T, commonName string) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName, Organization: []string{"Microsoft Corporation"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return der
+}
+
+// signatureList wraps DER certificates in one EFI_SIGNATURE_LIST. Every
+// entry in a list must be the same size, so callers group by size or pass
+// one certificate at a time — which is what real firmware does too.
+func signatureList(sigType [16]byte, certs ...[]byte) []byte {
+	sigSize := 0
+	for _, c := range certs {
+		if 16+len(c) > sigSize {
+			sigSize = 16 + len(c)
+		}
+	}
+	out := make([]byte, 0, 28+len(certs)*sigSize)
+	out = append(out, sigType[:]...)
+	var hdr [12]byte
+	binary.LittleEndian.PutUint32(hdr[0:], uint32(28+len(certs)*sigSize)) // SignatureListSize
+	binary.LittleEndian.PutUint32(hdr[4:], 0)                             // SignatureHeaderSize
+	binary.LittleEndian.PutUint32(hdr[8:], uint32(sigSize))               // SignatureSize
+	out = append(out, hdr[:]...)
+	for _, c := range certs {
+		entry := make([]byte, sigSize)
+		copy(entry[16:], c) // first 16 bytes are the SignatureOwner GUID
+		out = append(out, entry...)
+	}
+	return out
+}
+
+func TestParseUEFISignatureListFindsBothCAGenerations(t *testing.T) {
+	db := signatureList(efiCertX509GUID, selfSigned(t, "Microsoft Corporation UEFI CA 2011"))
+	db = append(db, signatureList(efiCertX509GUID, selfSigned(t, "Microsoft UEFI CA 2023"))...)
+	db = append(db, signatureList(efiCertX509GUID, selfSigned(t, "Some OEM Platform Key"))...)
+
+	got := parseUEFISignatureListCAs(db)
+	if len(got) != 2 || got[0] != "2011" || got[1] != "2023" {
+		t.Fatalf("parseUEFISignatureListCAs = %v, want [2011 2023]", got)
+	}
+}
+
+func TestParseUEFISignatureListIgnoresNonX509Lists(t *testing.T) {
+	// A db commonly also holds SHA-256 hashes of individual revoked or
+	// allowed binaries. Those lists carry no certificate; treating their
+	// bytes as DER must not invent an authority, and must not stop the walk
+	// before the X509 list that follows.
+	var sha256Type [16]byte
+	sha256Type[0] = 0x26 // any GUID that is not EFI_CERT_X509_GUID
+	hashes := make([]byte, 32)
+	db := signatureList(sha256Type, hashes)
+	db = append(db, signatureList(efiCertX509GUID, selfSigned(t, "Microsoft UEFI CA 2023"))...)
+
+	got := parseUEFISignatureListCAs(db)
+	if len(got) != 1 || got[0] != "2023" {
+		t.Fatalf("parseUEFISignatureListCAs = %v, want [2023]", got)
+	}
+}
+
+func TestParseUEFISignatureListSurvivesTruncation(t *testing.T) {
+	// A short read of the variable must not panic or loop forever; it
+	// reports what it could read, and "unknown" covers the rest.
+	db := signatureList(efiCertX509GUID, selfSigned(t, "Microsoft Corporation UEFI CA 2011"))
+	for _, cut := range []int{0, 1, 27, 28, len(db) / 2, len(db) - 1} {
+		if got := parseUEFISignatureListCAs(db[:cut]); len(got) > 1 {
+			t.Fatalf("truncated at %d returned %v", cut, got)
+		}
+	}
+	// A list claiming zero size would spin forever if the walk trusted it.
+	spin := make([]byte, 28)
+	copy(spin, efiCertX509GUID[:])
+	done := make(chan []string, 1)
+	go func() { done <- parseUEFISignatureListCAs(spin) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("parseUEFISignatureListCAs did not terminate on a zero-size list")
+	}
+}
+
+// ── The verdict: the whole point is that it fires ONLY on a known mismatch ──
+
+func TestSecureBootChainBlocksOnlyOnAKnownMismatch(t *testing.T) {
+	cases := []struct {
+		name                  string
+		on, known             bool
+		trusted, staged       []string
+		wantBlocked, wantWarn bool
+	}{
+		{"2023-only firmware, 2011-only shim: the failure this exists to prevent",
+			true, true, []string{"2023"}, []string{"2011"}, true, false},
+		{"2011-only firmware, 2023-only shim: the same failure the other way",
+			true, true, []string{"2011"}, []string{"2023"}, true, false},
+		{"dual-signed shim satisfies either firmware",
+			true, true, []string{"2023"}, []string{"2011", "2023"}, false, false},
+		{"overlapping sets are fine",
+			true, true, []string{"2011", "2023"}, []string{"2011"}, false, false},
+		{"db unreadable warns, never blocks: refusing every PC whose SecureBoot module is missing would be worse than a recoverable reboot",
+			true, true, nil, []string{"2011"}, false, true},
+		{"Secure Boot off: the signing authority is not what stands in the way",
+			false, true, nil, []string{"2011"}, false, false},
+		{"Secure Boot state unknown: nothing to grade against",
+			false, false, []string{"2023"}, []string{"2011"}, false, false},
+		{"a build that did not record what it stages cannot grade anything",
+			true, true, []string{"2023"}, nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkSecureBootChain(tc.on, tc.known, tc.trusted, tc.staged)
+			if got.Blocked != tc.wantBlocked || got.Warn != tc.wantWarn {
+				t.Fatalf("blocked=%v warn=%v, want blocked=%v warn=%v",
+					got.Blocked, got.Warn, tc.wantBlocked, tc.wantWarn)
+			}
+			if (got.Blocked || got.Warn) && got.Message == "" {
+				t.Fatal("a verdict that stops or warns the user must say why")
+			}
+		})
+	}
+}
+
+func TestSecureBootRefusalSaysWhatToDoAndThatNothingChanged(t *testing.T) {
+	// The moment of maximum fear: the user is told no. The sentence has to
+	// carry the reassurance and the two ways out, or it reads as a dead end.
+	v := checkSecureBootChain(true, true, []string{"2023"}, []string{"2011"})
+	for _, want := range []string{"Nothing has been changed", "Secure Boot off", "2023", "2011"} {
+		if !strings.Contains(v.Message, want) {
+			t.Errorf("refusal does not mention %q:\n%s", want, v.Message)
+		}
+	}
+	// It must not leak the internals a nervous reader cannot act on.
+	for _, forbidden := range []string{"EFI_SIGNATURE_LIST", "db variable", "Authenticode"} {
+		if strings.Contains(v.Message, forbidden) {
+			t.Errorf("refusal leaks %q at the user:\n%s", forbidden, v.Message)
+		}
+	}
+}
+
+func TestStagedShimAuthoritiesParsesTheBuildStamp(t *testing.T) {
+	old := shimAuthorities
+	t.Cleanup(func() { shimAuthorities = old })
+
+	shimAuthorities = ""
+	if got := stagedShimAuthorities(); got != nil {
+		t.Errorf("an unstamped build must report unknown, got %v", got)
+	}
+	shimAuthorities = "2023, 2011 ,,2023"
+	got := stagedShimAuthorities()
+	if len(got) != 2 || got[0] != "2011" || got[1] != "2023" {
+		t.Errorf("stagedShimAuthorities = %v, want [2011 2023] deduped and sorted", got)
+	}
+}
+
+func TestHumanAuthoritiesReadsAsASentence(t *testing.T) {
+	for in, want := range map[string]string{
+		"2011":           "2011",
+		"2011,2023":      "2011 and 2023",
+		"2011,2023,2030": "2011, 2023 and 2030",
+	} {
+		if got := humanAuthorities(strings.Split(in, ",")); got != want {
+			t.Errorf("humanAuthorities(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/app/secureboot_windows.go
+++ b/app/secureboot_windows.go
@@ -1,0 +1,51 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// trustedUefiAuthorities reads the firmware's `db` variable and reports which
+// Microsoft UEFI CA generations it holds (#322).
+//
+// Get-SecureBootUEFI returns the raw EFI_SIGNATURE_LIST chain, which is the
+// authoritative form; it is base64'd across the process boundary because
+// runCmd hands back text. Get-SecureBootDbCertificates exists on newer
+// builds and is tried second — it returns parsed certificates, so it needs
+// no signature-list walk, only the subject strings.
+//
+// An empty result means "could not tell", never "trusts nothing": the caller
+// warns rather than refusing.
+func trustedUefiAuthorities() []string {
+	out, err := runPowerShellOutput(
+		`try { $v = Get-SecureBootUEFI -Name db -ErrorAction Stop; ` +
+			`[Convert]::ToBase64String($v.Bytes) } catch { '' }`)
+	if err == nil {
+		if raw := strings.TrimSpace(out); raw != "" {
+			if db, decErr := base64.StdEncoding.DecodeString(raw); decErr == nil {
+				if gens := parseUEFISignatureListCAs(db); len(gens) > 0 {
+					return gens
+				}
+			}
+		}
+	}
+
+	// Fallback: the cmdlet that hands back parsed certificates. Present on
+	// Windows 11 and recent Windows 10; absent elsewhere, which is exactly
+	// the case the warn path exists for.
+	out, err = runPowerShellOutput(
+		`try { Get-SecureBootDbCertificates -ErrorAction Stop | ` +
+			`ForEach-Object { $_.Subject } } catch { '' }`)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(out, "\n") {
+		for _, gen := range matchMicrosoftUefiCA(line) {
+			seen[gen] = true
+		}
+	}
+	return sortedKeys(seen)
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1785,6 +1785,41 @@ wootc/
 
 ## 9. Open Questions
 
+#### Which Microsoft UEFI CA the firmware trusts (#322)
+
+Secure Boot launches only a loader signed by a certificate authority present
+in the firmware's `db` variable. Microsoft's third-party authority exists in
+two generations:
+
+| Generation | Certificate | Notes |
+|---|---|---|
+| `Microsoft Corporation UEFI CA 2011` | expired 2026-06-27 | firmware ignores expiry, so machines holding it still boot 2011-signed loaders |
+| `Microsoft UEFI CA 2023` | current | signs everything Microsoft issues now; new machines increasingly ship it alone |
+
+A shim signed only by an authority this firmware does not hold fails at
+`bad shim signature` **after** the reboot, and the firmware falls back to
+Windows with nothing said. wootc therefore closes the loop at both ends:
+
+- **Build time.** `packaging/shim-authorities.py` reads the Authenticode
+  signatures out of the staged `shimx64.efi` (walking *every* WIN_CERTIFICATE,
+  since a dual-signed binary carries two) and writes `shim-authorities.json`.
+  The release refuses to publish a shim that is not 2023-signed, and stamps
+  the generations into each exe with `-X main.shimAuthorities=…`.
+- **Preflight.** `getSystemInfo` reads `db` via `Get-SecureBootUEFI -Name db`,
+  parses the `EFI_SIGNATURE_LIST` chain, and records which generations the
+  firmware holds. `gateScenario` refuses **before** anything is written when
+  both sides are known and do not intersect.
+- **When `db` cannot be read**, the install proceeds with an on-screen
+  warning rather than a refusal. `bad shim signature` costs the user a reboot
+  back into Windows, not their data; refusing every PC whose SecureBoot
+  PowerShell module is unavailable would block machines that work today.
+  (This is a deliberate softening of the original design in
+  `docs/borrowed-from-libertix.md` §1, which called for refusing on unknown.)
+
+`mmx64.efi` (MokManager) is signed by the distribution's own key and verified
+by shim rather than by the firmware, so it is deliberately not graded against
+the Microsoft authorities.
+
 1. **Secure Boot with GRUB2**: WubiUEFI uses shim for Secure Boot.
    wootc inherits this for the GRUB2 path. The shim must be signed by
    Microsoft's 3rd-party UEFI CA (the standard path for community

--- a/docs/borrowed-from-libertix.md
+++ b/docs/borrowed-from-libertix.md
@@ -82,12 +82,23 @@ ISO ships Debian's shim 16.1, which is dual-signed.
    2023-only cell must show the refusal text and never reach the reboot.
 
 ### Tasks
-- [ ] build-time signer extraction → `shim-authorities.json`, fail on 2011-only
-- [ ] bump the shim source to a dual-signed `shim-x64`, pin the NVR, assert in E2E
-- [ ] `SystemInfo.TrustedUefiAuthorities` + `SecureBootEnabled`
-- [ ] gate + user text + ledger line
-- [ ] harness `db` axis, three cells
-- [ ] `docs/user-guide.md` requirements, `SPEC.md` Secure Boot paragraph, `docs/status.md` row
+- [x] build-time signer extraction → `shim-authorities.json`, fail on 2011-only
+      (`packaging/shim-authorities.py`, `--require 2023` in `release.yml`)
+- [x] bump the shim source to a dual-signed `shim-x64`, pin the NVR
+      (`shim-x64-16.1-7`, pinned in both `release.yml` and `run-e2e.sh`)
+- [x] `SystemInfo.TrustedUefiAuthorities` + the `db` parser
+      (`app/secureboot.go`, `app/secureboot_windows.go`)
+- [x] gate + user text (`gateScenario`, launchpad warning banner)
+- [ ] harness `db` axis, three cells (2011-only, 2023-only, both) — the OVMF
+      vars work is the remaining piece
+- [x] `docs/user-guide.md` requirements, `SPEC.md` Secure Boot section
+
+**One deviation from the design above.** This section originally said an
+unreadable `db` under Secure Boot should *refuse*. The implementation warns
+instead. Refusing would block every machine whose SecureBoot PowerShell module
+is unavailable — including ones that work today — to prevent a failure that
+costs a reboot back into Windows and no data. The refusal is reserved for the
+case we can actually prove: both sides known, no intersection.
 
 ## 2. Recovery guard: when Windows comes back, wootc explains itself
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -39,7 +39,11 @@ anything needs attention. Under the hood it wants:
 - **At least 35 GB of free space** on `C:` — 20 GB for Linux plus the 15 GB
   the app keeps back so Windows still has room. More is better; you choose the
   size.
-- **Secure Boot** on is fine — wootc uses a Microsoft-trusted boot chain.
+- **Secure Boot** on is fine — wootc stages a boot loader signed by Microsoft,
+  and checks *before* it changes anything that your PC's firmware trusts the
+  certificate it was signed with. If it does not, wootc says so and stops
+  rather than leaving you at a startup error
+  ([#322](https://github.com/tuna-os/wootc/issues/322)).
 - **BitLocker off**, for now. wootc never asks you to decrypt your drive, but
   the encrypted-drive path is not proven green yet, so the alpha stops before
   installing on a BitLocker-protected PC and says so

--- a/packaging/shim-authorities.py
+++ b/packaging/shim-authorities.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""shim-authorities.py — which Microsoft UEFI CA signed this EFI binary?
+
+A machine's firmware trusts a set of certificate authorities (the UEFI `db`
+variable). Microsoft's third-party signing authority exists in two
+generations: "Microsoft Corporation UEFI CA 2011", whose certificate expired
+2026-06-27, and "Microsoft UEFI CA 2023", which signs everything issued now.
+Firmware does not check expiry, so a machine holding the 2011 CA still boots a
+2011-signed shim — but new machines increasingly ship the 2023 CA alone, and
+on those a 2011-only shim dies with "bad shim signature" after the reboot,
+with nothing said beforehand (#322).
+
+So the build has to know what it is staging. This reads the Authenticode
+signatures out of a PE image's security directory and reports which Microsoft
+CA generations signed it. A dual-signed shim carries two WIN_CERTIFICATE
+entries; both are walked.
+
+    shim-authorities.py shimx64.efi            -> 2011,2023
+    shim-authorities.py --json shimx64.efi ... -> {"shimx64.efi": ["2011","2023"]}
+    shim-authorities.py --require 2023 shim…   -> exit 1 unless 2023 signed
+
+No third-party modules: openssl(1) does the PKCS#7 parsing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Issuer common names, mapped to the generation names the installer and the
+# firmware preflight speak. Matched on the issuer, not the leaf: the leaf is
+# a per-publisher certificate ("Microsoft Windows UEFI Driver Publisher"),
+# and it is the CA above it that has to be in the firmware's db.
+CA_PATTERNS = (
+    (re.compile(r"Microsoft Corporation UEFI CA 2011"), "2011"),
+    (re.compile(r"Microsoft (?:Corporation )?UEFI CA 2023"), "2023"),
+)
+
+
+class PEError(RuntimeError):
+    pass
+
+
+def _u16(data: bytes, off: int) -> int:
+    if off < 0 or off + 2 > len(data):
+        raise PEError("PE field runs past the end of the image")
+    return struct.unpack_from("<H", data, off)[0]
+
+
+def _u32(data: bytes, off: int) -> int:
+    if off < 0 or off + 4 > len(data):
+        raise PEError("PE field runs past the end of the image")
+    return struct.unpack_from("<I", data, off)[0]
+
+
+def security_directory(data: bytes) -> tuple[int, int]:
+    """Return (offset, size) of the certificate table, or (0, 0) if unsigned."""
+    if len(data) < 0x40 or data[:2] != b"MZ":
+        raise PEError("not a PE image (no MZ header)")
+    pe = _u32(data, 0x3C)
+    if pe + 24 > len(data) or data[pe : pe + 4] != b"PE\0\0":
+        raise PEError("not a PE image (no PE signature)")
+    opt_size = _u16(data, pe + 20)
+    opt = pe + 24
+    if opt_size == 0 or opt + opt_size > len(data):
+        raise PEError("PE optional header runs past the end of the image")
+    magic = _u16(data, opt)
+    # The data-directory array starts after the optional header's fixed part:
+    # 112 bytes for PE32+ (magic 0x20b), 96 for PE32 (0x10b).
+    if magic == 0x20B:
+        dirs = opt + 112
+    elif magic == 0x10B:
+        dirs = opt + 96
+    else:
+        raise PEError(f"unknown PE optional header magic {magic:#x}")
+    # Index 4 is IMAGE_DIRECTORY_ENTRY_SECURITY; each entry is (RVA, size),
+    # and for this one the "RVA" is really a file offset.
+    entry = dirs + 4 * 8
+    return _u32(data, entry), _u32(data, entry + 4)
+
+
+def pkcs7_blobs(data: bytes) -> list[bytes]:
+    """Every WIN_CERTIFICATE payload in the image, in file order.
+
+    A dual-signed binary appends a second WIN_CERTIFICATE after the first,
+    each 8-byte aligned. Returning both is the whole point here: reporting
+    only the first would call Fedora's dual-signed shim 2011-only.
+    """
+    off, size = security_directory(data)
+    if off == 0 or size == 0:
+        return []
+    if off + size > len(data):
+        raise PEError("certificate table runs past the end of the image")
+    blob = data[off : off + size]
+    out: list[bytes] = []
+    pos = 0
+    while pos + 8 <= len(blob):
+        length = struct.unpack_from("<I", blob, pos)[0]
+        if length < 8 or pos + length > len(blob):
+            break
+        out.append(blob[pos + 8 : pos + length])
+        pos += (length + 7) & ~7
+    return out
+
+
+def issuers(pkcs7: bytes) -> list[str]:
+    with tempfile.NamedTemporaryFile(suffix=".p7", delete=True) as tmp:
+        tmp.write(pkcs7)
+        tmp.flush()
+        proc = subprocess.run(
+            ["openssl", "pkcs7", "-inform", "DER", "-in", tmp.name,
+             "-print_certs", "-noout", "-text"],
+            capture_output=True, text=True, check=False,
+        )
+    if proc.returncode != 0:
+        return []
+    return re.findall(r"Issuer:.*", proc.stdout)
+
+
+def authorities(path: Path) -> list[str]:
+    """Microsoft CA generations that signed this image, sorted."""
+    data = path.read_bytes()
+    found: set[str] = set()
+    for blob in pkcs7_blobs(data):
+        for line in issuers(blob):
+            for pattern, generation in CA_PATTERNS:
+                if pattern.search(line):
+                    found.add(generation)
+    return sorted(found)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("images", nargs="+", type=Path)
+    ap.add_argument("--json", action="store_true",
+                    help="emit {basename: [generations]} instead of a comma list")
+    ap.add_argument("--require", metavar="GEN", action="append", default=[],
+                    help="exit non-zero unless every image carries this generation")
+    args = ap.parse_args(argv)
+
+    result: dict[str, list[str]] = {}
+    for image in args.images:
+        try:
+            result[image.name] = authorities(image)
+        except PEError as exc:
+            print(f"{image}: {exc}", file=sys.stderr)
+            return 2
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        for name, gens in sorted(result.items()):
+            print(f"{name}\t{','.join(gens) if gens else 'none'}")
+
+    rc = 0
+    for want in args.require:
+        for name, gens in sorted(result.items()):
+            if want not in gens:
+                print(f"::error::{name} is not signed by the Microsoft UEFI CA {want} "
+                      f"(found: {','.join(gens) if gens else 'no Microsoft UEFI CA'}). "
+                      f"Machines whose firmware trusts only the {want} authority would "
+                      f"fail with 'bad shim signature' after the reboot (#322).",
+                      file=sys.stderr)
+                rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/e2e/run-e2e.sh
+++ b/tests/e2e/run-e2e.sh
@@ -1363,11 +1363,17 @@ if [ "$SKIP_BUILD" = false ]; then
         # Keep the stopped container until after podman cp. With `--rm`, the
         # previous `podman wait` deleted it before either signed EFI binary
         # could be extracted.
+        # The SAME pinned, dual-signed shim the release stages (#322). A
+        # harness that proves a 2011-only chain while the release ships a
+        # dual-signed one is testing a different product; keep this NVR in
+        # step with .github/workflows/release.yml.
+        _shim_rpm="https://kojipkgs.fedoraproject.org/packages/shim/16.1/7/x86_64/shim-x64-16.1-7.x86_64.rpm"
         CID=$(podman create quay.io/fedora/fedora:44 \
-            bash -c "dnf install -y -q shim-x64 grub2-efi-x64 2>/dev/null && \
-              cp /boot/efi/EFI/fedora/shimx64.efi /tmp/ && \
-              cp /boot/efi/EFI/fedora/grubx64.efi /tmp/ && \
-              cp /boot/efi/EFI/fedora/mmx64.efi /tmp/ && echo DONE")
+            bash -c "dnf install -y -q '$_shim_rpm' grub2-efi-x64 2>/dev/null && \
+              for f in shimx64.efi mmx64.efi; do \
+                cp /usr/lib/efi/shim/*/EFI/fedora/\$f /tmp/ 2>/dev/null || \
+                cp /boot/efi/EFI/fedora/\$f /tmp/; done && \
+              cp /boot/efi/EFI/fedora/grubx64.efi /tmp/ && echo DONE")
         podman start -a "$CID" >/dev/null 2>&1 || true
         podman cp "$CID:/tmp/shimx64.efi" "${SCRIPT_DIR}/wootc-files/shimx64.efi" 2>/dev/null || true
         podman cp "$CID:/tmp/grubx64.efi" "${SCRIPT_DIR}/wootc-files/grubx64.efi" 2>/dev/null || true

--- a/tests/unit/secure-boot-authorities.bats
+++ b/tests/unit/secure-boot-authorities.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# secure-boot-authorities.bats — the shim we stage must be one this firmware
+# can launch (#322).
+#
+# Under Secure Boot the firmware only launches a loader signed by a CA in its
+# `db`. Microsoft's third-party authority has two generations: the 2011 CA
+# (certificate expired 2026-06-27) and the 2023 CA, which signs everything
+# issued now. Firmware ignores expiry, so a 2011-signed shim still boots on a
+# machine that holds the 2011 CA — but new machines increasingly ship the 2023
+# CA alone, and there a 2011-only shim dies at "bad shim signature" AFTER the
+# reboot, with nothing said before it. The release records what it signs, the
+# preflight reads what the firmware trusts, and the refusal happens while
+# Windows is still on screen.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    RELEASE="$REPO_ROOT/.github/workflows/release.yml"
+    E2E="$REPO_ROOT/tests/e2e/run-e2e.sh"
+    SA="$REPO_ROOT/packaging/shim-authorities.py"
+}
+
+@test "the release stages a DUAL-signed shim, pinned by exact NVR" {
+    # Fedora 44's own shim-x64 is 16.1-5, signed only by the 2011 authority.
+    # An unpinned 'dnf install shim-x64' is exactly how a single-signed build
+    # comes back silently.
+    grep -q 'shim-x64-16.1-7' "$RELEASE"
+    grep -q 'kojipkgs.fedoraproject.org/packages/shim' "$RELEASE"
+    run grep -E 'dnf install -y -q shim-x64 ' "$RELEASE"
+    [ "$status" -ne 0 ]
+}
+
+@test "the build refuses to publish a shim that 2023-only firmware cannot launch" {
+    grep -q 'shim-authorities.py --require 2023' "$RELEASE"
+    # The check must run on the binary that is actually published, not on a
+    # copy or a name.
+    grep -q 'release-assets/shimx64.efi' "$RELEASE"
+}
+
+@test "the exe is stamped from the extracted shim, never from a second copy of the pin" {
+    # A hardcoded stamp is how an exe starts describing a binary nobody
+    # ships. It must be derived from shim-authorities.json.
+    grep -q 'X main.shimAuthorities=\$SHIM_AUTHORITIES' "$RELEASE"
+    grep -q "SHIM_AUTHORITIES=\$(python3 -c" "$RELEASE"
+    run grep -E 'SHIM_AUTHORITIES="2011' "$RELEASE"
+    [ "$status" -ne 0 ]
+    # ...which requires the artifacts to be built BEFORE the exes.
+    local artifacts brands
+    artifacts=$(grep -n 'name: Build deployer boot artifacts' "$RELEASE" | cut -d: -f1)
+    brands=$(grep -n 'name: Build brand installers' "$RELEASE" | cut -d: -f1)
+    [ -n "$artifacts" ] && [ -n "$brands" ]
+    [ "$artifacts" -lt "$brands" ]
+}
+
+@test "MokManager is NOT graded against the Microsoft CAs" {
+    # mmx64.efi is signed by Fedora's key and verified by shim, not by the
+    # firmware. Requiring a Microsoft CA on it would fail every build for a
+    # reason that is not real.
+    run grep -E 'shim-authorities.py.*mmx64' "$RELEASE"
+    [ "$status" -ne 0 ]
+}
+
+@test "the harness proves the same shim the release ships" {
+    # A harness on a 2011-only chain while the release ships dual-signed is
+    # testing a different product.
+    grep -q 'shim-x64-16.1-7' "$E2E"
+    run grep -E 'dnf install -y -q shim-x64 ' "$E2E"
+    [ "$status" -ne 0 ]
+}
+
+@test "the extractor walks EVERY signature, not just the first" {
+    # A dual-signed PE appends a second WIN_CERTIFICATE after the first.
+    # Reading only the first would report Fedora's dual-signed shim as
+    # 2011-only and re-introduce the whole bug.
+    grep -q 'def pkcs7_blobs' "$SA"
+    grep -q 'while pos + 8 <= len(blob)' "$SA"
+    grep -q 'pos += (length + 7) & ~7' "$SA"
+    python3 -c "import ast,sys; ast.parse(open('$SA').read())"
+}
+
+@test "the extractor matches on the ISSUER, not the leaf subject" {
+    # The leaf is a per-publisher certificate ('Microsoft Windows UEFI Driver
+    # Publisher'); the CA above it is what has to be in the firmware's db.
+    grep -q 'Issuer:' "$SA"
+    grep -q 'Microsoft Corporation UEFI CA 2011' "$SA"
+    grep -q 'Microsoft (?:Corporation )?UEFI CA 2023' "$SA"
+}
+
+@test "the preflight gates BEFORE anything is written, and only on a known mismatch" {
+    local app="$REPO_ROOT/app/app.go"
+    # In gateScenario, which runs before the first byte of the install.
+    grep -q 'checkSecureBootChain' "$app"
+    grep -q 'TrustedUefiAuthorities' "$app"
+    # An unreadable db must warn, not refuse: "bad shim signature" costs a
+    # reboot back into Windows, and refusing every PC whose SecureBoot module
+    # is unavailable would block machines that work today.
+    grep -q 'SecureBootChainWarning' "$app"
+    grep -q 'Warn:' "$REPO_ROOT/app/secureboot.go"
+    grep -q 'secureBootChainWarning' "$REPO_ROOT/app/frontend/src/screens/launchpad.js"
+}
+
+@test "the db read is Windows-only and the dev stub gates nothing" {
+    grep -q 'func trustedUefiAuthorities' "$REPO_ROOT/app/secureboot_windows.go"
+    grep -q 'func trustedUefiAuthorities() \[\]string { return nil }' "$REPO_ROOT/app/secureboot_other.go"
+    grep -q 'go:build windows' "$REPO_ROOT/app/secureboot_windows.go"
+    grep -q 'go:build !windows' "$REPO_ROOT/app/secureboot_other.go"
+}


### PR DESCRIPTION
Closes the 2011-vs-2023 Microsoft UEFI CA gap found in the Libertix investigation (#308, spec §1).

## The problem, measured

Under Secure Boot the firmware launches only a loader signed by a CA in its `db`. Microsoft's third-party authority has two generations: **2011** (certificate expired 2026-06-27) and **2023** (signs everything issued now). Firmware ignores expiry, so a 2011-signed shim still boots where the 2011 CA is present — but new machines increasingly ship the 2023 CA alone.

Read straight off the binaries:

| binary | Authenticode signers |
|---|---|
| `shimx64.efi` in `v0.1.0-alpha.1` | 2011 only |
| Fedora 44 `shim-x64-16.1-5` | 2011 only |
| rawhide `shim-x64-16.1-7` | **2011 and 2023** |

And wootc had no code that read `db` at all. On 2023-only firmware the user rebooted into `bad shim signature`, the firmware fell back to Windows, and nothing explained it — a failure that lands *after* the commit point.

## What changes

**Build side.** `packaging/shim-authorities.py` reads the Authenticode signatures out of a PE image's security directory. It walks **every** `WIN_CERTIFICATE`, because a dual-signed binary carries two and reading only the first reports Fedora's dual-signed shim as 2011-only. `release.yml` now:

- pins `shim-x64-16.1-7` by exact NVR (an unpinned `dnf install shim-x64` is how a single-signed build comes back silently);
- refuses to publish a shim that is not 2023-signed (`--require 2023`);
- writes `shim-authorities.json` beside `SHA256SUMS`, and stamps the generations into each exe via `-X main.shimAuthorities=…`;
- **builds the boot artifacts before the exes**, so that stamp is derived from the binary actually shipped rather than from a second copy of the pin.

`run-e2e.sh` takes the same pinned shim — a harness proving a 2011-only chain while the release ships dual-signed is testing a different product. `mmx64.efi` is deliberately not graded: shim verifies it, not the firmware.

**Preflight side.** `getSystemInfo` reads `db` through `Get-SecureBootUEFI`, parses the `EFI_SIGNATURE_LIST` chain (with `Get-SecureBootDbCertificates` as fallback), and records the generations. `gateScenario` refuses **before a single byte is written**, naming both sides, saying nothing has been changed, and giving the two ways out.

## One deviation from the merged spec, on purpose

`docs/borrowed-from-libertix.md` §1 said an unreadable `db` should *refuse*. This warns instead, and the doc now says so. Refusing would block every PC whose SecureBoot PowerShell module is unavailable — including ones that work today — to prevent a failure that costs a reboot back into Windows and no data. The refusal is reserved for what we can prove: both sides known, no intersection.

## Tests

- `app/secureboot_test.go` builds a **real** `db` blob from generated X.509 certificates rather than hand-written hex, so a parser bug fails here instead of on someone's PC. Covers non-X509 lists, truncation at six offsets, and a zero-size list that would otherwise spin forever.
- The verdict table pins all eight cases, including that an unstamped build and an unknown `db` gate nothing.
- `tests/unit/secure-boot-authorities.bats` (9 tests) pins the pin, the `--require`, the step ordering, the derived stamp, the harness parity, and the build-tag symmetry.
- Local: 520 bats + Go suite green; `gofmt`/`vet` clean; `GOOS=windows` and Linux both build.

## Still open on #322

The OVMF `db` axis for the harness (2011-only / 2023-only / both cells) is the remaining piece; the issue keeps that checkbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_