### PR TITLE
renovate: adopt the shared org preset; stop bot PRs paging a code owner

### DIFF
--- a/.github/workflows/drop-bot-review-requests.yml
+++ b/.github/workflows/drop-bot-review-requests.yml
@@ -11,12 +11,16 @@ name: Drop bot review requests
 # genuinely requires a code-owner approval, the PR still waits for one; it just
 # stops sitting in a person's review queue.
 #
-# pull_request_target is used so the token can write on the PR. It is safe here
-# because this workflow never checks out or executes any code from the pull
-# request -- it only calls the API with values GitHub itself supplies.
+# Deliberately `pull_request`, not `pull_request_target`: this needs no code
+# from the PR, and pull_request_target would hand a write token and secrets to
+# a workflow triggered by PR contents for no benefit (tunaOS forbids it
+# outright -- tests/test_fork_safe_workflows.py). The job is additionally
+# limited to same-repo PRs: a fork PR's token is read-only, so the API call
+# would fail rather than do anything useful. Renovate branches live in the
+# repository, so the bots this exists for are always in scope.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, ready_for_review]
 
 permissions:
@@ -28,7 +32,9 @@ concurrency:
 
 jobs:
   drop:
-    if: github.event.pull_request.user.type == 'Bot'
+    if: >-
+      github.event.pull_request.user.type == 'Bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Remove auto-requested reviewers

--- a/.github/workflows/drop-bot-review-requests.yml
+++ b/.github/workflows/drop-bot-review-requests.yml
@@ -1,0 +1,52 @@
+name: Drop bot review requests
+
+# CODEOWNERS (`* @hanthor` in most tuna-os repos) makes GitHub request a review
+# on every pull request, bots included. Those requests are what turn routine
+# dependency bumps into a notification stream: Renovate opens the PR, GitHub
+# asks a human to review it, and the human gets pinged even though the PR is
+# going to merge itself on green CI via platformAutomerge.
+#
+# This drops the auto-requested reviewers from bot-authored PRs only. Human PRs
+# are untouched, and nothing about branch protection changes -- if a repo
+# genuinely requires a code-owner approval, the PR still waits for one; it just
+# stops sitting in a person's review queue.
+#
+# pull_request_target is used so the token can write on the PR. It is safe here
+# because this workflow never checks out or executes any code from the pull
+# request -- it only calls the API with values GitHub itself supplies.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: drop-bot-review-requests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  drop:
+    if: github.event.pull_request.user.type == 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove auto-requested reviewers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          requested=$(gh api "repos/${REPO}/pulls/${PR}" \
+            --jq '{reviewers: [.requested_reviewers[].login], team_reviewers: [.requested_teams[].slug]}')
+          users=$(printf '%s' "$requested" | jq -c '.reviewers')
+          teams=$(printf '%s' "$requested" | jq -c '.team_reviewers')
+          if [ "$users" = "[]" ] && [ "$teams" = "[]" ]; then
+            echo "No review requests on this PR; nothing to drop."
+            exit 0
+          fi
+          echo "Dropping review requests -- users: ${users} teams: ${teams}"
+          printf '%s' "$requested" \
+            | gh api -X DELETE "repos/${REPO}/pulls/${PR}/requested_reviewers" --input - >/dev/null
+          echo "Done."

--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "local>tuna-os/.github",
+    "local>tuna-os/.github"
   ],
-  "automerge": false,
-  "platformAutomerge": true,
   "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "patch",
-        "pin",
-        "pinDigest",
-        "digest"
-      ],
-      "automerge": true
-    },
     {
       "description": "fedora base image major bumps are IGNORED (not even proposed): the fedora:46/rawhide image's dnf repos serve fc45-built packages with a keyring mismatch, breaking container builds. automerge:false alone did not stop renovate (tacklebox #209/#211); ignore prevents PR creation. Remove once the upstream image is consistent.",
       "matchDatasources": [


### PR DESCRIPTION
## Summary

⚠️ **Depends on tuna-os/.github#70.** Until that preset is on `main`, `local>tuna-os/.github` does not resolve — merge it first.

This repo carried its own copy of a `renovate.json` that 32 repos shared almost verbatim, so the fleet's automerge policy could only be changed 32 times or not at all. It now extends the single org preset, which adds `minor` to the automerged set and keeps `major` gated (tuna-os/.github#12). `platformAutomerge` means GitHub's native auto-merge does the merging, so **branch protection still gates every automerged PR** — nothing is bypassed.

**Preserved verbatim:** the **fedora major-bump block** (`enabled: false` for the three fedora images), which exists because fedora:46/rawhide serves fc45-built packages with a keyring mismatch that breaks container builds. Widening automerge must not quietly re-enable the bumps someone disabled on purpose; it doesn't, since the rule is repo-local and applied after the preset.

`CODEOWNERS` makes GitHub request a review on every PR, bots included. The added workflow drops those auto-requested reviewers from bot-authored PRs only; human PRs are untouched.

## Testing

- `renovate.json` parses and passes the org automerge policy checker.
- The workflow parses as YAML; its `run` block is clean under `bash -n` and `shellcheck -S warning`.
- The fedora rule diffed before/after — byte-identical.

## Checklist

- [ ] Commit messages are signed-off (`git commit -s`) — not added; I do not add sign-off trailers on a maintainer's behalf.
- [x] No secrets or machine-specific paths are committed
- [x] Config-only change

## Related

- References: tuna-os/.github#70, tuna-os/.github#12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_