### PR TITLE
fix(dto): regenerate the C# DTOs and the system_info golden — main is red

### DIFF
--- a/app/testdata/dto/system_info.json
+++ b/app/testdata/dto/system_info.json
@@ -26,5 +26,7 @@
   ],
   "bitLockerRecoveryKeyWarning": false,
   "suggestedHostname": "my-laptop",
-  "suggestedUsername": "winuser"
+  "suggestedUsername": "winuser",
+  "trustedUefiAuthorities": null,
+  "secureBootChainWarning": ""
 }

--- a/shell/Wootc.Shell/Engine/Dto.cs
+++ b/shell/Wootc.Shell/Engine/Dto.cs
@@ -178,6 +178,24 @@ public class SystemInfo
     /// </summary>
     [JsonPropertyName("suggestedUsername")]
     public string SuggestedUsername { get; set; } = string.Empty;
+
+    /// <summary>
+    /// TrustedUefiAuthorities lists the Microsoft UEFI CA generations this
+    /// machine's firmware holds in its db variable ("2011", "2023"), so the
+    /// preflight can tell before the reboot whether the signed shim this
+    /// build stages will be launched at all (#322). Empty means the db could
+    /// not be read, which warns rather than refusing.
+    /// </summary>
+    [JsonPropertyName("trustedUefiAuthorities")]
+    public List<string> TrustedUefiAuthorities { get; set; } = new();
+
+    /// <summary>
+    /// SecureBootChainWarning is set when Secure Boot is on but the db could
+    /// not be read: honest disclosure that one check could not be made,
+    /// shown before the user commits rather than after the restart.
+    /// </summary>
+    [JsonPropertyName("secureBootChainWarning")]
+    public string SecureBootChainWarning { get; set; } = string.Empty;
 }
 
 /// <summary>


### PR DESCRIPTION
**`main` is currently red.** `TestGeneratedCSharpDTOsNotStale` and `TestDTOGoldens/system_info` both fail on `5e96295`. Confirmed by running them against `origin/main` directly, not inferred from this PR.

## Cause

Two PRs landed in parallel and neither one's CI could see the other:

- **#349** added `TrustedUefiAuthorities` and `SecureBootChainWarning` to `SystemInfo` for the Secure Boot preflight (#322).
- **#348** landed the DTO goldens and the C# generator for the WinUI shell (#342).

Each was green on its own head. Together, the committed `Dto.cs` and `system_info.json` describe a `SystemInfo` that no longer exists.

## The fix

Exactly what the failing tests instruct, and nothing else:

```
cd app && go generate ./...
go test -run TestDTOGoldens -update
```

The diff is the two fields, in both files. 21 lines added, 1 changed.

## Note for next time

A stale-generated-file check compares a committed artifact against code in *another* file, so it cannot be kept green by any single PR's CI. It goes red whenever two PRs touch both sides inside the same window. That is a property of the check, not a mistake by either author. Worth considering whether the generator should run in CI and commit, or whether the check should be advisory on PRs and blocking only on `main`.

## Verification

Both failing tests pass. Full local gate green on this head: 542 bats, 4 Python suites, the Go suite, Windows and Linux builds.

## Scope change

This PR previously carried a five-commit stack. Main has since moved eight commits ahead and independently landed #342 (via #348), #330 (via #339) and #332, so two of those commits were duplicates. The PR is now just the red-main fix, so it can land immediately. My remaining unique work (#335 artifact pinning, #333 ESP chain refresh, #334 step catalogue) follows separately, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki