### PR TITLE
chore: add repo scaffolding (EditorConfig, code owners, CLAUDE.md)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,52 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,mjs}]
+indent_style = space
+indent_size = 2
+
+[*.{css,scss}]
+indent_style = space
+indent_size = 2
+
+[*.{sh,bash}]
+indent_style = space
+indent_size = 2
+
+[*.bats]
+indent_style = space
+indent_size = 2
+
+[*.ps1]
+indent_style = space
+indent_size = 4
+
+[{Containerfile,Dockerfile}*]
+indent_style = space
+indent_size = 4
+
+[{justfile,Justfile}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hanthor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+This file exists so Claude Code picks up project instructions automatically.
+The actual agent instructions live in [`AGENTS.md`](AGENTS.md) — read that
+file before making changes here.
+
+Keeping one instruction set instead of two avoids the files drifting apart.


### PR DESCRIPTION
## Summary

Contributor-facing files this repo did not have. No source changes.

- **`.editorconfig`** — generated from the file types this repo actually contains (12 sections). `.go` gets `indent_style = tab` to match gofmt; there are also `.bats`, `.sh`, `.py` and `.js` blocks, since this repo genuinely ships all of them.
- **`.github/CODEOWNERS`** — `* @hanthor`.
- **`CLAUDE.md`** — a short pointer at the existing `AGENTS.md`, matching the convention in `tuna-os/tunaos`: one instruction set, so the two cannot drift.

PR and issue templates are deliberately **not** added: `tuna-os/.github` already serves those org-wide to every public repo without its own.

## Testing

Nothing executable changed — three files added, none modified. `.editorconfig` only affects editors and cannot alter the tree on its own, so the Go sources and bats suites are unaffected.

## Checklist

- [ ] Commit messages are signed-off (`git commit -s`) — DCO required — *not added: I'm not able to attest a DCO sign-off on a maintainer's behalf.*
- [x] `just fix` passes locally (format + lint) — n/a, no code changed
- [x] Tests pass (`just test` / relevant CI workflow) — n/a; CI will confirm
- [x] No secrets or machine-specific paths are committed
- [x] Changelog / docs updated if user-visible behavior changed — n/a

## Related

- References: ACMM Tier A — `acmm:editor-config`, `acmm:claude-md`, `aef:structural-gates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_