### PR TITLE
docs: escape the angle-bracket placeholder in manual-testing.md

### DIFF
--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -50,7 +50,7 @@ deliberately small. Treat it as alpha software anyway.
    opens the "Bring over from Windows" dashboard, and your Windows folders
    are bridged (look for the "Windows drive" bookmark in the file manager).
 4. **The way back**: reboot → Windows starts by default. In Windows, the
-   app's Manage screen offers "Restart into <your distro>" whenever you
+   app's Manage screen offers "Restart into `<your distro>`" whenever you
    want Linux again — and Uninstall puts everything back.
 
 ## If something goes wrong


### PR DESCRIPTION
Fixes #278. Refs tuna-os/tunaos#1986.

`docs/manual-testing.md` contains a bare angle-bracket placeholder that MDX parses as an unclosed JSX element:

```
Error: MDX compilation failed for "docs/manual-testing.md"
  Cause: Expected a closing tag for `<your distro>` before the end of `paragraph`
```

`tuna-os/docs`'s `sync-org-docs` workflow has been failing at that gate since 2026-08-19, which freezes **all 31 synced repositories'** docs at the 08-19 snapshot — not just this repo's.

The fix wraps the placeholder in backticks. The diff is exactly one line:

```diff
-   app's Manage screen offers "Restart into <your distro>" whenever you
+   app's Manage screen offers "Restart into `<your distro>`" whenever you
```

No content change, and it matches how the same file already renders `C:\wootc` and `wootc.exe uninstall`.

Note this unblocks only the wootc half. #278 records a twin in `tunaos-packages` (`TIDEFORGE-ACTION-CACHE.md`) that needs the same treatment before the org sync goes green.