### PR TITLE
docs: escape the angle-bracket placeholders in upstream-blessings.md

### DIFF
--- a/docs/upstream-blessings.md
+++ b/docs/upstream-blessings.md
@@ -25,7 +25,7 @@ logo signed by someone else:
 | Question | `blessing.json` key | What a "no" costs |
 |---|---|---|
 | May we ship your **mark** (logo, colours, typeface) inside the installer? | `decisions.mark` | the branded build loses its assets |
-| May we call it **"<Brand> Installer"**? | `decisions.name` | the name reverts to generic wootc |
+| May we call it **"`<Brand>` Installer"**? | `decisions.name` | the name reverts to generic wootc |
 | May we use this **tagline**? | `decisions.tagline` | tagline reverts, brand can stay |
 | May we **distribute an exe** under your brand at all? | `decisions.distributeExe` | the exe drops from every release |
 
@@ -96,12 +96,12 @@ Adapt per project; keep it short and make the "no" genuinely free.
 >
 > 1. May we use the Bazzite mark, colours and typeface in the installer?
 > 2. May we call it "Bazzite Installer"?
-> 3. May we use the tagline "<the tagline from brand.json>"?
+> 3. May we use the tagline "`<the tagline from brand.json>`"?
 > 4. May we distribute an exe branded as Bazzite at all?
 >
-> Here is exactly what it looks like today: <branded walkthrough link>.
-> Every asset and where we took it from: <provenance link>. A real install,
-> start to finish, on video: <e2e link>.
+> Here is exactly what it looks like today: `<branded walkthrough link>`.
+> Every asset and where we took it from: `<provenance link>`. A real install,
+> start to finish, on video: `<e2e link>`.
 >
 > On winget: `Bazzite.Installer` belongs in your namespace, not ours. We
 > have the manifests rendered and would rather hand them to you than publish


### PR DESCRIPTION
The org docs sync is still red. #350 fixed the placeholder in `manual-testing.md`, and the build did not go green — it moved on to the next file. Run [33661387079](https://github.com/tuna-os/docs/actions/runs/33661387079), dispatched after #350 merged:

```
Error: MDX compilation failed for "docs/wootc/upstream-blessings.md"
  Cause: Unexpected character `.` (U+002E) in attribute name,
         expected an attribute name character … (102:53)
```

## Where 102:53 actually is

Synced line 102 is this file's **line 99**, once the sync script prepends its frontmatter:

```
> 3. May we use the tagline "<the tagline from brand.json>"?
```

Column 53 is the `.` in `brand.json`. MDX reads `<the` as a JSX tag name, then `tagline` and `from` and `brand` as boolean attributes — and a `.` cannot appear in an attribute name.

## Why all five, not just that one

MDX stops at the first error, so fixing line 99 alone would simply surface line 102 on the next run, then 103, then 104. This backticks every bare placeholder outside a code fence:

| line | placeholder |
|---|---|
| 28 | `<Brand>` in the decisions table |
| 99 | `<the tagline from brand.json>` |
| 102 | `<branded walkthrough link>` |
| 103 | `<provenance link>` |
| 104 | `<e2e link>` |

The file already renders `app/branding/<brand>/blessing.json` exactly this way, and it is the same treatment #350 applied.

**Deliberately unchanged:** `<https://tuna-os.github.io/wootc/e2e/latest/>` on line 49. That is a CommonMark autolink, and `sanitizeHtml` rewrites it to `[url](url)` before MDX ever sees it.

## Why not fix this in the sync script instead

`sanitizeHtml` in `tuna-os/docs` escapes `<` only when followed by a digit, whitespace or `=`, and its comment is explicit about why it stays narrow:

> Every MDX-safety rewrite below is a regex over `<`, and README files are mostly shell. `--since=<30d>` in a bash sample and `<30s` in a prose table look identical to a regex; only one of them may be escaped. Rewriting inside a fence produces a site that builds and documents commands that do not run, which is worse than the build failure it replaces.

That reasoning holds here. These placeholders start with letters, and `<the tagline from brand>` is *syntactically valid JSX* — bare words are boolean attributes — so only the dot made it fail. No regex separates "prose placeholder" from "real markup" without risking the false positives that comment is guarding against. The source file is the right place to fix it.

## Verification

Scanned the whole file for bare `<...>` outside fenced blocks and inline-code spans; none remain except the autolink above.

This should be the last blocker — the sync has been red for **14 consecutive runs since 2026-08-19**, freezing docs for all 31 synced repos. If a fourth file surfaces, the same treatment applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_