### PR TITLE
Pin boot artifacts, keep the ESP's signed chain fresh, and show every install step (#335, #333, #334)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,12 +234,20 @@ jobs:
           # Read from the shim that was actually extracted a step earlier —
           # never a second copy of the pin, which is how a stamp starts
           # describing a binary nobody is shipping.
+          # Pin the exe to the release it is cut from (#335). The installer
+          # and its boot artifacts ship together and are gated by one E2E
+          # run; an exe that fetches from `latest` would run a deployer it
+          # was never tested with, and SHA256SUMS cannot catch that — the
+          # manifest comes from the same moved release.
+          RELEASE_TAG="${{ steps.chan.outputs.tag }}"
+          [ -n "$RELEASE_TAG" ] || { echo "::error::no release tag to pin the boot artifacts to"; exit 1; }
+          echo "pinning boot artifacts to $RELEASE_TAG"
           SHIM_AUTHORITIES=$(python3 -c "import json;print(','.join(json.load(open('release-assets/shim-authorities.json'))['shimx64.efi']))")
           [ -n "$SHIM_AUTHORITIES" ] || { echo "::error::the staged shim carries no Microsoft UEFI CA"; exit 1; }
           echo "staging a shim signed by the Microsoft UEFI CA(s): $SHIM_AUTHORITIES"
           while IFS=$'\t' read -r brand exe; do
             (cd app && GOOS=windows GOARCH=amd64 go build -tags desktop,production \
-              -ldflags "-w -s -X main.brandID=$brand -X main.shimAuthorities=$SHIM_AUTHORITIES" \
+              -ldflags "-w -s -X main.brandID=$brand -X main.shimAuthorities=$SHIM_AUTHORITIES -X main.releaseTag=$RELEASE_TAG" \
               -o "../release-assets/$exe.exe" .)
             echo "built $exe.exe (brand: $brand)"
           done <<< "$brands"

--- a/app/branding_embed.go
+++ b/app/branding_embed.go
@@ -58,3 +58,12 @@ func embeddedBranding() (Branding, bool) {
 	}
 	return b, true
 }
+
+// releaseTag is the release this binary was cut from, set at build time with
+// -ldflags "-X main.releaseTag=v0.2.0". It pins where the boot artifacts are
+// fetched from (#335): the exe and the deployer kernel/initramfs/shim ship
+// together and are gated together by one E2E run, so an installer must never
+// pull a boot chain from a release it was not tested with. Empty in a local
+// build, which falls back to `latest` — the only thing an unstamped build
+// can do.
+var releaseTag = ""

--- a/app/deployer_url.go
+++ b/app/deployer_url.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// ── Where the boot artifacts come from ────────────────────────────────────
+// Cross-platform on purpose: the rule is pure string logic, and the CI test
+// tier runs on Linux. A Windows-only helper here would be a rule nothing
+// checks until a release goes out.
+
+const releasesBaseURL = "https://github.com/tuna-os/wootc/releases/"
+
+// deployerBaseURL returns where boot artifacts + SHA256SUMS are fetched from.
+//
+// PINNED to the release this exe was cut from (#335), not `latest`. The two
+// halves ship together and are tested together: an exe from
+// v0.1.0-alpha.1 pulling whatever `latest` points at today runs a deployer
+// kernel, initramfs and signed shim it has never been run with, and the
+// SHA256SUMS check cannot catch that — the manifest is fetched from the same
+// moved release, so mismatched-but-consistent artifacts verify perfectly.
+// Version skew between the installer and its boot chain is now impossible.
+//
+// An unstamped build (a local `go build`) has no release to pin to and falls
+// back to `latest`, which is the only thing a developer build can do.
+//
+// WOOTC_DEPLOYER_MIRROR still overrides everything for local/offline testing
+// and for the E2E harness, which builds its own artifacts. The fail-closed
+// SHA256SUMS verification in downloadDeployer applies unchanged against
+// whatever URL is used, so none of this weakens verification — only where it
+// points.
+func deployerBaseURL() string {
+	if v := strings.TrimSpace(os.Getenv("WOOTC_DEPLOYER_MIRROR")); v != "" {
+		if !strings.HasSuffix(v, "/") {
+			v += "/"
+		}
+		return v
+	}
+	if tag := strings.TrimSpace(releaseTag); tag != "" {
+		return releasesBaseURL + "download/" + tag + "/"
+	}
+	return releasesBaseURL + "latest/download/"
+}

--- a/app/deployer_url_test.go
+++ b/app/deployer_url_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The installer and its boot artifacts (deployer kernel, initramfs, signed
+// shim) are cut by one release job and gated by one E2E run. An exe that
+// fetches from `latest` runs whatever is newest today — a deployer it was
+// never tested with — and SHA256SUMS cannot catch it, because the manifest
+// comes from the same moved release: mismatched-but-consistent artifacts
+// verify perfectly (#335).
+
+func TestDeployerBaseURLPinsTheReleaseItWasCutFrom(t *testing.T) {
+	oldTag, oldMirror := releaseTag, os.Getenv("WOOTC_DEPLOYER_MIRROR")
+	t.Cleanup(func() {
+		releaseTag = oldTag
+		_ = os.Setenv("WOOTC_DEPLOYER_MIRROR", oldMirror)
+	})
+	_ = os.Unsetenv("WOOTC_DEPLOYER_MIRROR")
+
+	releaseTag = "v0.2.0-alpha.3"
+	got := deployerBaseURL()
+	want := "https://github.com/tuna-os/wootc/releases/download/v0.2.0-alpha.3/"
+	if got != want {
+		t.Fatalf("deployerBaseURL() = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "/latest/") {
+		t.Fatal("a stamped build must never fetch from latest")
+	}
+}
+
+func TestDeployerBaseURLFallsBackForAnUnstampedBuild(t *testing.T) {
+	// A developer's `go build` has no release to pin to. Refusing to run
+	// would make the tree unusable locally; `latest` is the only honest
+	// answer available to it.
+	oldTag, oldMirror := releaseTag, os.Getenv("WOOTC_DEPLOYER_MIRROR")
+	t.Cleanup(func() {
+		releaseTag = oldTag
+		_ = os.Setenv("WOOTC_DEPLOYER_MIRROR", oldMirror)
+	})
+	_ = os.Unsetenv("WOOTC_DEPLOYER_MIRROR")
+
+	releaseTag = ""
+	if got := deployerBaseURL(); got != "https://github.com/tuna-os/wootc/releases/latest/download/" {
+		t.Fatalf("unstamped build = %q, want the latest fallback", got)
+	}
+}
+
+func TestDeployerMirrorStillWinsOverThePin(t *testing.T) {
+	// The E2E harness and the offline bundle build their own artifacts and
+	// serve them locally; the pin must not take that away.
+	oldTag, oldMirror := releaseTag, os.Getenv("WOOTC_DEPLOYER_MIRROR")
+	t.Cleanup(func() {
+		releaseTag = oldTag
+		_ = os.Setenv("WOOTC_DEPLOYER_MIRROR", oldMirror)
+	})
+
+	releaseTag = "v9.9.9"
+	for in, want := range map[string]string{
+		"http://192.0.2.10:8000/pool":  "http://192.0.2.10:8000/pool/",
+		"http://192.0.2.10:8000/pool/": "http://192.0.2.10:8000/pool/",
+	} {
+		_ = os.Setenv("WOOTC_DEPLOYER_MIRROR", in)
+		if got := deployerBaseURL(); got != want {
+			t.Errorf("mirror %q = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/app/deployer_windows.go
+++ b/app/deployer_windows.go
@@ -15,23 +15,6 @@ import (
 
 // ── Deployer download ─────────────────────────────────────────────────────────
 
-const defaultDeployerBaseURL = "https://github.com/tuna-os/wootc/releases/latest/download/"
-
-// deployerBaseURL returns where boot artifacts + SHA256SUMS are fetched
-// from. WOOTC_DEPLOYER_MIRROR overrides it for local/offline testing (e.g. a
-// dev VM with no network route to GitHub) — the SHA256SUMS fail-closed check
-// in downloadDeployer still applies unchanged against whatever URL is used,
-// so this does not weaken verification, only where it points.
-func deployerBaseURL() string {
-	if v := strings.TrimSpace(os.Getenv("WOOTC_DEPLOYER_MIRROR")); v != "" {
-		if !strings.HasSuffix(v, "/") {
-			v += "/"
-		}
-		return v
-	}
-	return defaultDeployerBaseURL
-}
-
 func downloadDeployer(ctx context.Context, progress func(float64)) error {
 	installDir := filepath.Join(wootcDir(), "install")
 	// The signed shim+grub pair carries the Secure Boot chain; mmx64.efi

--- a/app/frontend/src/screens/progress.js
+++ b/app/frontend/src/screens/progress.js
@@ -9,6 +9,11 @@ import { el, btn } from '../lib/ui.js';
 // The canonical ordered step list. The Go backend emits these exact strings on
 // install:progress, so main.js's event wiring imports it to mark earlier steps
 // complete, and the step list below renders it.
+// The step list the user watches. It must be EXACTLY the pipeline's step
+// names from app.go, in order: a step whose name does not match never lights
+// up, and stays grey for the whole install — which reads as a step that did
+// not happen. payload/steps.tsv is the catalogue and app/steps_test.go fails
+// when these drift (#334).
 export const INSTALL_STEPS = [
   'Checking your PC',
   'Preparing Windows',
@@ -21,7 +26,11 @@ export const INSTALL_STEPS = [
   'Getting Linux prepared',
   'Making Linux bootable on your machine',
   'Saving your settings',
-  'Collecting your look',
+  'Saving your BitLocker recovery key',
+  'Looking at your installed apps',
+  'Checking your signed-in apps',
+  'Looking for your cloud drives',
+  'Collecting your look and Wi-Fi',
   'Finishing up',
 ];
 

--- a/app/steps_test.go
+++ b/app/steps_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// ── One catalogue of phase names (#334) ────────────────────────────────────
+//
+// The words a user watches during an install live in four places: the Phase-1
+// pipeline here, the step list the progress screen renders, the deployer's
+// splash table, and the markers the E2E harness greps for. Nothing held them
+// together and they had already drifted — five pipeline steps were missing
+// from the screen's list, and one entry on the screen was never emitted, so
+// it stayed grey for the entire install. To a nervous user a grey step reads
+// as one that did not happen.
+//
+// payload/steps.tsv is the catalogue. These tests are what make it binding.
+
+var pipelineStepRe = regexp.MustCompile(`(?m)^\s+\{"([^"]+)", \d+,`)
+
+func pipelineSteps(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile("app.go")
+	if err != nil {
+		t.Fatalf("read app.go: %v", err)
+	}
+	var out []string
+	for _, m := range pipelineStepRe.FindAllStringSubmatch(string(data), -1) {
+		out = append(out, m[1])
+	}
+	if len(out) < 10 {
+		t.Fatalf("found only %d pipeline steps; the matcher or the pipeline changed", len(out))
+	}
+	return out
+}
+
+func frontendSteps(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile("frontend/src/screens/progress.js")
+	if err != nil {
+		t.Fatalf("read progress.js: %v", err)
+	}
+	block := regexp.MustCompile(`(?s)INSTALL_STEPS = \[(.*?)\n\];`).FindStringSubmatch(string(data))
+	if block == nil {
+		t.Fatal("INSTALL_STEPS not found in progress.js")
+	}
+	var out []string
+	for _, m := range regexp.MustCompile(`(?m)^\s+'(.*)',`).FindAllStringSubmatch(block[1], -1) {
+		out = append(out, strings.ReplaceAll(m[1], `\'`, `'`))
+	}
+	return out
+}
+
+func catalogue(t *testing.T) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile("../payload/steps.tsv")
+	if err != nil {
+		t.Fatalf("read steps.tsv: %v", err)
+	}
+	out := map[string]string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		f := strings.Split(line, "\t")
+		if len(f) >= 2 {
+			out[f[0]] = f[1]
+		}
+	}
+	return out
+}
+
+func TestProgressScreenListsExactlyWhatThePipelineEmits(t *testing.T) {
+	pipeline, frontend := pipelineSteps(t), frontendSteps(t)
+
+	inFrontend := map[string]bool{}
+	for _, s := range frontend {
+		inFrontend[s] = true
+	}
+	for _, s := range pipeline {
+		if !inFrontend[s] {
+			t.Errorf("the pipeline emits %q but the progress screen never lists it — "+
+				"the user never sees that step happen", s)
+		}
+	}
+	inPipeline := map[string]bool{}
+	for _, s := range pipeline {
+		inPipeline[s] = true
+	}
+	for _, s := range frontend {
+		if !inPipeline[s] {
+			t.Errorf("the progress screen lists %q but nothing ever emits it — "+
+				"it stays grey for the whole install, which reads as a step that failed", s)
+		}
+	}
+	// Order matters too: the list is rendered top to bottom as a sequence.
+	if len(pipeline) == len(frontend) {
+		for i := range pipeline {
+			if pipeline[i] != frontend[i] {
+				t.Errorf("step %d differs: pipeline %q, screen %q", i, pipeline[i], frontend[i])
+				break
+			}
+		}
+	}
+}
+
+func TestEveryPipelineStepIsInTheCatalogue(t *testing.T) {
+	cat := catalogue(t)
+	for _, s := range pipelineSteps(t) {
+		owner, ok := cat[s]
+		if !ok {
+			t.Errorf("pipeline step %q is not in payload/steps.tsv", s)
+			continue
+		}
+		if owner != "installer" {
+			t.Errorf("pipeline step %q is catalogued as %q, want installer", s, owner)
+		}
+	}
+}

--- a/docs/architecture-boundary.md
+++ b/docs/architecture-boundary.md
@@ -26,7 +26,10 @@ that turns an attached empty block device into a bootable Linux root.
 - Post-install verification: ostree deploy-root discovery
   (`/ostree/deploy/*/deploy/*`), BLS entry patching under
   `boot/loader/entries/`, initramfs regeneration via ostree paths.
-- Target-signed shim/grub sourcing from `usr/lib/bootupd/updates/`.
+- Target-signed shim/grub sourcing from `usr/lib/bootupd/updates/` — at
+  install time, and again on every boot: `wootc-esp-sync` copies the
+  deployment's current signed chain forward onto the Windows ESP so an
+  SBAT revocation cannot strand a machine that booted yesterday (#333).
 - ESP kernel-sync globs (`boot/ostree/*/vmlinuz*`).
 
 ## The provisioner contract (adaptation seam)

--- a/docs/borrowed-from-libertix.md
+++ b/docs/borrowed-from-libertix.md
@@ -339,10 +339,17 @@ and every catalogue deployer id has a splash line; a Go test asserts the same
 for the pipeline; CI fails when a generated file is stale.
 
 ### Tasks
-- [ ] `payload/steps.tsv` + generator (`just steps`) + stale-check in CI
-- [ ] `app.go` pipeline and `progress.js` consume the generated labels
-- [ ] `deploy.sh` splash table generated; harness marker list generated
-- [ ] bats + Go parity tests
+- [x] `payload/steps.tsv` — the catalogue, with an owner and the on-screen
+      words for every id
+- [x] bats + Go parity tests. These found the drift the section predicted:
+      **five** pipeline steps were missing from the progress screen's list,
+      and one entry on the screen was never emitted, so it stayed grey for the
+      whole install — which reads as a step that did not happen. Fixed here.
+- [ ] generation (`just steps` writing the splash table and the frontend list)
+      — **deferred on purpose.** The value of this section is that drift
+      cannot survive CI, and the parity tests deliver that. Generating a
+      `case` table into `deploy.sh` is a mechanical rewrite of the file that
+      decides whether a user's machine boots, for no additional safety.
 
 ## 6. Signed catalogue and exe freshness
 

--- a/docs/borrowed-from-libertix.md
+++ b/docs/borrowed-from-libertix.md
@@ -288,11 +288,19 @@ Extend `wootc-esp-sync`:
    is picked up before the next reboot rather than one late.
 
 ### Tasks
-- [ ] deployer mirrors the ESP manifest to `/etc/wootc/esp-manifest`
-- [ ] `wootc-esp-sync`: signed-chain source discovery + SBAT/CA gate + archive-then-atomic replace, shim last
-- [ ] `.path` trigger unit; ordering pins in bats
-- [ ] harness: after Phase 2, plant a newer shim in the bootupd path, reboot, assert the ESP trio changed and the archive exists and the system still boots
-- [ ] `docs/architecture-boundary.md` line about bootupd sourcing becomes true
+- [x] ownership without a new manifest: refresh only a vendor directory whose
+      `grub.cfg` carries the `# wootc` marker — the same rule the installer's
+      D1 guard already applies, re-checked on every boot because a second OS
+      can be installed after us
+- [x] `wootc-esp-sync`: signed-chain source discovery + SBAT/CA gate +
+      archive-then-atomic replace, shim last (`wootc-shim-trust` grades the
+      candidate against the firmware's own `db` and the installed SBAT
+      generation)
+- [x] `.path` trigger unit on bootupd's `EFI.json`; contract pins in bats and
+      behavioural coverage in `tests/unit/test_esp_chain_refresh.py`
+- [ ] harness: after Phase 2, plant a newer shim in the bootupd path, reboot,
+      assert the ESP trio changed, the archive exists, and the system still boots
+- [x] `docs/architecture-boundary.md` line about bootupd sourcing becomes true
 
 ## 5. One step catalogue, restated everywhere, diffed in CI
 

--- a/docs/borrowed-from-libertix.md
+++ b/docs/borrowed-from-libertix.md
@@ -377,7 +377,8 @@ mode and it shows a permanent warning.
    today it is part of the signed exe.
 
 ### Tasks
-- [ ] embed the release tag; pin `deployerBaseURL`; harness override unchanged
+- [x] embed the release tag; pin `deployerBaseURL`; harness override unchanged
+      (`app/deployer_url.go`, `-X main.releaseTag=` in `release.yml`)
 - [ ] minisign the manifest in `release.yml`; verify in `fetchChecksums`; test key for the harness and the offline bundle
 - [ ] launchpad freshness notice
 - [ ] `docs/RELEASING.md`: key custody and rotation

--- a/payload/deployer/deploy.sh
+++ b/payload/deployer/deploy.sh
@@ -2816,6 +2816,18 @@ QGAEOF
         "$DEPLOY_ROOT/var/usrlocal/bin/wootc-esp-sync"
     install -m644 /usr/lib/wootc/migration/wootc-esp-sync.service \
         "$DEPLOY_ROOT/etc/systemd/system/wootc-esp-sync.service"
+    # Signed-chain refresh (#333): grades a candidate shim against the
+    # firmware's trust store and the installed SBAT generation before it is
+    # allowed onto the ESP. Without this helper wootc-esp-sync leaves the
+    # signed chain alone, which is the pre-#333 behaviour.
+    mig_opt 755 wootc-shim-trust "$DEPLOY_ROOT/var/usrlocal/bin/wootc-shim-trust"
+    if [[ -f /usr/lib/wootc/migration/wootc-esp-sync.path ]]; then
+        install -m644 /usr/lib/wootc/migration/wootc-esp-sync.path \
+            "$DEPLOY_ROOT/etc/systemd/system/wootc-esp-sync.path"
+        mkdir -p "$DEPLOY_ROOT/etc/systemd/system/paths.target.wants"
+        ln -sf ../wootc-esp-sync.path \
+            "$DEPLOY_ROOT/etc/systemd/system/paths.target.wants/wootc-esp-sync.path"
+    fi
     mkdir -p "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants"
     ln -sf ../wootc-esp-sync.service \
         "$DEPLOY_ROOT/etc/systemd/system/multi-user.target.wants/wootc-esp-sync.service"

--- a/payload/deployer/module-setup.sh
+++ b/payload/deployer/module-setup.sh
@@ -129,6 +129,8 @@ install() {
     inst /usr/lib/wootc/migration/org.tunaos.wootc.policy
     inst /usr/lib/wootc/migration/wootc-esp-sync
     inst /usr/lib/wootc/migration/wootc-esp-sync.service
+    inst /usr/lib/wootc/migration/wootc-esp-sync.path
+    inst /usr/lib/wootc/migration/wootc-shim-trust
     inst /usr/lib/wootc/migration/wootc-apply-look
     inst /usr/lib/wootc/migration/wootc-apply-look.desktop
     inst /usr/lib/wootc/migration/wootc-detect-apps

--- a/payload/migration/wootc-esp-sync
+++ b/payload/migration/wootc-esp-sync
@@ -15,8 +15,22 @@
 # (ostree/Fedora/EL), falls back to newest /boot/vmlinuz-* (classic
 # Debian/Arch layouts).
 #
+# The SIGNED CHAIN goes stale the same way, and worse (#333). shim, GRUB and
+# MokManager are staged once by the Windows installer and then never touched,
+# while Microsoft ships SBAT revocations through Windows Update: when a
+# generation is revoked, the firmware stops launching a shim below it, and a
+# machine that booted Linux yesterday stops today with no change the user
+# made. CVE fixes in shim and GRUB never arrive either. The deployment
+# already carries a current signed chain (bootupd's payload), so this copies
+# it forward — but only after wootc-shim-trust has graded the candidate
+# against the firmware's own trust store and the installed SBAT generation,
+# because a shim the firmware will not accept is worse than a stale one: the
+# stale one still boots.
+#
 # Test hooks: WOOTC_ESP_DIR overrides mounting (points at a fake ESP);
-# WOOTC_BOOT_DIR overrides /boot; WOOTC_CMDLINE overrides /proc/cmdline.
+# WOOTC_BOOT_DIR overrides /boot; WOOTC_CMDLINE overrides /proc/cmdline;
+# WOOTC_CHAIN_SOURCE overrides where the replacement signed chain is read
+# from (normally bootupd's staged payload).
 
 set -Eeuo pipefail
 
@@ -158,6 +172,85 @@ if [[ ! -f "$GRUB_CFG" ]] || [[ "$(cat "$GRUB_CFG")" != "$WANT_CFG" ]]; then
     log "updated $(basename "$(dirname "$GRUB_CFG")")/grub.cfg"
 fi
 fi
+
+# ── Signed chain: shim / GRUB / MokManager (#333) ───────────────────────────
+# Only in a vendor directory wootc itself owns. The marker is the same one the
+# Windows installer's D1 guard uses to refuse clobbering another Linux: if the
+# grub.cfg here is not ours, neither are the binaries beside it.
+sync_signed_chain() {
+    command -v wootc-shim-trust >/dev/null 2>&1 || {
+        log "wootc-shim-trust not installed — leaving the signed chain alone"; return 0; }
+
+    local vendor_dir="" d
+    for d in "$ESP_MNT"/EFI/*/; do
+        [[ -f "$d/grub.cfg" ]] || continue
+        grep -q '# wootc' "$d/grub.cfg" 2>/dev/null || continue
+        [[ -f "$d/shimx64.efi" ]] || continue
+        vendor_dir="${d%/}"
+        break
+    done
+    [[ -n "$vendor_dir" ]] || { log "no wootc-owned vendor directory on the ESP; signed chain untouched"; return 0; }
+
+    # Source: bootupd's staged payload first (what `bootc upgrade` refreshes),
+    # then the deployment's own ESP tree for classic layouts.
+    local src="" cand
+    if [[ -n "${WOOTC_CHAIN_SOURCE:-}" ]]; then
+        [[ -f "$WOOTC_CHAIN_SOURCE/shimx64.efi" ]] || {
+            log "WOOTC_CHAIN_SOURCE has no shimx64.efi; signed chain untouched"; return 0; }
+        src="${WOOTC_CHAIN_SOURCE%/}"
+    fi
+    for cand in /usr/lib/bootupd/updates/EFI/*/ /boot/efi/EFI/*/; do
+        [[ -n "$src" ]] && break
+        [[ -f "${cand}shimx64.efi" ]] || continue
+        src="${cand%/}"
+        break
+    done
+    [[ -n "$src" ]] || { log "no signed chain in the deployment to copy forward"; return 0; }
+
+    local archive="$ESP_MNT/EFI/wootc/archive"
+    local f stamp
+    stamp=$(sha256sum "$src/shimx64.efi" 2>/dev/null | cut -c1-16)
+    [[ -n "$stamp" ]] || return 0
+
+    # GRUB and MokManager first, shim LAST. A power cut between them then
+    # leaves a shim that still chains a GRUB it can verify; the other order
+    # leaves a new shim above an old GRUB, which is the combination that does
+    # not boot.
+    local replaced=0
+    for f in grubx64.efi mmx64.efi shimx64.efi; do
+        [[ -f "$src/$f" ]] || continue
+        [[ -f "$vendor_dir/$f" ]] || continue
+        cmp -s "$src/$f" "$vendor_dir/$f" && continue
+        # Grade the candidate. Only shim carries SBAT and a firmware-visible
+        # signature; the others ride behind it, but an unsigned GRUB would be
+        # rejected by shim just as surely, so all three are checked.
+        if ! wootc-shim-trust check "$src/$f" "$vendor_dir/$f" >/dev/null; then
+            log "keeping the installed $f (candidate refused — see above)"
+            continue
+        fi
+        mkdir -p "$archive/$stamp"
+        cp -f "$vendor_dir/$f" "$archive/$stamp/$f" 2>/dev/null || {
+            log "could not archive the current $f — refusing to replace what we cannot put back"
+            continue
+        }
+        cp -f "$src/$f" "$vendor_dir/$f.new" && sync && mv -f "$vendor_dir/$f.new" "$vendor_dir/$f" || {
+            log "failed to install $f; restoring from the archive"
+            cp -f "$archive/$stamp/$f" "$vendor_dir/$f" 2>/dev/null || true
+            rm -f "$vendor_dir/$f.new" 2>/dev/null || true
+            continue
+        }
+        if ! cmp -s "$src/$f" "$vendor_dir/$f"; then
+            log "post-write check failed for $f; restoring from the archive"
+            cp -f "$archive/$stamp/$f" "$vendor_dir/$f" 2>/dev/null || true
+            continue
+        fi
+        log "refreshed $(basename "$vendor_dir")/$f from the deployment"
+        replaced=$((replaced + 1))
+    done
+    [[ "$replaced" -gt 0 ]] && changed=1
+    return 0
+}
+sync_signed_chain
 
 if [[ "$changed" -eq 1 ]]; then
     sync

--- a/payload/migration/wootc-esp-sync.path
+++ b/payload/migration/wootc-esp-sync.path
@@ -1,0 +1,14 @@
+[Unit]
+Description=Refresh the Windows ESP when a bootc upgrade stages a new boot chain
+# bootupd rewrites its staged payload when `bootc upgrade` lands. Watching it
+# means an updated shim reaches the ESP on the boot that staged it, rather
+# than one boot later — which matters when the reason for the update is an
+# SBAT revocation that is about to stop the current shim booting (#333).
+ConditionPathExists=/etc/wootc/host-esp.conf
+
+[Path]
+PathChanged=/usr/lib/bootupd/updates/EFI.json
+Unit=wootc-esp-sync.service
+
+[Install]
+WantedBy=paths.target

--- a/payload/migration/wootc-shim-trust
+++ b/payload/migration/wootc-shim-trust
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# /usr/local/bin/wootc-shim-trust
+#
+# Decide whether a candidate EFI binary may replace the one currently on the
+# Windows ESP (#333).
+#
+# wootc's Phase-2 boot chain lives on the Windows ESP: firmware → shim →
+# GRUB → the kernel pair. Those shim/GRUB copies are staged once, by the
+# Windows installer, and then never touched again — while the deployment they
+# boot keeps updating. Two things go wrong with that over time:
+#
+#   1. SBAT revocation. Microsoft ships SBAT updates through Windows Update.
+#      When a generation is revoked, a shim below it stops being launched —
+#      a machine that worked yesterday stops booting Linux today, with no
+#      change the user made.
+#   2. CVE fixes in shim and GRUB never reach the ESP at all.
+#
+# The deployment already carries a current, signed chain (bootupd's payload
+# under /usr/lib/bootupd/updates), so the fix is to copy it forward. But
+# copying blindly is its own hazard: a shim the firmware will not accept is
+# worse than a stale one, because the stale one still boots. So every
+# candidate is graded first.
+#
+#   wootc-shim-trust authorities <file.efi>  Microsoft UEFI CA generations that signed it
+#   wootc-shim-trust db                      generations this firmware trusts
+#   wootc-shim-trust sbat <file.efi>         the shim SBAT generation number
+#   wootc-shim-trust check <cand> <current>  exit 0 if <cand> is safe to install
+#
+# `check` is the one the sync script calls. It answers no — loudly, on
+# stderr, with the reason — far more readily than yes.
+
+from __future__ import annotations
+
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+EFIVARS = Path("/sys/firmware/efi/efivars")
+IMAGE_SECURITY_DATABASE_GUID = "d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+EFI_CERT_X509_GUID = uuid.UUID("a5c059a1-94e4-4aa7-87b5-ab155c2bf072")
+
+CA_PATTERNS = (
+    (re.compile(r"Microsoft Corporation UEFI CA 2011"), "2011"),
+    (re.compile(r"Microsoft (?:Corporation )?UEFI CA 2023"), "2023"),
+)
+
+
+def warn(msg: str) -> None:
+    print(f"[wootc-shim-trust] {msg}", file=sys.stderr, flush=True)
+
+
+# ── PE parsing ──────────────────────────────────────────────────────────────
+
+def _u16(d: bytes, o: int) -> int:
+    return struct.unpack_from("<H", d, o)[0] if 0 <= o and o + 2 <= len(d) else 0
+
+
+def _u32(d: bytes, o: int) -> int:
+    return struct.unpack_from("<I", d, o)[0] if 0 <= o and o + 4 <= len(d) else 0
+
+
+def _optional_header(data: bytes) -> tuple[int, int, int]:
+    """(optional header offset, data-directory offset, section table offset)."""
+    if len(data) < 0x40 or data[:2] != b"MZ":
+        raise ValueError("not a PE image")
+    pe = _u32(data, 0x3C)
+    if pe + 24 > len(data) or data[pe : pe + 4] != b"PE\0\0":
+        raise ValueError("not a PE image")
+    opt_size = _u16(data, pe + 20)
+    opt = pe + 24
+    magic = _u16(data, opt)
+    dirs = opt + (112 if magic == 0x20B else 96)
+    return opt, dirs, opt + opt_size
+
+
+def pkcs7_blobs(data: bytes) -> list[bytes]:
+    """Every WIN_CERTIFICATE payload. A dual-signed binary carries two, and
+    reading only the first reports a dual-signed shim as single-signed."""
+    _, dirs, _ = _optional_header(data)
+    off, size = _u32(data, dirs + 32), _u32(data, dirs + 36)
+    if not off or not size or off + size > len(data):
+        return []
+    blob, out, pos = data[off : off + size], [], 0
+    while pos + 8 <= len(blob):
+        length = struct.unpack_from("<I", blob, pos)[0]
+        if length < 8 or pos + length > len(blob):
+            break
+        out.append(blob[pos + 8 : pos + length])
+        pos += (length + 7) & ~7
+    return out
+
+
+def authorities(path: Path) -> list[str]:
+    data = path.read_bytes()
+    found: set[str] = set()
+    for blob in pkcs7_blobs(data):
+        with tempfile.NamedTemporaryFile(suffix=".p7") as tmp:
+            tmp.write(blob)
+            tmp.flush()
+            proc = subprocess.run(
+                ["openssl", "pkcs7", "-inform", "DER", "-in", tmp.name,
+                 "-print_certs", "-noout", "-text"],
+                capture_output=True, text=True, check=False)
+        if proc.returncode != 0:
+            continue
+        for line in re.findall(r"Issuer:.*", proc.stdout):
+            for pattern, gen in CA_PATTERNS:
+                if pattern.search(line):
+                    found.add(gen)
+    return sorted(found)
+
+
+def sbat_generation(path: Path) -> int | None:
+    """The shim component's SBAT generation, from the .sbat section.
+
+    Format is CSV: `component,generation,vendor,...`. The shim's own line is
+    what firmware revocation targets, so that is the number compared.
+    """
+    data = path.read_bytes()
+    try:
+        _, _, sections = _optional_header(data)
+        pe = _u32(data, 0x3C)
+        count = _u16(data, pe + 6)
+    except ValueError:
+        return None
+    for i in range(count):
+        ent = sections + i * 40
+        name = data[ent : ent + 8].rstrip(b"\x00").decode("ascii", "replace")
+        if name != ".sbat":
+            continue
+        size, off = _u32(data, ent + 16), _u32(data, ent + 20)
+        body = data[off : off + size].split(b"\x00")[0].decode("ascii", "replace")
+        for line in body.splitlines():
+            parts = line.split(",")
+            if len(parts) >= 2 and parts[0] == "shim":
+                try:
+                    return int(parts[1])
+                except ValueError:
+                    return None
+    return None
+
+
+# ── The firmware's own opinion ──────────────────────────────────────────────
+
+def firmware_db() -> list[str]:
+    """Microsoft UEFI CA generations in the firmware's db variable.
+
+    Empty means "could not tell" — no efivarfs, a BIOS boot, or a db we could
+    not parse — never "trusts nothing".
+    """
+    try:
+        raw = (EFIVARS / f"db-{IMAGE_SECURITY_DATABASE_GUID}").read_bytes()[4:]
+    except OSError:
+        return []
+    found: set[str] = set()
+    off = 0
+    while off + 28 <= len(raw):
+        sig_type = uuid.UUID(bytes_le=raw[off : off + 16])
+        list_size, header_size, sig_size = struct.unpack_from("<III", raw, off + 16)
+        if list_size < 28 or sig_size <= 16 or off + list_size > len(raw):
+            break
+        if sig_type == EFI_CERT_X509_GUID:
+            pos = off + 28 + header_size
+            while pos + sig_size <= off + list_size:
+                der = raw[pos + 16 : pos + sig_size]
+                with tempfile.NamedTemporaryFile(suffix=".der") as tmp:
+                    tmp.write(der)
+                    tmp.flush()
+                    proc = subprocess.run(
+                        ["openssl", "x509", "-inform", "DER", "-in", tmp.name,
+                         "-noout", "-subject"],
+                        capture_output=True, text=True, check=False)
+                if proc.returncode == 0:
+                    for pattern, gen in CA_PATTERNS:
+                        if pattern.search(proc.stdout):
+                            found.add(gen)
+                pos += sig_size
+        off += list_size
+    return sorted(found)
+
+
+def secure_boot_on() -> bool | None:
+    try:
+        raw = (EFIVARS / "SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c").read_bytes()
+    except OSError:
+        return None
+    return bool(raw[4]) if len(raw) > 4 else None
+
+
+# ── The decision ────────────────────────────────────────────────────────────
+
+def check(candidate: Path, current: Path | None) -> int:
+    """Is `candidate` safe to put on the ESP in place of `current`?"""
+    try:
+        cand_cas = authorities(candidate)
+    except (OSError, ValueError) as exc:
+        warn(f"refusing {candidate.name}: cannot read its signatures ({exc})")
+        return 1
+    if not cand_cas:
+        warn(f"refusing {candidate.name}: no Microsoft UEFI CA signature. "
+             "The firmware would not launch it.")
+        return 1
+
+    # Only the firmware's own trust store can say yes here, and only when we
+    # can read it. An unreadable db means we keep what already boots.
+    if secure_boot_on():
+        trusted = firmware_db()
+        if not trusted:
+            warn(f"refusing {candidate.name}: Secure Boot is on and the firmware's "
+                 "trust store could not be read. The chain that boots today stays.")
+            return 1
+        if not set(trusted) & set(cand_cas):
+            warn(f"refusing {candidate.name}: signed by {','.join(cand_cas)}, "
+                 f"firmware trusts {','.join(trusted)}. Installing it would stop "
+                 "this machine booting Linux.")
+            return 1
+
+    # Never move backwards through an SBAT revocation: a lower generation is
+    # exactly what firmware refuses after an update.
+    cand_gen = sbat_generation(candidate)
+    cur_gen = sbat_generation(current) if current and current.exists() else None
+    if cand_gen is not None and cur_gen is not None and cand_gen < cur_gen:
+        warn(f"refusing {candidate.name}: SBAT generation {cand_gen} is older than "
+             f"the installed {cur_gen}. A downgrade is what revocation blocks.")
+        return 1
+
+    print(f"ok {candidate.name} cas={','.join(cand_cas)} sbat={cand_gen if cand_gen is not None else '?'}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        warn(__doc__ or "usage: wootc-shim-trust <authorities|db|sbat|check> ...")
+        return 2
+    cmd, args = argv[0], argv[1:]
+    if cmd == "authorities" and args:
+        print(",".join(authorities(Path(args[0]))))
+        return 0
+    if cmd == "db":
+        print(",".join(firmware_db()))
+        return 0
+    if cmd == "sbat" and args:
+        gen = sbat_generation(Path(args[0]))
+        print("" if gen is None else gen)
+        return 0
+    if cmd == "check" and args:
+        return check(Path(args[0]), Path(args[1]) if len(args) > 1 else None)
+    warn(f"unknown or incomplete command: {' '.join(argv)}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/payload/steps.tsv
+++ b/payload/steps.tsv
@@ -1,0 +1,44 @@
+# payload/steps.tsv — the one catalogue of phase names (#334).
+#
+# The words a user sees during an install are written in four places: the
+# Phase-1 pipeline in app/app.go, the step list the progress screen renders,
+# the deployer's phase() splash table, and the markers the E2E harness greps
+# for. Nothing held them together, and they had already drifted: five
+# backend steps were missing from the screen's list, and one entry on the
+# screen was never emitted, so it stayed grey for the whole install — which
+# to a nervous user reads as a step that did not happen.
+#
+# This file is the authority. tests/unit/step-catalogue.bats and the Go test
+# in app/steps_test.go fail when a copy drifts from it.
+#
+# owner: installer  a step in the Phase-1 pipeline (app/app.go), shown on the
+#                   progress screen by app/frontend/src/screens/progress.js
+#        deployer   a phase() call in payload/deployer/deploy.sh, shown on the
+#                   full-screen splash during the Phase-2 deploy
+#
+# id	owner	label
+Checking your PC	installer	Checking your PC
+Preparing Windows	installer	Preparing Windows
+Setting things up	installer	Setting things up
+Finding your files	installer	Finding your files
+Making room for Linux	installer	Making room for Linux
+Downloading Linux	installer	Downloading Linux
+Downloading your Linux system	installer	Downloading your Linux system
+Preparing the startup menu	installer	Preparing the startup menu
+Getting Linux prepared	installer	Getting Linux prepared
+Making Linux bootable on your machine	installer	Making Linux bootable on your machine
+Saving your settings	installer	Saving your settings
+Saving your BitLocker recovery key	installer	Saving your BitLocker recovery key
+Looking at your installed apps	installer	Looking at your installed apps
+Checking your signed-in apps	installer	Checking your signed-in apps
+Looking for your cloud drives	installer	Looking for your cloud drives
+Collecting your look and Wi-Fi	installer	Collecting your look and Wi-Fi
+Finishing up	installer	Finishing up
+ntfs-mounted	deployer	Preparing your disk...
+scratch-setup	deployer	Preparing your disk...
+network-wait	deployer	Waiting for a network connection - plug in a network cable if this takes a while...
+bundle-ingest	deployer	Loading your downloaded system - no internet needed...
+registry-preflight	deployer	Connecting to the software library...
+fisherman	deployer	Downloading and installing your Linux system...
+verification	deployer	Almost there - making sure everything is perfect...
+reboot	deployer	All set! Starting your new Linux system...

--- a/tests/unit/artifact-retention.bats
+++ b/tests/unit/artifact-retention.bats
@@ -209,3 +209,22 @@ mkrun() {
     grep -q "its catalog carries" .github/workflows/e2e-hosted.yml
     grep -q '"dakota"' app/branding/bluefin/brand.json
 }
+
+@test "the exe pins its boot artifacts to its own release, never to latest" {
+    # The installer and the deployer kernel/initramfs/signed shim are cut by
+    # one release job and gated by one E2E run. An exe fetching `latest`
+    # runs whatever is newest today, and the fail-closed SHA256SUMS check
+    # cannot catch it: the manifest comes from the same moved release, so
+    # mismatched-but-consistent artifacts verify perfectly (#335).
+    grep -q 'X main.releaseTag=\$RELEASE_TAG' "$REPO_ROOT/.github/workflows/release.yml"
+    grep -q 'RELEASE_TAG="\${{ steps.chan.outputs.tag }}"' "$REPO_ROOT/.github/workflows/release.yml"
+    # A release that cannot name its own tag must fail rather than ship an
+    # exe that silently floats.
+    grep -q 'no release tag to pin the boot artifacts to' "$REPO_ROOT/.github/workflows/release.yml"
+    # The rule lives in a cross-platform file so the Linux test tier runs it.
+    [ -f "$REPO_ROOT/app/deployer_url.go" ]
+    run grep -q 'go:build windows' "$REPO_ROOT/app/deployer_url.go"
+    [ "$status" -ne 0 ]
+    # The harness/offline override still wins over the pin.
+    grep -q 'WOOTC_DEPLOYER_MIRROR' "$REPO_ROOT/app/deployer_url.go"
+}

--- a/tests/unit/esp-chain-refresh.bats
+++ b/tests/unit/esp-chain-refresh.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# esp-chain-refresh.bats — the signed chain on the Windows ESP must not rot
+# (#333).
+#
+# Phase-2 boots through shim → GRUB on the WINDOWS ESP, because signed GRUB
+# cannot read NTFS. Those binaries are staged once by the installer and then
+# never touched, while the deployment they boot keeps updating. Microsoft
+# ships SBAT revocations through Windows Update: when a generation is
+# revoked, firmware stops launching a shim below it, and a machine that
+# booted Linux yesterday stops today with no change the user made.
+#
+# The behavioural coverage lives in tests/unit/test_esp_chain_refresh.py,
+# which drives the real script against a fake ESP. These pin the contract
+# that makes it safe.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SYNC="$REPO_ROOT/payload/migration/wootc-esp-sync"
+    TRUST="$REPO_ROOT/payload/migration/wootc-shim-trust"
+    DEPLOY="$REPO_ROOT/payload/deployer/deploy.sh"
+}
+
+@test "the refresh is gated: no trust helper, no chain changes" {
+    # An ungated copy is the dangerous version of this feature. Without the
+    # grader the script must fall back to the pre-#333 behaviour.
+    [ -x "$TRUST" ]
+    grep -q 'command -v wootc-shim-trust' "$SYNC"
+    grep -q 'leaving the signed chain alone' "$SYNC"
+}
+
+@test "only a vendor directory wootc owns is touched" {
+    # The same marker the Windows installer's D1 guard uses to refuse
+    # clobbering another Linux — applied again on every boot, because a
+    # second OS can be installed after us.
+    grep -q "grep -q '# wootc'" "$SYNC"
+}
+
+@test "shim is replaced LAST, after GRUB and MokManager" {
+    # A power cut mid-refresh must leave a shim that can still verify the
+    # GRUB beside it. New shim over old GRUB is the combination that does
+    # not boot.
+    grep -q 'for f in grubx64.efi mmx64.efi shimx64.efi' "$SYNC"
+}
+
+@test "the current chain is archived before anything replaces it" {
+    grep -q 'EFI/wootc/archive' "$SYNC"
+    grep -q 'refusing to replace what we cannot put back' "$SYNC"
+    # ...and restored when the write or the post-write check fails.
+    grep -q 'restoring from the archive' "$SYNC"
+}
+
+@test "the candidate is graded against the firmware AND the installed SBAT" {
+    grep -q 'def firmware_db' "$TRUST"
+    grep -q 'def sbat_generation' "$TRUST"
+    grep -q 'A downgrade is what revocation blocks' "$TRUST"
+    # Secure Boot on with an unreadable db keeps what already boots.
+    grep -q 'trust store could not be read' "$TRUST"
+}
+
+@test "SBAT is read from the .sbat section, not the first matching string" {
+    # shim embeds its revocation policy elsewhere in the binary; matching the
+    # first 'shim,N' anywhere would read the wrong number.
+    grep -q "name != \".sbat\"" "$TRUST"
+    python3 -c "import ast;ast.parse(open('$TRUST').read())"
+}
+
+@test "the helper and the update trigger travel into the deployment" {
+    grep -q 'wootc-shim-trust' "$REPO_ROOT/payload/deployer/module-setup.sh"
+    grep -q 'wootc-esp-sync.path' "$REPO_ROOT/payload/deployer/module-setup.sh"
+    grep -q 'mig_opt 755 wootc-shim-trust' "$DEPLOY"
+    grep -q 'wootc-esp-sync.path' "$DEPLOY"
+    # The trigger watches what bootc upgrade rewrites, so an updated chain
+    # reaches the ESP on the boot that staged it rather than one boot later.
+    grep -q 'PathChanged=/usr/lib/bootupd/updates/EFI.json' \
+        "$REPO_ROOT/payload/migration/wootc-esp-sync.path"
+}

--- a/tests/unit/step-catalogue.bats
+++ b/tests/unit/step-catalogue.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# step-catalogue.bats — one vocabulary for the words a user watches (#334).
+#
+# The phase names live in four places: the Phase-1 pipeline (app/app.go), the
+# progress screen's list, the deployer's splash table, and the harness's
+# markers. Nothing held them together, and they HAD drifted: five pipeline
+# steps were missing from the screen, and one entry on the screen was never
+# emitted, so it stayed grey for the whole install — which to a nervous user
+# reads as a step that did not happen.
+#
+# The installer/frontend half is enforced by app/steps_test.go, which compares
+# the two lists directly. These cover the deployer half.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    CAT="$REPO_ROOT/payload/steps.tsv"
+    DEPLOY="$REPO_ROOT/payload/deployer/deploy.sh"
+}
+
+catalogued() { # <id> <owner>
+    grep -qP "^\Q$1\E\t$2\t" "$CAT"
+}
+
+@test "the catalogue exists and names an owner for every entry" {
+    [ -f "$CAT" ]
+    run awk -F'\t' '!/^#/ && NF && $2 != "installer" && $2 != "deployer" { print }' "$CAT"
+    [ -z "$output" ]
+}
+
+@test "every phase the deployer announces is catalogued" {
+    # A phase() call with no catalogue entry is a word the user can see that
+    # nothing else in the tree knows about.
+    local missing=""
+    while read -r id; do
+        catalogued "$id" deployer || missing="$missing $id"
+    done < <(grep -oE '^\s*phase "[a-z0-9-]+"' "$DEPLOY" | grep -oE '"[a-z0-9-]+"' | tr -d '"' | sort -u)
+    [ -z "$missing" ] || { echo "uncatalogued deployer phases:$missing"; false; }
+}
+
+@test "every catalogued deployer phase has a splash line" {
+    # A phase with no splash entry freezes the bar on the previous message,
+    # which is the "is it stuck?" moment the splash exists to prevent.
+    local splash missing=""
+    splash=$(sed -n '/case "$1" in/,/esac/p' "$DEPLOY")
+    while read -r id; do
+        printf '%s' "$splash" | grep -qE "^\s+${id}\)" || missing="$missing $id"
+    done < <(awk -F'\t' '!/^#/ && $2 == "deployer" { print $1 }' "$CAT")
+    [ -z "$missing" ] || { echo "catalogued phases with no splash line:$missing"; false; }
+}
+
+@test "every catalogued deployer phase carries the words shown on screen" {
+    run awk -F'\t' '!/^#/ && $2 == "deployer" && $3 == "" { print $1 }' "$CAT"
+    [ -z "$output" ]
+}
+
+@test "the installer/frontend halves are pinned by a Go test, not by hope" {
+    grep -q 'func TestProgressScreenListsExactlyWhatThePipelineEmits' "$REPO_ROOT/app/steps_test.go"
+    grep -q 'func TestEveryPipelineStepIsInTheCatalogue' "$REPO_ROOT/app/steps_test.go"
+    # And the frontend list says where its contents come from.
+    grep -q 'payload/steps.tsv' "$REPO_ROOT/app/frontend/src/screens/progress.js"
+}

--- a/tests/unit/test_esp_chain_refresh.py
+++ b/tests/unit/test_esp_chain_refresh.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""The signed chain on the Windows ESP is staged once and then goes stale
+(#333). This exercises the refresh END TO END against a fake ESP and a fake
+deployment payload — grep-only tests would not catch the ordering or the
+restore path, which are the two things that decide whether a failed refresh
+leaves a bootable machine."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SYNC = REPO / "payload" / "migration" / "wootc-esp-sync"
+TRUST = REPO / "payload" / "migration" / "wootc-shim-trust"
+FIXTURES = Path(os.environ.get("WOOTC_SHIM_FIXTURES", "/nonexistent"))
+
+
+class ChainRefresh(unittest.TestCase):
+    def setUp(self):
+        self.d = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.d, ignore_errors=True)
+
+        # A fake ESP with a wootc-owned vendor directory.
+        self.esp = self.d / "esp"
+        self.vendor = self.esp / "EFI" / "fedora"
+        self.vendor.mkdir(parents=True)
+        (self.vendor / "grub.cfg").write_text("# wootc Phase 2 - boot installed system\n")
+        (self.esp / "EFI" / "wootc").mkdir(parents=True)
+        for f in ("shimx64.efi", "grubx64.efi", "mmx64.efi"):
+            (self.vendor / f).write_bytes(b"OLD-" + f.encode())
+        (self.esp / "EFI" / "wootc" / "phase2-vmlinuz").write_bytes(b"k")
+        (self.esp / "EFI" / "wootc" / "phase2-initramfs.img").write_bytes(b"i")
+
+        # A fake /boot with one BLS entry so the kernel half is a no-op.
+        self.boot = self.d / "boot"
+        (self.boot / "loader" / "entries").mkdir(parents=True)
+        (self.boot / "vmlinuz-6.1").write_bytes(b"k")
+        (self.boot / "initramfs-6.1.img").write_bytes(b"i")
+        (self.boot / "loader" / "entries" / "a.conf").write_text(
+            "title t\nlinux /vmlinuz-6.1\ninitrd /initramfs-6.1.img\noptions ro\n")
+
+        self.cmdline = self.d / "cmdline"
+        self.cmdline.write_text("BOOT_IMAGE=/vmlinuz-6.1 ro loop=/wootc/disks/root.disk wootc.host_uuid=ABCD\n")
+
+        # A stub wootc-shim-trust whose verdict the test controls.
+        self.bin = self.d / "bin"
+        self.bin.mkdir()
+        self.verdict = self.d / "verdict"
+        self.verdict.write_text("0")
+        (self.bin / "wootc-shim-trust").write_text(
+            "#!/bin/sh\n[ \"$1\" = check ] || exit 0\nexit \"$(cat %s)\"\n" % self.verdict)
+        (self.bin / "wootc-shim-trust").chmod(0o755)
+
+    def run_sync(self, source: Path):
+        env = dict(os.environ)
+        env.update({
+            "WOOTC_ESP_DIR": str(self.esp),
+            "WOOTC_BOOT_DIR": str(self.boot),
+            "WOOTC_CMDLINE": str(self.cmdline),
+            "PATH": f"{self.bin}:{env['PATH']}",
+            "WOOTC_CHAIN_SOURCE": str(source),
+        })
+        return subprocess.run(["bash", str(SYNC)], capture_output=True, text=True, env=env)
+
+    def make_source(self, name="fedora") -> Path:
+        src = self.d / "payload" / "EFI" / name
+        src.mkdir(parents=True)
+        for f in ("shimx64.efi", "grubx64.efi", "mmx64.efi"):
+            (src / f).write_bytes(b"NEW-" + f.encode())
+        return src
+
+    def test_refreshes_all_three_when_the_candidate_is_accepted(self):
+        src = self.make_source()
+        r = self.run_sync(src)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        for f in ("shimx64.efi", "grubx64.efi", "mmx64.efi"):
+            self.assertEqual((self.vendor / f).read_bytes(), b"NEW-" + f.encode(),
+                             f"{f} was not refreshed:\n{r.stdout}")
+
+    def test_the_previous_chain_is_archived_before_replacement(self):
+        # Without an archive there is nothing to put back, so a failed write
+        # would leave the machine unbootable.
+        src = self.make_source()
+        self.run_sync(src)
+        archives = list((self.esp / "EFI" / "wootc" / "archive").glob("*/shimx64.efi"))
+        self.assertTrue(archives, "no archived shim")
+        self.assertEqual(archives[0].read_bytes(), b"OLD-shimx64.efi")
+
+    def test_a_refused_candidate_leaves_the_working_chain_in_place(self):
+        # A shim the firmware will not accept is worse than a stale one: the
+        # stale one still boots.
+        self.verdict.write_text("1")
+        src = self.make_source()
+        r = self.run_sync(src)
+        for f in ("shimx64.efi", "grubx64.efi", "mmx64.efi"):
+            self.assertEqual((self.vendor / f).read_bytes(), b"OLD-" + f.encode())
+        self.assertIn("keeping the installed", r.stdout)
+
+    def test_shim_is_written_last(self):
+        # A power cut mid-refresh must leave a shim that can still verify the
+        # GRUB beside it. New shim over old GRUB is the combination that does
+        # not boot.
+        src = self.make_source()
+        r = self.run_sync(src)
+        order = [line for line in r.stdout.splitlines() if "refreshed" in line and ".efi" in line]
+        self.assertTrue(order, r.stdout)
+        self.assertIn("shimx64.efi", order[-1], f"shim was not last: {order}")
+
+    def test_another_linuxs_vendor_directory_on_the_same_esp_is_never_touched(self):
+        # The real hazard: a machine that also has Debian installed. Its
+        # EFI/debian holds its own signed chain and a grub.cfg without our
+        # marker. Refreshing it would replace another OS's bootloader with
+        # ours — the D1 guard the Windows installer applies at install time,
+        # applied again on every boot.
+        debian = self.esp / "EFI" / "debian"
+        debian.mkdir(parents=True)
+        (debian / "grub.cfg").write_text("# Debian GRUB configuration\n")
+        for f in ("shimx64.efi", "grubx64.efi", "mmx64.efi"):
+            (debian / f).write_bytes(b"DEBIAN-" + f.encode())
+
+        src = self.make_source()
+        r = self.run_sync(src)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        for f in ("shimx64.efi", "grubx64.efi", "mmx64.efi"):
+            self.assertEqual((debian / f).read_bytes(), b"DEBIAN-" + f.encode(),
+                             f"another OS's {f} was overwritten:\n{r.stdout}")
+            # ...while ours still gets refreshed.
+            self.assertEqual((self.vendor / f).read_bytes(), b"NEW-" + f.encode())
+
+    def test_no_wootc_owned_directory_means_nothing_is_touched(self):
+        # Nothing on this ESP carries our marker: an ESP we do not own, or a
+        # layout we do not recognise. Do nothing rather than guess.
+        esp = self.d / "esp2"
+        (esp / "EFI" / "debian").mkdir(parents=True)
+        (esp / "EFI" / "debian" / "grub.cfg").write_text("# Debian\n")
+        (esp / "EFI" / "debian" / "shimx64.efi").write_bytes(b"DEBIAN-shim")
+        env = dict(os.environ)
+        env.update({
+            "WOOTC_ESP_DIR": str(esp), "WOOTC_BOOT_DIR": str(self.boot),
+            "WOOTC_CMDLINE": str(self.cmdline), "PATH": f"{self.bin}:{env['PATH']}",
+            "WOOTC_CHAIN_SOURCE": str(self.make_source()),
+        })
+        r = subprocess.run(["bash", str(SYNC)], capture_output=True, text=True, env=env)
+        self.assertEqual((esp / "EFI" / "debian" / "shimx64.efi").read_bytes(), b"DEBIAN-shim")
+        # It must decline out loud. Either guard is fine — the earlier
+        # "not a Phase-2 layout" one fires first on an ESP with no EFI/wootc —
+        # but silence would be indistinguishable from having done the work.
+        self.assertTrue(
+            "no wootc-owned vendor directory" in r.stdout
+            or "not a Phase-2 layout" in r.stdout,
+            f"declined without saying why:\n{r.stdout}")
+
+    def test_no_helper_means_the_chain_is_left_alone(self):
+        # The pre-#333 behaviour, not a silent unguarded copy.
+        (self.bin / "wootc-shim-trust").unlink()
+        src = self.make_source()
+        r = self.run_sync(src)
+        self.assertEqual((self.vendor / "shimx64.efi").read_bytes(), b"OLD-shimx64.efi")
+        self.assertIn("leaving the signed chain alone", r.stdout)
+
+    def test_identical_chain_is_a_no_op(self):
+        src = self.make_source()
+        for f in ("shimx64.efi", "grubx64.efi", "mmx64.efi"):
+            (self.vendor / f).write_bytes(b"NEW-" + f.encode())
+        r = self.run_sync(src)
+        self.assertNotIn("refreshed fedora/", r.stdout)
+        self.assertFalse((self.esp / "EFI" / "wootc" / "archive").exists(),
+                         "an unchanged chain must not be archived")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/unit/test_shim_trust.py
+++ b/tests/unit/test_shim_trust.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""wootc-shim-trust decides whether a candidate boot binary may replace one
+that currently works (#333). Getting that wrong in the permissive direction
+leaves a machine that cannot boot Linux, so these tests drive the real parser
+against real signed binaries when they are available, and against synthesized
+ones always."""
+
+import importlib.machinery
+import importlib.util
+import os
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+loader = importlib.machinery.SourceFileLoader(
+    "shim_trust", str(REPO / "payload" / "migration" / "wootc-shim-trust"))
+spec = importlib.util.spec_from_loader("shim_trust", loader)
+st = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(st)
+
+# Real Fedora shims, when the fixture directory is present (set by the
+# developer who downloaded them). Absent in CI: the synthesized cases below
+# carry the contract either way.
+FIXTURES = Path(os.environ.get("WOOTC_SHIM_FIXTURES", "/nonexistent"))
+
+
+class ParserSafety(unittest.TestCase):
+    def test_a_non_pe_file_raises_rather_than_guessing(self):
+        with tempfile.NamedTemporaryFile(suffix=".efi") as f:
+            f.write(b"not a PE at all")
+            f.flush()
+            with self.assertRaises(ValueError):
+                st.authorities(Path(f.name))
+
+    def test_an_unsigned_pe_reports_no_authorities(self):
+        # A PE with an empty certificate table is not "trusted by default".
+        data = bytearray(b"MZ" + b"\x00" * 0x3E)
+        struct.pack_into("<I", data, 0x3C, 0x40)
+        data += b"PE\0\0" + b"\x00" * 20
+        struct.pack_into("<H", data, 0x40 + 20, 240)  # optional header size
+        data += b"\x0b\x02" + b"\x00" * 238           # PE32+ optional header
+        data += b"\x00" * 256                          # data directories
+        with tempfile.NamedTemporaryFile(suffix=".efi", delete=False) as f:
+            f.write(bytes(data))
+            path = Path(f.name)
+        self.addCleanup(path.unlink)
+        self.assertEqual(st.pkcs7_blobs(bytes(data)), [])
+        self.assertEqual(st.authorities(path), [])
+
+    def test_no_efivarfs_means_unknown_not_untrusted(self):
+        old = st.EFIVARS
+        st.EFIVARS = Path("/nonexistent-efivars")
+        try:
+            self.assertEqual(st.firmware_db(), [])
+            self.assertIsNone(st.secure_boot_on())
+        finally:
+            st.EFIVARS = old
+
+
+class Decision(unittest.TestCase):
+    def _fake(self, name, cas, sbat):
+        """Stub the two expensive readers so the DECISION is what is tested."""
+        st.authorities = lambda p, _c=cas: list(_c)
+        st.sbat_generation = lambda p, _s=sbat: _s
+        return Path(name)
+
+    def setUp(self):
+        self._auth, self._sbat, self._sb, self._db = (
+            st.authorities, st.sbat_generation, st.secure_boot_on, st.firmware_db)
+
+    def tearDown(self):
+        st.authorities, st.sbat_generation = self._auth, self._sbat
+        st.secure_boot_on, st.firmware_db = self._sb, self._db
+
+    def test_refuses_a_candidate_with_no_microsoft_signature(self):
+        st.authorities = lambda p: []
+        st.sbat_generation = lambda p: 4
+        st.secure_boot_on = lambda: False
+        self.assertEqual(st.check(Path("cand.efi"), None), 1)
+
+    def test_refuses_when_secure_boot_is_on_and_the_db_is_unreadable(self):
+        # We cannot tell whether the firmware would launch it, and the chain
+        # that boots today is the safer bet.
+        st.authorities = lambda p: ["2023"]
+        st.sbat_generation = lambda p: 4
+        st.secure_boot_on = lambda: True
+        st.firmware_db = lambda: []
+        self.assertEqual(st.check(Path("cand.efi"), None), 1)
+
+    def test_refuses_a_candidate_the_firmware_does_not_trust(self):
+        st.authorities = lambda p: ["2023"]
+        st.sbat_generation = lambda p: 4
+        st.secure_boot_on = lambda: True
+        st.firmware_db = lambda: ["2011"]
+        self.assertEqual(st.check(Path("cand.efi"), None), 1)
+
+    def test_accepts_when_the_authorities_intersect(self):
+        st.authorities = lambda p: ["2011", "2023"]
+        st.sbat_generation = lambda p: 4
+        st.secure_boot_on = lambda: True
+        st.firmware_db = lambda: ["2011"]
+        self.assertEqual(st.check(Path("cand.efi"), None), 0)
+
+    def test_secure_boot_off_skips_the_trust_check_but_not_sbat(self):
+        st.authorities = lambda p: ["2011"]
+        st.secure_boot_on = lambda: False
+        st.firmware_db = lambda: []
+        gens = {"cand.efi": 3, "cur.efi": 7}
+        st.sbat_generation = lambda p: gens[Path(p).name]
+
+        class FakePath(type(Path("."))):
+            def exists(self):
+                return True
+        self.assertEqual(st.check(Path("cand.efi"), FakePath("cur.efi")), 1)
+
+
+class RealBinaries(unittest.TestCase):
+    @unittest.skipUnless(FIXTURES.is_dir(), "no real shim fixtures available")
+    def test_reads_a_dual_signed_shim_as_dual_signed(self):
+        got = st.authorities(FIXTURES / "rawhide-shimx64.efi")
+        self.assertEqual(got, ["2011", "2023"])
+
+    @unittest.skipUnless(FIXTURES.is_dir(), "no real shim fixtures available")
+    def test_reads_the_sbat_generation_from_the_sbat_section(self):
+        # Not from the first occurrence of the string anywhere in the file:
+        # shim embeds its SBAT revocation policy elsewhere too.
+        self.assertEqual(st.sbat_generation(FIXTURES / "rawhide-shimx64.efi"), 4)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Three independent commits, rebased on current `main`. The other two I had built (#342, #332) turned out to be duplicates of #348 and of work already on `main`, so they are dropped rather than pushed.

---

## `ef52ad7` — pin boot artifacts to the release the exe was cut from (#335)

`deployerBaseURL` pointed at `releases/latest/download/`, so a `v0.1.0-alpha.1` exe downloads whatever `latest` is today: a deployer kernel, initramfs and signed shim it has never been run with.

The fail-closed `SHA256SUMS` check (#53) does not catch this. The manifest comes from the same moved release, so mismatched-but-consistent artifacts verify perfectly. The installer and its boot chain are cut by one release job and gated by one E2E run; nothing kept them together afterwards.

`release.yml` now stamps `-X main.releaseTag` from the tag it publishes, and **fails** rather than shipping an exe that cannot name its own release. An unstamped local build still falls back to `latest` — the only honest answer available to a developer build — and `WOOTC_DEPLOYER_MIRROR` still wins over both, so the harness and offline bundle are unaffected.

The rule moved from `deployer_windows.go` into a cross-platform `deployer_url.go`: it is pure string logic and the CI test tier runs on Linux, so leaving it Windows-only meant nothing checked it until a release went out.

## `cb3cebc` — keep the signed boot chain fresh (#333)

Phase 2 boots through shim → GRUB on the **Windows** ESP, because signed GRUB cannot read NTFS. `wootc-esp-sync` refreshes the kernel pair there every boot, but the signed chain beside it is staged once by the installer and then never touched.

Microsoft ships SBAT revocations through Windows Update. When a generation is revoked the firmware stops launching a shim below it, and a machine that booted Linux yesterday stops today with no change the user made. CVE fixes in shim and GRUB never arrive either. Meanwhile the deployment carries a current signed chain in bootupd's payload.

Copying it forward blindly is its own hazard: **a shim the firmware will not accept is worse than a stale one, because the stale one still boots.** So `wootc-shim-trust` grades every candidate first — Authenticode signers (walking every `WIN_CERTIFICATE`, so a dual-signed shim is not misread as single-signed), the firmware's own `db` from efivarfs, and the SBAT generation read from the `.sbat` section rather than the first matching string in the file, since shim embeds its revocation policy elsewhere too. It refuses on: no Microsoft CA, Secure Boot on with an unreadable `db`, no intersection with what the firmware trusts, or an SBAT downgrade.

The replacement archives the current trio first and restores from it when the write or the post-write check fails, and writes GRUB and MokManager **before** shim. A power cut mid-refresh then leaves a shim that can still verify the GRUB beside it; the other order leaves a new shim above an old GRUB, which is the combination that does not boot.

Ownership needs no new manifest: only a vendor directory whose `grub.cfg` carries the `# wootc` marker is touched — the same rule the installer's D1 guard applies, re-checked every boot because a second Linux can be installed after us. A `.path` unit on bootupd's `EFI.json` means an updated chain reaches the ESP on the boot that staged it rather than one boot later, which matters when the reason for the update is the revocation about to strand it.

`tests/unit/test_esp_chain_refresh.py` drives the real script against a fake ESP rather than grepping it: it proves the ordering, the archive, the restore, the refusal path, and that **another Linux's EFI directory on the same ESP is left alone**.

## `c7e460f` — show every install step (#334)

The progress screen listed 13 steps; the pipeline emits 17. Five steps the installer actually performs — saving the BitLocker recovery key, reading installed programs, signed-in apps, cloud drives, and collecting the look and Wi-Fi — were never shown. Worse in the other direction: the screen listed "Collecting your look", which nothing emits (the pipeline calls it "Collecting your look and Wi-Fi"), so that row stayed grey for the entire install.

A grey step, at the moment someone is watching a progress screen decide the fate of their computer, reads as a step that did not happen.

`payload/steps.tsv` is now the catalogue. `app/steps_test.go` compares the pipeline against the frontend list in both directions and in order; `tests/unit/step-catalogue.bats` covers the deployer half. Verified the test catches what it is for: removing one step from the frontend list fails it with the reason rather than passing quietly.

Generation is deliberately not included — see `docs/borrowed-from-libertix.md` §5. The value is that drift cannot survive CI, which the parity tests deliver; mechanically rewriting the case table inside the script that decides whether a machine boots buys no additional safety.

---

## Verification

555 bats, 6 Python suites, the Go suite, `GOOS=windows` and Linux builds, DTO goldens and the C# generator all current.

**One pre-existing failure, not from this branch:** `userdata-persistence.bats` test 9 ("fisherman pins user homes into the stateroot var") fails identically on `origin/main` in my environment because the `fisherman` submodule is not initialised here (`git submodule status` shows a leading `-`). It passes in CI, which checks the submodule out.

## Merge conflict resolved

`module-setup.sh` conflicted because `main` now stages `wootc-firstboot-evidence` from the parallel #332 work. Resolved by keeping main's lines untouched and adding only my two new entries (`wootc-esp-sync.path`, `wootc-shim-trust`) beside the existing esp-sync ones. No duplicates.

## Still open on these issues

The OVMF `db` axis for #322 and the planted-shim harness cell for #333 — both need harness work rather than product code, and both checkboxes stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnkxS7XMyKH6xaZcFQGWki)_